### PR TITLE
fix: accessibility issue on video transcripts

### DIFF
--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -708,6 +708,10 @@
     line-height: lh();
 }
 
+.xmodule_display.xmodule_VideoBlock .video .subtitles .subtitles-menu li:has(> span:empty) {
+  display: none;
+}
+
 .xmodule_display.xmodule_VideoBlock .video .subtitles .subtitles-menu li span {
     display: block;
 }


### PR DESCRIPTION
Ticket: [TNL2-405](https://2u-internal.atlassian.net/browse/TNL2-405)
This PR fixes accessibility issue for video transcripts as when a video component's SRT file has an empty line, the transcript has an empty link that is still interactive.
 
Empty links should not be interactive and should be hidden from keyboard users as it takes extra click for them when an empty line occurs in the transcript.
Upstream PR: https://github.com/openedx/edx-platform/pull/37587
**Before:**
<video src="https://github.com/user-attachments/assets/d1c18ad5-7b16-4ac9-89f4-5a366b4c6039" controls></video>

**After:**
<video src="https://github.com/user-attachments/assets/bcdbcafe-9ccb-4266-821b-91ea6591b802" controls></video>

