### PR TITLE
feat: add a default audio codec for the HLS video player (#37525)

### DIFF
--- a/xmodule/js/src/video/02_html5_hls_video.js
+++ b/xmodule/js/src/video/02_html5_hls_video.js
@@ -26,6 +26,12 @@
                     // do common initialization independent of player type
                     this.init(el, config);
 
+                    // set a default audio codec if not provided, this helps reduce issues
+                    // switching audio codecs during playback
+                    if (!this.config.defaultAudioCodec) {
+                        this.config.defaultAudioCodec = "mp4a.40.5";
+                    }
+
                     _.bindAll(this, 'playVideo', 'pauseVideo', 'onReady');
 
                     // If we have only HLS sources and browser doesn't support HLS then show error message.


### PR DESCRIPTION
Deploy of https://github.com/openedx/edx-platform/pull/37525

## Description

Some HLS video sources, when performing a level switch from default starting bitrate to a different bitrate encounter an error which causes garbled audio.

Defining a default audio codec seems to reduce this occurrence. See [the docs](https://github.com/video-dev/hls.js/blob/v0.14.17/docs/API.md#defaultaudiocodec) which note that omitting a default value can cause issues.

**NOTE** that the _real_ fix is probably to [update our now five years out-of-date HLS library version](https://github.com/video-dev/hls.js/tree/v0.14.17) but that is a whole other conversation for a different day and can probably just be deferred to extraction of the video block.

## Testing instructions

1. Load a known broken video. These are often from outside sources like private YouTube videos or CloudFront hosted files.
2. Before fix, at the 10 second mark the video should perform a level switch and cause broken audio.
3. After fix, there should be no breakage to audio.