### PR TITLE
fix: reorder showanswer checks to restore expected behavior in preview mode

### DIFF
--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -1498,14 +1498,14 @@ class _BuiltInProblemBlock(
         if not self.correctness_available():
             # If correctness is being withheld, then don't show answers either.
             return False
-        elif self.showanswer == '':
-            return False
         elif self.showanswer == SHOWANSWER.NEVER:
             return False
         elif user_is_staff:
             # This is after the 'never' check because admins can see the answer
             # unless the problem explicitly prevents it
             return True
+        elif self.showanswer == '':
+            return False
         elif self.showanswer == SHOWANSWER.ATTEMPTED:
             return self.is_attempted() or self.is_past_due()
         elif self.showanswer == SHOWANSWER.ANSWERED:


### PR DESCRIPTION
### Description:

- Fixes the “Show Answer” option not working in preview mode by reordering the showanswer condition checks. This ensures preview behavior matches the expected logic without affecting published problems.

### Jira:

- [TNL2-446](https://2u-internal.atlassian.net/browse/TNL2-446)
 