### PR TITLE
feat: extend beta component types and improve editor behavior

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -69,10 +69,12 @@ COMPONENT_TYPES = [
     'openassessment',
     'drag-and-drop-v2',
 ]
-if is_games_xblock_enabled():
-    COMPONENT_TYPES.append('games')
 
 BETA_COMPONENT_TYPES = ['library_v2', 'itembank']
+
+if is_games_xblock_enabled():
+    COMPONENT_TYPES.append('games')
+    BETA_COMPONENT_TYPES.append('games')
 
 ADVANCED_COMPONENT_TYPES = sorted({name for name, class_ in XBlock.load_classes()} - set(COMPONENT_TYPES))
 

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -301,6 +301,12 @@ function($, _, Backbone, gettext, BasePage,
             this.xblockView.refresh(xblockView, block_added, is_duplicate);
             // Update publish and last modified information from the server.
             this.model.fetch();
+
+            // Auto-open editor for games blocks when first added
+            if (block_added && !is_duplicate && xblockView && xblockView.$el &&
+                xblockView.$el.find('.xblock-header-primary').attr('data-block-type') === 'games') {
+                setTimeout(function() { xblockView.$el.find('.edit-button').first().trigger('click'); }, 500);
+            }
         },
 
         renderAddXBlockComponents: function() {


### PR DESCRIPTION
### Description:

- Adds the Games XBlock to `BETA_COMPONENT_TYPES` to reflect its beta status
- Ensures consistent classification of beta components across the platform
- Automatically opens the editor when a new block is created (for legacy view)
- Improves authoring workflow and reduces extra user actions

### Jira

- https://2u-internal.atlassian.net/browse/TNL2-458

### Authors

- @viv-helix 
- @pganesh-apphelix 

#### Video (After):

https://github.com/user-attachments/assets/c565fe39-6dea-4601-a735-12882308ae3c




