### PR TITLE
fix: enhance error handling and logging in LMSAccountRetirementView

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1121,22 +1121,20 @@ class LMSAccountRetirementView(ViewSet):
             except AttributeError:
                 user_id = 'unknown'
 
-            error_details = {
-                'error_type': 'RetirementStateError',
-                'user_id': user_id,
-                'original_error': str(exc),
-                'timestamp': datetime.datetime.now(pytz.UTC).isoformat()
-            }
-
-            try:
-                current_responses = json.loads(retirement.responses) if retirement.responses else []
-                current_responses.append(error_details)
-                retirement.responses = json.dumps(current_responses)
-                retirement.save()
-            except (json.JSONDecodeError, AttributeError):
-                pass
-
             log_error = self._sanitize_error_message(str(exc))
+            
+            # Store error information in retirement status as plain text
+            error_msg = f"RetirementStateError: {log_error}"
+            try:
+                if 'retirement' in locals() and retirement:
+                    if retirement.responses:
+                        retirement.responses += f"\\n{error_msg}"
+                    else:
+                        retirement.responses = error_msg
+                    retirement.save()
+            except AttributeError:
+                pass  # Continue with logging even if response storage fails
+
             log.error(
                 'RetirementStateError during user retirement: user_id=%s, error=%s',
                 user_id, log_error
@@ -1149,22 +1147,20 @@ class LMSAccountRetirementView(ViewSet):
             except AttributeError:
                 user_id = 'unknown'
 
-            error_details = {
-                'error_type': type(exc).__name__,
-                'user_id': user_id,
-                'original_error': str(exc),
-                'timestamp': datetime.datetime.now(pytz.UTC).isoformat()
-            }
-
-            try:
-                current_responses = json.loads(retirement.responses) if retirement.responses else []
-                current_responses.append(error_details)
-                retirement.responses = json.dumps(current_responses)
-                retirement.save()
-            except (json.JSONDecodeError, AttributeError):
-                pass
-
             log_error = self._sanitize_error_message(str(exc))
+            
+            # Store error information in retirement status as plain text
+            error_msg = f"{type(exc).__name__}: {log_error}"
+            try:
+                if 'retirement' in locals() and retirement:
+                    if retirement.responses:
+                        retirement.responses += f"\\n{error_msg}"
+                    else:
+                        retirement.responses = error_msg
+                    retirement.save()
+            except AttributeError:
+                pass  # Continue with logging even if response storage fails
+
             log.error(
                 'Unexpected error during user retirement: user_id=%s, error=%s',
                 user_id, log_error
@@ -1189,11 +1185,19 @@ class LMSAccountRetirementView(ViewSet):
 
         message = error_message
 
+        # Remove email addresses
         message = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
                           '-', message, flags=re.IGNORECASE)
 
+        # Remove username values in various formats
         message = re.sub(r"username='[^']*'", "username='-'", message)
         message = re.sub(r'username="[^"]*"', 'username="-"', message)
+        message = re.sub(r'username:\s*[^\s,]+', 'username: -', message)
+        message = re.sub(r'username=\s*[^\s,]+', 'username=-', message)
+        
+        # Remove common username patterns in error messages
+        message = re.sub(r'\bUser\s+[A-Za-z0-9._-]+\s+not found', 'User - not found', message, flags=re.IGNORECASE)
+        message = re.sub(r'for user\s+[A-Za-z0-9._-]+', 'for user -', message, flags=re.IGNORECASE)
 
         return message
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1128,14 +1128,13 @@ class LMSAccountRetirementView(ViewSet):
                 'timestamp': datetime.datetime.now(pytz.UTC).isoformat()
             }
 
-            # Store detailed error information in retirement status
             try:
                 current_responses = json.loads(retirement.responses) if retirement.responses else []
                 current_responses.append(error_details)
                 retirement.responses = json.dumps(current_responses)
                 retirement.save()
             except (json.JSONDecodeError, AttributeError):
-                pass  # Continue with logging even if response storage fails
+                pass
 
             log_error = self._sanitize_error_message(str(exc))
             log.error(
@@ -1157,14 +1156,13 @@ class LMSAccountRetirementView(ViewSet):
                 'timestamp': datetime.datetime.now(pytz.UTC).isoformat()
             }
 
-            # Store detailed error information in retirement status
             try:
                 current_responses = json.loads(retirement.responses) if retirement.responses else []
                 current_responses.append(error_details)
                 retirement.responses = json.dumps(current_responses)
                 retirement.save()
             except (json.JSONDecodeError, AttributeError):
-                pass  # Continue with logging even if response storage fails
+                pass
 
             log_error = self._sanitize_error_message(str(exc))
             log.error(
@@ -1189,14 +1187,11 @@ class LMSAccountRetirementView(ViewSet):
         if not error_message:
             return error_message
 
-        # Simple PII removal for the most common cases in retirement errors
         message = error_message
 
-        # Remove email addresses
         message = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
                           '-', message, flags=re.IGNORECASE)
 
-        # Remove username values but keep the structure
         message = re.sub(r"username='[^']*'", "username='-'", message)
         message = re.sub(r'username="[^"]*"', 'username="-"', message)
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -6,7 +6,9 @@ https://openedx.atlassian.net/wiki/display/TNL/User+API
 """
 
 import datetime
+import json
 import logging
+import re
 from functools import wraps
 
 import pytz
@@ -1118,25 +1120,87 @@ class LMSAccountRetirementView(ViewSet):
                 user_id = retirement.user.id
             except AttributeError:
                 user_id = 'unknown'
+
+            error_details = {
+                'error_type': 'RetirementStateError',
+                'user_id': user_id,
+                'original_error': str(exc),
+                'timestamp': datetime.datetime.now(pytz.UTC).isoformat()
+            }
+
+            # Store detailed error information in retirement status
+            try:
+                current_responses = json.loads(retirement.responses) if retirement.responses else []
+                current_responses.append(error_details)
+                retirement.responses = json.dumps(current_responses)
+                retirement.save()
+            except (json.JSONDecodeError, AttributeError):
+                pass  # Continue with logging even if response storage fails
+
+            log_error = self._sanitize_error_message(str(exc))
             log.error(
                 'RetirementStateError during user retirement: user_id=%s, error=%s',
-                user_id, str(exc)
+                user_id, log_error
             )
             record_exception()
-            return Response(str(exc), status=status.HTTP_400_BAD_REQUEST)
+            return Response("RetirementStateError occurred during retirement", status=status.HTTP_400_BAD_REQUEST)
         except Exception as exc:  # pylint: disable=broad-except
             try:
                 user_id = retirement.user.id
             except AttributeError:
                 user_id = 'unknown'
+
+            error_details = {
+                'error_type': type(exc).__name__,
+                'user_id': user_id,
+                'original_error': str(exc),
+                'timestamp': datetime.datetime.now(pytz.UTC).isoformat()
+            }
+
+            # Store detailed error information in retirement status
+            try:
+                current_responses = json.loads(retirement.responses) if retirement.responses else []
+                current_responses.append(error_details)
+                retirement.responses = json.dumps(current_responses)
+                retirement.save()
+            except (json.JSONDecodeError, AttributeError):
+                pass  # Continue with logging even if response storage fails
+
+            log_error = self._sanitize_error_message(str(exc))
             log.error(
                 'Unexpected error during user retirement: user_id=%s, error=%s',
-                user_id, str(exc)
+                user_id, log_error
             )
             record_exception()
-            return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response("Internal error occurred during retirement", status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def _sanitize_error_message(self, error_message):
+        """
+        Remove common PII from error messages while preserving debugging context.
+
+        Args:
+            error_message (str): The original error message
+
+        Returns:
+            str: Error message with PII removed
+        """
+        if not error_message:
+            return error_message
+
+        # Simple PII removal for the most common cases in retirement errors
+        message = error_message
+
+        # Remove email addresses
+        message = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
+                          '-', message, flags=re.IGNORECASE)
+
+        # Remove username values but keep the structure
+        message = re.sub(r"username='[^']*'", "username='-'", message)
+        message = re.sub(r'username="[^"]*"', 'username="-"', message)
+
+        return message
 
 
 class AccountRetirementView(ViewSet):

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1115,24 +1115,7 @@ class LMSAccountRetirementView(ViewSet):
             record_exception()
             return Response(status=status.HTTP_404_NOT_FOUND)
         except RetirementStateError as exc:
-            try:
-                user_id = retirement.user.id
-            except AttributeError:
-                user_id = 'unknown'
-
-            log_error = self._sanitize_error_message(str(exc))
-
-            # Store error information in retirement status as plain text
-            error_msg = f"RetirementStateError: {log_error}"
-            try:
-                if 'retirement' in locals() and retirement:
-                    if retirement.responses:
-                        retirement.responses += f"\\n{error_msg}"
-                    else:
-                        retirement.responses = error_msg
-                    retirement.save()
-            except AttributeError:
-                pass  # Continue with logging even if response storage fails
+            user_id, log_error = self._store_retirement_error(exc, retirement, "RetirementStateError")
 
             log.error(
                 'RetirementStateError during user retirement: user_id=%s, error=%s',
@@ -1141,24 +1124,7 @@ class LMSAccountRetirementView(ViewSet):
             record_exception()
             return Response("RetirementStateError occurred during retirement", status=status.HTTP_400_BAD_REQUEST)
         except Exception as exc:  # pylint: disable=broad-except
-            try:
-                user_id = retirement.user.id
-            except AttributeError:
-                user_id = 'unknown'
-
-            log_error = self._sanitize_error_message(str(exc))
-
-            # Store error information in retirement status as plain text
-            error_msg = f"{type(exc).__name__}: {log_error}"
-            try:
-                if 'retirement' in locals() and retirement:
-                    if retirement.responses:
-                        retirement.responses += f"\\n{error_msg}"
-                    else:
-                        retirement.responses = error_msg
-                    retirement.save()
-            except AttributeError:
-                pass  # Continue with logging even if response storage fails
+            user_id, log_error = self._store_retirement_error(exc, retirement)
 
             log.error(
                 'Unexpected error during user retirement: user_id=%s, error=%s',
@@ -1185,7 +1151,7 @@ class LMSAccountRetirementView(ViewSet):
         message = error_message
 
         # Remove email addresses
-        message = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
+        message = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b',
                          '-', message, flags=re.IGNORECASE)
 
         # Remove username values in various formats
@@ -1199,6 +1165,46 @@ class LMSAccountRetirementView(ViewSet):
         message = re.sub(r'for user\s+[A-Za-z0-9._-]+', 'for user -', message, flags=re.IGNORECASE)
 
         return message
+
+    def _store_retirement_error(self, exc, retirement, error_prefix=""):
+        """
+        Store sanitized error information in retirement status and return user_id and log_error for logging.
+
+        Args:
+            exc: The exception object
+            retirement: The retirement object (may be None)
+            error_prefix: Optional prefix for the error message (e.g., "RetirementStateError")
+
+        Returns:
+            tuple: (user_id, log_error) for logging purposes
+        """
+        # Get user_id safely
+        try:
+            user_id = retirement.user.id if retirement else 'unknown'
+        except AttributeError:
+            user_id = 'unknown'
+
+        # Sanitize error message
+        log_error = self._sanitize_error_message(str(exc))
+
+        # Create error message with prefix
+        if error_prefix:
+            error_msg = f"{error_prefix}: {log_error}"
+        else:
+            error_msg = f"{type(exc).__name__}: {log_error}"
+
+        # Store error information in retirement status as plain text
+        try:
+            if retirement is not None:
+                if retirement.responses:
+                    retirement.responses += f"\n{error_msg}"
+                else:
+                    retirement.responses = error_msg
+                retirement.save()
+        except AttributeError as e:
+            log.warning('Failed to store error in retirement status: %s', str(e))
+
+        return user_id, log_error
 
 
 class AccountRetirementView(ViewSet):

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -6,7 +6,6 @@ https://openedx.atlassian.net/wiki/display/TNL/User+API
 """
 
 import datetime
-import json
 import logging
 import re
 from functools import wraps
@@ -1072,7 +1071,7 @@ class LMSAccountRetirementView(ViewSet):
     parser_classes = (JSONParser,)
 
     @request_requires_username
-    def post(self, request):
+    def post(self, request):  # pylint: disable=too-many-statements
         """
         POST /api/user/v1/accounts/retire_misc/
 
@@ -1122,7 +1121,7 @@ class LMSAccountRetirementView(ViewSet):
                 user_id = 'unknown'
 
             log_error = self._sanitize_error_message(str(exc))
-            
+
             # Store error information in retirement status as plain text
             error_msg = f"RetirementStateError: {log_error}"
             try:
@@ -1148,7 +1147,7 @@ class LMSAccountRetirementView(ViewSet):
                 user_id = 'unknown'
 
             log_error = self._sanitize_error_message(str(exc))
-            
+
             # Store error information in retirement status as plain text
             error_msg = f"{type(exc).__name__}: {log_error}"
             try:
@@ -1187,14 +1186,14 @@ class LMSAccountRetirementView(ViewSet):
 
         # Remove email addresses
         message = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
-                          '-', message, flags=re.IGNORECASE)
+                         '-', message, flags=re.IGNORECASE)
 
         # Remove username values in various formats
         message = re.sub(r"username='[^']*'", "username='-'", message)
         message = re.sub(r'username="[^"]*"', 'username="-"', message)
         message = re.sub(r'username:\s*[^\s,]+', 'username: -', message)
         message = re.sub(r'username=\s*[^\s,]+', 'username=-', message)
-        
+
         # Remove common username patterns in error messages
         message = re.sub(r'\bUser\s+[A-Za-z0-9._-]+\s+not found', 'User - not found', message, flags=re.IGNORECASE)
         message = re.sub(r'for user\s+[A-Za-z0-9._-]+', 'for user -', message, flags=re.IGNORECASE)


### PR DESCRIPTION
### Description:
User retirement 500 errors difficult to debug due to PII in error messages.

### Solution:

- Added `sanitize_error_message()` method to replace emails/usernames with `-` in logs
- Enhanced exception handling to store full error details in `UserRetirementStatus.responses`
- Return generic error messages to API callers

### Private JIRA Link:
[BOMS-297](https://2u-internal.atlassian.net/browse/BOMS-297)