### PR TITLE
Set X-FRAME-OPTIONS header to SameOrigin

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -333,7 +333,7 @@ MIDDLEWARE_CLASSES = (
 )
 
 # Clickjacking protection can be enabled by setting this to 'DENY'
-X_FRAME_OPTIONS = 'ALLOW'
+X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 ############# XBlock Configuration ##########
 

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -86,9 +86,9 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
         Check the x-frame-option response header
         """
 
-        # check to see that the default setting is to ALLOW iframing
+        # check to see that the default setting is to use SAMEORIGIN iframing
         resp = self.client.get('/')
-        self.assertEquals(resp['X-Frame-Options'], 'ALLOW')
+        self.assertEquals(resp['X-Frame-Options'], 'SAMEORIGIN')
 
     @override_settings(X_FRAME_OPTIONS='DENY')
     def test_deny_x_frame_options(self):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1210,7 +1210,7 @@ MIDDLEWARE_CLASSES = (
 )
 
 # Clickjacking protection can be enabled by setting this to 'DENY'
-X_FRAME_OPTIONS = 'ALLOW'
+X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 ############################### Pipeline #######################################
 


### PR DESCRIPTION
Update the X-FRAME-OPTIONS to SameOrigin to prevent clickjacking

JIRA Ticket: https://openedx.atlassian.net/browse/TNL-2616

TODO:
- [ ] Review and test impact of this change on LTI with @ormsbee (ETA Tuesday 9/8)