### PR TITLE
fix: improve logging for user retirement errors with exception details

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1118,10 +1118,9 @@ class LMSAccountRetirementView(ViewSet):
                 user_id = retirement.user.id
             except AttributeError:
                 user_id = 'unknown'
-            exception_type = type(exc).__name__
             log.exception(
-                'RetirementStateError during user retirement: user_id=%s, exception_type=%s, error=%s',
-                user_id, exception_type, str(exc)
+                'RetirementStateError during user retirement: user_id=%s, error=%s',
+                user_id, str(exc)
             )
             record_exception()
             return Response(str(exc), status=status.HTTP_400_BAD_REQUEST)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1108,7 +1108,7 @@ class LMSAccountRetirementView(ViewSet):
                 user=retirement.user,
             )
         except UserRetirementStatus.DoesNotExist:
-            log.error(
+            log.exception(
                 'UserRetirementStatus not found for retirement action'
             )
             record_exception()
@@ -1118,9 +1118,10 @@ class LMSAccountRetirementView(ViewSet):
                 user_id = retirement.user.id
             except AttributeError:
                 user_id = 'unknown'
-            log.error(
-                'RetirementStateError during user retirement: user_id=%s, error=%s',
-                user_id, str(exc)
+            exception_type = type(exc).__name__
+            log.exception(
+                'RetirementStateError during user retirement: user_id=%s, exception_type=%s, error=%s',
+                user_id, exception_type, str(exc)
             )
             record_exception()
             return Response(str(exc), status=status.HTTP_400_BAD_REQUEST)
@@ -1129,9 +1130,10 @@ class LMSAccountRetirementView(ViewSet):
                 user_id = retirement.user.id
             except AttributeError:
                 user_id = 'unknown'
-            log.error(
-                'Unexpected error during user retirement: user_id=%s, error=%s',
-                user_id, str(exc)
+            exception_type = type(exc).__name__
+            log.exception(
+                'Unexpected error during user retirement: user_id=%s, exception_type=%s, error=%s',
+                user_id, exception_type, str(exc)
             )
             record_exception()
             return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
### Description:
User retirement failures were difficult to debug due to limited logging information.

### Solution:
Enhanced exception logging in `LMSAccountRetirementView`:


- Changed `log.error` to `log.exception` to include full stacktraces
- Added `exception_type` logging for better error classification
- Maintains original response behavior

### Private JIRA Link:
[BOMS-290](https://2u-internal.atlassian.net/browse/BOMS-290)