### PR TITLE
fix: pasting a component with image isn't working

### DIFF
--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -747,8 +747,8 @@ def _import_file_into_course(
         contentstore().save(content)
         return True, {clipboard_file_path: f"static/{import_path}"}
     elif current_file.content_digest == file_data_obj.md5_hash:
-        # The file already exists and matches exactly, so no action is needed except substitutions
-        return None, {clipboard_file_path: f"static/{import_path}"}
+        # The file already exists and matches exactly, so no action is needed
+        return None, {}
     else:
         # There is a conflict with some other file that has the same name.
         return False, {}


### PR DESCRIPTION
Ticket: [TNL2-394](https://2u-internal.atlassian.net/browse/TNL2-394)
When copying a component that has image in it, and we try to paste it. Image URL appends `static_None`. Result in crash or image not found error.
  - In this commit we have fixed this scenario, copy paste is working for components containing images.
  - Previous Code [link](https://github.com/openedx/edx-platform/commit/36c16d695259db0d92a43c1da5aed03a3197cacb#diff-4deb51bb5c3961a4a76ed1a264942c99df1cc63749fc6a614f8774ffe9266bca:~:text=%23%20The%20file%20already,%7D%22%7D), that caused the issue.
  - upstream PR [Link](https://github.com/openedx/edx-platform/pull/37529).

**Before:**
<video src="https://github.com/user-attachments/assets/e58e8485-3c98-4aa9-bc84-c31f70ecd0cf" controls></video>
<video src="https://github.com/user-attachments/assets/771b03c5-34df-4ec3-8437-e88370ff46ef" controls></video>

**After:**
<video src="https://github.com/user-attachments/assets/6ba420f7-7c92-4860-a78b-19bcc06e0ae4" controls></video>
<video src="https://github.com/user-attachments/assets/e954ff44-d7ea-4ca0-8abe-8479593ead44" controls></video>

