### PR TITLE
fix: move default audio codec setting earlier to init correctly

### DIFF
--- a/xmodule/js/src/video/02_html5_hls_video.js
+++ b/xmodule/js/src/video/02_html5_hls_video.js
@@ -23,14 +23,14 @@
 
                     this.config = config;
 
-                    // do common initialization independent of player type
-                    this.init(el, config);
-
                     // set a default audio codec if not provided, this helps reduce issues
                     // switching audio codecs during playback
                     if (!this.config.defaultAudioCodec) {
                         this.config.defaultAudioCodec = "mp4a.40.5";
                     }
+
+                    // do common initialization independent of player type
+                    this.init(el, config);
 
                     _.bindAll(this, 'playVideo', 'pauseVideo', 'onReady');
 


### PR DESCRIPTION
## Description

Hopeful fix for #19 , moves `defaultAudioCodec` config earlier in initialization to set correctly.

## Deadline

ASAP