### PR TITLE
fix: video default audio codec fix (attempt 3)

### DIFF
--- a/xmodule/js/src/video/02_html5_hls_video.js
+++ b/xmodule/js/src/video/02_html5_hls_video.js
@@ -23,14 +23,8 @@
 
                     this.config = config;
 
-                    // set a default audio codec if not provided, this helps reduce issues
-                    // switching audio codecs during playback
-                    if (!this.config.defaultAudioCodec) {
-                        this.config.defaultAudioCodec = "mp4a.40.5";
-                    }
-
                     // do common initialization independent of player type
-                    this.init(el, config);
+                    this.init(el, this.config);
 
                     _.bindAll(this, 'playVideo', 'pauseVideo', 'onReady');
 

--- a/xmodule/js/src/video/02_html5_hls_video.js
+++ b/xmodule/js/src/video/02_html5_hls_video.js
@@ -24,7 +24,7 @@
                     this.config = config;
 
                     // do common initialization independent of player type
-                    this.init(el, this.config);
+                    this.init(el, config);
 
                     _.bindAll(this, 'playVideo', 'pauseVideo', 'onReady');
 

--- a/xmodule/js/src/video/03_video_player.js
+++ b/xmodule/js/src/video/03_video_player.js
@@ -182,7 +182,10 @@
                                 onReadyHLS: function() { dfd.resolve(); },
                                 videoSources: state.HLSVideoSources,
                                 canPlayHLS: state.canPlayHLS,
-                                HLSOnlySources: state.HLSOnlySources
+                                HLSOnlySources: state.HLSOnlySources,
+                                // set a default audio codec if not provided, this helps reduce issues
+                                // switching audio codecs during playback
+                                defaultAudioCodec: "mp4a.40.5"
                             })
                         );
                         // `loadedmetadata` event triggered too early on Safari due


### PR DESCRIPTION
## Description

I found that setting a default audio codec (`defaultAudioCodec = "mp4a.40.5"`) helps reduce issues in HLS streams switching bitrates mid-stream.

After several attempt to set this config (#19 and #21) I found that I needed to set the config much higher up the initialization chain to actually set that value all the places that are used in the level switching process.

Third time's the charm? 

## Deadline

ASAP but also I probably won't be able to monitor rollout 🤷 