### PR TITLE
feat: allows a reversion of the  retirement partner report reset toggle

### DIFF
--- a/openedx/core/djangoapps/user_api/admin.py
+++ b/openedx/core/djangoapps/user_api/admin.py
@@ -185,7 +185,7 @@ class UserRetirementPartnerReportingStatusAdmin(admin.ModelAdmin):
         """
         return obj.user.id
 
-    def reset_state(self, request, queryset):
+    def reset_state_false(self, request, queryset):
         """
         Action callback for bulk resetting is_being_processed to False (0).
         """
@@ -194,9 +194,22 @@ class UserRetirementPartnerReportingStatusAdmin(admin.ModelAdmin):
             message_bit = "one user was"
         else:
             message_bit = "%s users were" % rows_updated
-        self.message_user(request, "%s successfully reset." % message_bit)
+        self.message_user(request, "%s successfully reset to False." % message_bit)
 
-    reset_state.short_description = 'Reset is_being_processed to False'
+    reset_state_false.short_description = "Reset is_being_processed to False"
+
+    def reset_state_true(self, request, queryset):
+        """
+        Action callback for bulk resetting is_being_processed to True (1).
+        """
+        rows_updated = queryset.update(is_being_processed=1)
+        if rows_updated == 1:
+            message_bit = "one user was"
+        else:
+            message_bit = "%s users were" % rows_updated
+        self.message_user(request, "%s successfully reset to True." % message_bit)
+
+    reset_state_true.short_description = "Reset is_being_processed to True"
 
 
 @admin.register(BulkUserRetirementConfig)


### PR DESCRIPTION

* feat: allows a reversion of the  retirement partner report reset toggle

This allows you to set retirement partner report statuses to True as well as to False. One sample use case: if an overly large number of retirement partner reports have their status reset to false, the partner report queue can struggle to deal with the large queue.

FIXES: APER-4177

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
