### PR TITLE
fix: AI moderation fields in accessible_fields

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
@@ -23,6 +23,7 @@ class Comment(models.Model):
         'closed', 'created_at', 'updated_at', 'depth', 'at_position_list',
         'type', 'commentable_id', 'abuse_flaggers', 'endorsement',
         'child_count', 'edit_history',
+        'is_spam', 'ai_moderation_reason', 'abuse_flagged',
     ]
 
     updatable_fields = [

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -33,6 +33,7 @@ class Thread(models.Model):
         'abuse_flaggers', 'resp_skip', 'resp_limit', 'resp_total', 'thread_type',
         'endorsed_responses', 'non_endorsed_responses', 'non_endorsed_resp_total',
         'context', 'last_activity_at', 'closed_by', 'close_reason_code', 'edit_history',
+        'is_spam', 'ai_moderation_reason', 'abuse_flagged',
     ]
 
     # updateable_fields are sent in PUT requests


### PR DESCRIPTION
## Description 
This PR adds a few fields in `Comment` and `Thread` to identify if content is spam. So manual efforts are reduced to remove the spam. 

As of now it is just a MVP. 

There are various changes supposed to be done on this. 

## Test Instructions 
- Install this forum on your devstack / environment (Open edX is on forum==0.3.8, edx/forum is on forum == 0.3.9) 
- Enable Ai Moderation waffle `discussions.enable_ai_moderation`
- Set following in your environment files 
```
AI_MODERATION_API_URL: 'URL_FOR_AI'
AI_MODERATION_CLIENT_ID: 'AI_CLIENT_ID'
AI_MODERATION_USER_ID: USER_ID_OF_GLOBAL_MODERATOR
```
- Now try and create a spam / scam post, you should see it as reported (if you are a staff) 
- ModerationAuditLog in Django admin will also show you the spammed post

## Related PRs and order of merging:- 
1. https://github.com/edx/forum/pull/1
2. https://github.com/edx/sandbox-internal/pull/385
3. https://github.com/edx/edx-internal/pull/13562
4. https://github.com/edx/edx-internal/pull/13561
5. https://github.com/edx/edx-platform/pull/26

## Needs Migration command to be run 
This PR adds new migration files so migration commands need to run if not run automatically 

```
./manage.py lms migrate forum
```

## Verification 
- To check if it's installed or not, you can go to your edxapp env in your desired environment and fire following :- 
```
pip list | grep forum
```

This should list `0.3.9`  as forum version


## Known issues :-  

- https://2u-internal.atlassian.net/browse/COSMO2-770

## Deadline :-  ASAP


# Jira Link 
- https://2u-internal.atlassian.net/browse/COSMO2-738
- https://2u-internal.atlassian.net/browse/COSMO2-759
