### PR TITLE
fix: handle missing CourseOverview during manual enrollment retirement

### DIFF
--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -1584,7 +1584,6 @@ class ManualEnrollmentAudit(models.Model):
             try:
                 manual_enrollment_audit.history.update(reason="", enrolled_email=retired_email)
             except CourseOverview.DoesNotExist:
-                # Course overview no longer exists, skip historical update but continue retirement
                 log.warning(
                     f"CourseOverview missing for enrollment during retirement, skipping historical update "
                     f"for audit {manual_enrollment_audit.id}"

--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -1581,7 +1581,14 @@ class ManualEnrollmentAudit(models.Model):
             return False
 
         for manual_enrollment_audit in manual_enrollment_audits:
-            manual_enrollment_audit.history.update(reason="", enrolled_email=retired_email)
+            try:
+                manual_enrollment_audit.history.update(reason="", enrolled_email=retired_email)
+            except CourseOverview.DoesNotExist:
+                # Course overview no longer exists, skip historical update but continue retirement
+                log.warning(
+                    f"CourseOverview missing for enrollment during retirement, skipping historical update "
+                    f"for audit {manual_enrollment_audit.id}"
+                )
         manual_enrollment_audits.update(reason="", enrolled_email=retired_email)
         return True
 

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -723,6 +723,30 @@ class TestManualEnrollmentAudit(SharedModuleStoreTestCase):
         assert not ManualEnrollmentAudit.objects.filter(enrollment=enrollment).exclude(enrolled_email='xxx')
         assert not ManualEnrollmentAudit.objects.filter(enrollment=enrollment).exclude(reason='')
 
+    def test_retirement_with_missing_course_overview(self):
+        """
+        Tests that retirement succeeds gracefully when CourseOverview is missing,
+        skipping historical updates but still updating current records.
+        """
+        enrollment = CourseEnrollment.enroll(self.user, self.course.id)
+        ManualEnrollmentAudit.create_manual_enrollment_audit(
+            self.instructor, self.user.email, ALLOWEDTOENROLL_TO_ENROLLED,
+            'test enrollment with missing overview', enrollment
+        )
+
+        # Delete the CourseOverview to simulate the missing overview scenario
+        CourseOverview.objects.filter(id=self.course.id).delete()
+
+        # Retirement should complete successfully without raising CourseOverview.DoesNotExist
+        ManualEnrollmentAudit.retire_manual_enrollments(user=self.user, retired_email="retired@test.com")
+
+        # Verify the main audit records were still updated despite missing CourseOverview
+        assert ManualEnrollmentAudit.objects.filter(enrollment=enrollment).exists()
+        assert not ManualEnrollmentAudit.objects.filter(enrollment=enrollment).exclude(
+            enrolled_email='retired@test.com'
+        )
+        assert not ManualEnrollmentAudit.objects.filter(enrollment=enrollment).exclude(reason='')
+
 
 class TestAccountRecovery(TestCase):
     """


### PR DESCRIPTION
### Description:
 User retirement process is failing with 500 errors for 133+ users due to ManualEnrollmentAudit records attempting to access CourseOverview data during historical record updates. This occurs when courses are deleted from the overview table but their associated enrollment records remain, causing django-simple-history to trigger CourseOverview lookups that fail with DoesNotExist exceptions.

### Solution:
Added exception handling around historical updates in `ManualEnrollmentAudit.retire_manual_enrollments()` method. When CourseOverview is missing, the system now:

- Logs a warning and skips historical update for that specific audit
- Continues processing remaining audits
- Still updates main audit records to complete retirement successfully

### Private JIRA Link:
[BOMS-370](https://2u-internal.atlassian.net/browse/BOMS-370)