### PR TITLE
fix: added logs and record exception for datadog monitoring

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1114,7 +1114,10 @@ class LMSAccountRetirementView(ViewSet):
             record_exception()
             return Response(status=status.HTTP_404_NOT_FOUND)
         except RetirementStateError as exc:
-            user_id = getattr(retirement, 'user', {}).get('id', 'unknown') if 'retirement' in locals() else 'unknown'
+            try:
+                user_id = retirement.user.id
+            except (AttributeError, NameError):
+                user_id = 'unknown'
             log.error(
                 'RetirementStateError during user retirement: user_id=%s, error=%s',
                 user_id, str(exc)
@@ -1122,7 +1125,10 @@ class LMSAccountRetirementView(ViewSet):
             record_exception()
             return Response(str(exc), status=status.HTTP_400_BAD_REQUEST)
         except Exception as exc:  # pylint: disable=broad-except
-            user_id = getattr(retirement, 'user', {}).get('id', 'unknown') if 'retirement' in locals() else 'unknown'
+            try:
+                user_id = retirement.user.id
+            except (AttributeError, NameError):
+                user_id = 'unknown'
             log.error(
                 'Unexpected error during user retirement: user_id=%s, error=%s',
                 user_id, str(exc)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1114,16 +1114,18 @@ class LMSAccountRetirementView(ViewSet):
             record_exception()
             return Response(status=status.HTTP_404_NOT_FOUND)
         except RetirementStateError as exc:
+            user_id = getattr(retirement, 'user', {}).get('id', 'unknown') if 'retirement' in locals() else 'unknown'
             log.error(
                 'RetirementStateError during user retirement: user_id=%s, error=%s',
-                getattr(retirement, 'user', {}).get('id', 'unknown') if 'retirement' in locals() else 'unknown', str(exc)
+                user_id, str(exc)
             )
             record_exception()
             return Response(str(exc), status=status.HTTP_400_BAD_REQUEST)
         except Exception as exc:  # pylint: disable=broad-except
+            user_id = getattr(retirement, 'user', {}).get('id', 'unknown') if 'retirement' in locals() else 'unknown'
             log.error(
                 'Unexpected error during user retirement: user_id=%s, error=%s',
-                getattr(retirement, 'user', {}).get('id', 'unknown') if 'retirement' in locals() else 'unknown', str(exc)
+                user_id, str(exc)
             )
             record_exception()
             return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -23,6 +23,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from edx_ace import ace
 from edx_ace.recipient import Recipient
+from edx_django_utils.monitoring import record_exception
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, PendingEnterpriseCustomerUser
@@ -1107,10 +1108,24 @@ class LMSAccountRetirementView(ViewSet):
                 user=retirement.user,
             )
         except UserRetirementStatus.DoesNotExist:
+            log.error(
+                'UserRetirementStatus not found for retirement action'
+            )
+            record_exception()
             return Response(status=status.HTTP_404_NOT_FOUND)
         except RetirementStateError as exc:
+            log.error(
+                'RetirementStateError during user retirement: user_id=%s, error=%s',
+                getattr(retirement, 'user', {}).get('id', 'unknown') if 'retirement' in locals() else 'unknown', str(exc)
+            )
+            record_exception()
             return Response(str(exc), status=status.HTTP_400_BAD_REQUEST)
         except Exception as exc:  # pylint: disable=broad-except
+            log.error(
+                'Unexpected error during user retirement: user_id=%s, error=%s',
+                getattr(retirement, 'user', {}).get('id', 'unknown') if 'retirement' in locals() else 'unknown', str(exc)
+            )
+            record_exception()
             return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1116,7 +1116,7 @@ class LMSAccountRetirementView(ViewSet):
         except RetirementStateError as exc:
             try:
                 user_id = retirement.user.id
-            except (AttributeError, NameError):
+            except AttributeError:
                 user_id = 'unknown'
             log.error(
                 'RetirementStateError during user retirement: user_id=%s, error=%s',
@@ -1127,7 +1127,7 @@ class LMSAccountRetirementView(ViewSet):
         except Exception as exc:  # pylint: disable=broad-except
             try:
                 user_id = retirement.user.id
-            except (AttributeError, NameError):
+            except AttributeError:
                 user_id = 'unknown'
             log.error(
                 'Unexpected error during user retirement: user_id=%s, error=%s',


### PR DESCRIPTION
### Description:
133+ user retirements are stuck in failed state with no diagnostic information preventing us from fixing them. This change adds detailed logging to identify root causes of retirement failures so we can systematically resolve the existing backlog and prevent future issues. 

### Solution:
Enhanced exception handling in LMS retirement endpoint with detailed error logging and DataDog integration.

- Added detailed error messages for each exception type
- User ID tracking (PII-compliant)
- `record_exception()` calls for monitoring

### Private JIRA Link:
[BOMS-290](https://2u-internal.atlassian.net/browse/BOMS-290)