### PR TITLE
fix: incorrect LTI exam due dates for self-paced courses

### DIFF
--- a/cms/djangoapps/contentstore/exams.py
+++ b/cms/djangoapps/contentstore/exams.py
@@ -74,13 +74,13 @@ def register_exams(course_key):
         # Exams in courses not using an LTI based proctoring provider should use the original definition of due_date
         # from contentstore/proctoring.py. These exams are powered by the edx-proctoring plugin and not the edx-exams
         # microservice.
+        is_instructor_paced = not course.self_paced
         if course.proctoring_provider == 'lti_external':
-            due_date = (
-                timed_exam.due.isoformat() if timed_exam.due
-                else (course.end.isoformat() if course.end else None)
-            )
+            due_date_source = timed_exam.due if is_instructor_paced else course.end
         else:
-            due_date = timed_exam.due if not course.self_paced else None
+            due_date_source = timed_exam.due if is_instructor_paced else None
+
+        due_date = due_date_source.isoformat() if due_date_source else None
 
         exams_list.append({
             'course_id': str(course_key),


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

These changes fix a bug in how LTI-based exam due dates are computed and written to the exams service. Prior to this change, an LTI exam due date was computed irrespective of the course pacing type. In certain cases, this caused incorrect due dates to be written to the exams service for LTI-based exams.

For example, if a course team initially develops a course as an instructor-paced course and sets a due date on an exam subsection, that subsection due date is written to the modulestore. If the course team subsequently changes that course pacing type to self-paced, then that due date remains in the modulestore to allow course teams to switch pacing types without erasing due dates. The impact of this is that, when the course is published, the exam subsection due date is written to the exams service as the due date, even though there are no static due dates in a self-paced course. Frequently, these due dates are in the past (e.g. for course reruns), so learners automatically cannot access exams. Even if the due date is manually corrected in the exams service, every course publish reverts the due date to the incorrect due date.

This change computes the due date of LTI-based exams as...
* the exam subsection due date if the course is instructor-paced, if the subsection has a due date; else None
* the course end date if the course is self-paced, if the course has an end date; else None

In order to correct any incorrect due dates, course teams should republish their courses.