### PR TITLE
fix:  use target user enrollment for org-level bulk delete and bulk restore

### DIFF
--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1819,7 +1819,7 @@ class BulkRestoreUserPosts(DeveloperErrorViewMixin, APIView):
         if course_or_org == "org":
             org_id = CourseKey.from_string(course_id).org
             enrollments = CourseEnrollment.objects.filter(
-                user=request.user
+                user=user
             ).values_list("course_id", flat=True)
             course_ids.extend([str(c_id) for c_id in enrollments if c_id.org == org_id])
             course_ids = list(set(course_ids))

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1667,7 +1667,7 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
         if course_or_org == "org":
             org_id = CourseKey.from_string(course_id).org
             enrollments = CourseEnrollment.objects.filter(
-                user=request.user
+                user=user
             ).values_list("course_id", flat=True)
             course_ids.extend([str(c_id) for c_id in enrollments if c_id.org == org_id])
             course_ids = list(set(course_ids))


### PR DESCRIPTION
**Problem Description:**
Bulk-delete and bulk-restore by organization in edX discussions only removed and restored posts from the currently active course.

**Solution:**
 In views.py incorrectly filtered CourseEnrollment records using request.user (the admin making the request) instead of user (the target user whose posts should be deleted).

**jira link**-   [COSMO2-787](https://2u-internal.atlassian.net/browse/COSMO2-787 )