### PR TITLE
fix: add text alternative for external link icon in LTI components

### DIFF
--- a/lms/templates/lti.html
+++ b/lms/templates/lti.html
@@ -37,6 +37,7 @@ from django.utils.translation import gettext as _
             <p class="lti-link external"><a target="_blank" class="link_lti_new_window" rel="noopener" href="${form_url}">
                 ${button_text or _('View resource in a new window')}
                  <span class="icon fa fa-external-link" aria-hidden="true"></span>
+                 <span class="sr-only">External link</span>
             </a></p>
         </div>
     % else:

--- a/xmodule/js/fixtures/lti.html
+++ b/xmodule/js/fixtures/lti.html
@@ -30,7 +30,12 @@
             <input name="oauth_callback" value="about:blank" />
             <input name="context_id" value="testorg/testcoursename/2014" />
 
-            <input type="submit" value="Press to Launch" />
+            <button type="submit" class="link_lti_new_window">
+                Press to Launch
+                <span class="icon fa fa-external-link" aria-hidden="true"></span>
+                <span class="sr-only">External link</span>
+                <span class="lti-launch-status"></span>
+            </button>
         </form>
 
     </div>


### PR DESCRIPTION
### Description

Fixes an accessibility issue in LTI components where the external link icon lacked a text alternative.
Added visually hidden text to ensure screen readers announce that the link opens in a new window, complying with WCAG 1.1.1 (Non-text Content).

### Fix Summary

 - Added hidden text (opens in a new window) next to the external link icon.
 - Marked the icon with aria-hidden="true".
 - Ensured consistency with text component external link behavior.

### Jira Ticket

[COSMO2-719](https://2u-internal.atlassian.net/jira/software/c/projects/COSMO2/boards/2821?selectedIssue=COSMO2-719)