### PR TITLE
fix: improving geolite workflow

### DIFF
--- a/.github/workflows/update-geolite-database.yml
+++ b/.github/workflows/update-geolite-database.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Create a branch, commit the code and make a PR
         id: create-pr
         run: |
-          BRANCH="${{ github.actor }}/geoip2-bot-update-country-database-$(echo "${{ github.sha }}" | cut -c 1-7)"
+          BRANCH="${{ github.actor }}/geoip2-bot-update-country-database-${{ github.run_id }}"
           git checkout -b $BRANCH
           git add .
           git status


### PR DESCRIPTION
# Description
We changed the branch name logic because the workflow regenerated the same branch name on reruns (since it was based on github.sha), causing GitHub to reject the push with “fetch first” because the branch already existed on the remote.