### PR TITLE
chore: Upgrade Django to 4.2.26 (security release)

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -167,7 +167,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.25
+django==4.2.26
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -331,7 +331,7 @@ distlib==0.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==4.2.25
+django==4.2.26
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -225,7 +225,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.25
+django==4.2.26
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -251,7 +251,7 @@ dill==0.4.0
     # via pylint
 distlib==0.4.0
     # via virtualenv
-django==4.2.25
+django==4.2.26
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -34,7 +34,7 @@ cryptography==45.0.7
     # via
     #   -c requirements/constraints.txt
     #   pyjwt
-django==4.2.25
+django==4.2.26
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -52,7 +52,7 @@ cryptography==45.0.7
     #   pyjwt
 ddt==1.7.2
     # via -r scripts/user_retirement/requirements/testing.in
-django==4.2.25
+django==4.2.26
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django-crum


### PR DESCRIPTION
Ran `make upgrade-package package=Django` in 3.11 venv.
