### PR TITLE
fix: improve beta label contrast in gamesxblock

### DIFF
--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -163,8 +163,8 @@
           display: inline-block;
 
           color: $uxpl-green-base;
-          background-color: #fff;
-          border-color: #fff;
+          background-color: $white;
+          border-color: $white;
           border-radius: 3px;
 
           font-size: 90%;

--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -163,8 +163,8 @@
           display: inline-block;
 
           color: $uxpl-green-base;
-          background-color: theme-color("inverse");
-          border-color: theme-color("inverse");
+          background-color: #fff;
+          border-color: #fff;
           border-radius: 3px;
 
           font-size: 90%;


### PR DESCRIPTION
**Description**
- Improves beta label contrast in the games block for accessibility.

**Jira**
- https://2u-internal.atlassian.net/browse/TNL2-489

**Screenshot**
 
<img width="134" height="137" alt="image (10)" src="https://github.com/user-attachments/assets/3d19a896-71c3-4b89-9bd5-b2438dd84a99" />
