### PR TITLE
fix: team posts now visible by handling standalone context properly

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -166,6 +166,7 @@ def get_threads(request, course, user_info, discussion_id=None, per_page=THREADS
                     'flagged',
                     'unread',
                     'unanswered',
+                    'context',
                 ]
             )
         )


### PR DESCRIPTION
### Description:

This update fixes the issue where team posts were not visible in the LMS. Team posts use context="standalone", and the retrieval logic was not handling it correctly, causing empty results.

The fix ensures team posts are displayed correctly after posting, without affecting regular course discussions.

### Linked PRs:

-  [forum](https://github.com/edx/forum/pull/5)

### Jira Ticket:

[COSMO2-776](https://2u-internal.atlassian.net/jira/software/c/projects/COSMO2/boards/2821?selectedIssue=COSMO2-776)
