### PR TITLE
feat: future proof artifact uploads (backport)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -124,26 +124,26 @@ jobs:
         shell: bash
         run: |
           cd test_root/log
-          mv pytest_warnings.json pytest_warnings_${{ matrix.shard_name }}.json
+          mv pytest_warnings.json pytest_warnings_${{ matrix.shard_name }}_${{ matrix.python-version }}_${{ matrix.django-version }}_${{ matrix.mongo-version }}_${{ matrix.os-version }}.json
 
       - name: save pytest warnings json file
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-warnings-json-${{ matrix.shard_name }}
+          name: pytest-warnings-json-${{ matrix.shard_name }}-${{ matrix.python-version }}-${{ matrix.django-version }}-${{ matrix.mongo-version }}-${{ matrix.os-version }}
           path: |
             test_root/log/pytest_warnings*.json
           overwrite: true
 
       - name: Renaming coverage data file
         run: |
-          mv reports/.coverage reports/${{ matrix.shard_name }}.coverage
+          mv reports/.coverage reports/${{ matrix.shard_name }}_${{ matrix.python-version }}_${{ matrix.django-version }}_${{ matrix.mongo-version }}_${{ matrix.os-version }}.coverage
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.shard_name }}
-          path: reports/${{ matrix.shard_name }}.coverage
+          name: coverage-${{ matrix.shard_name }}-${{ matrix.python-version }}-${{ matrix.django-version }}-${{ matrix.mongo-version }}-${{ matrix.os-version }}
+          path: reports/${{ matrix.shard_name }}_${{ matrix.python-version }}_${{ matrix.django-version }}_${{ matrix.mongo-version }}_${{ matrix.os-version }}.coverage
           overwrite: true
 
   collect-and-verify:

--- a/openedx/core/process_warnings.py
+++ b/openedx/core/process_warnings.py
@@ -91,7 +91,7 @@ def read_warning_data(dir_path):
     # TODO(jinder): currently this is hard-coded in, maybe create a constants file with info
     # THINK(jinder): but creating file for one constant seems overkill
     warnings_file_name_regex = (
-        r"pytest_warnings_?[\w-]*\.json"  # noqa pylint: disable=W1401
+        r"pytest_warnings_?[\w.-]*\.json"  # noqa pylint: disable=W1401
     )
 
     # iterate through files_in_dir and see if they match our know file name pattern


### PR DESCRIPTION
## Description

Backported from openedx PR: https://github.com/openedx/edx-platform/pull/37464

This PR future proofs artifact uploads to prevent the following error by creating unique artifact names.

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

This error used to occur when we had 2 django-version shards. It can potentially occur again if another shard is added for python, django, mongo or os version. This is due to github jobs running in parallel and attempting to upload artifacts with the same name at the same time.

Historically, this error triggered a lot when processing lms-4 (dj=pinned) and lms-4 (dj=5.2) since this shard took a longer time. For other shards, the artifact upload would finish on one job and the next job would delete before uploading another artifact with the same name. We were also losing logs on our unit tests because we were deleting them. This PR incidentally future proofs this as well.

## Supporting information

https://github.com/openedx/edx-platform/pull/37464
https://github.com/openedx/edx-platform/issues/36160

## Testing instructions

1. In Github action's unit-test summary page, scroll down to the artifacts section at the bottom.
2. Download pytest-warnings-json and open it.
3. The folder should contain files with names that contain the python, django, mongo and os version. With our current config, you should see a pytest_warnings_xmodule-with-lms for ubuntu 22.04 and ubuntu 24.04.
