### PR TITLE
fix: reset default PDF URL to an empty string

### DIFF
--- a/common/static/js/vendor/pdfjs/viewer.js
+++ b/common/static/js/vendor/pdfjs/viewer.js
@@ -27,7 +27,7 @@
 
 'use strict';
 
-var DEFAULT_URL = 'compressed.tracemonkey-pldi-09.pdf';
+var DEFAULT_URL = '';
 var DEFAULT_SCALE_DELTA = 1.1;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 10.0;


### PR DESCRIPTION
**Description**

- Replaced pdf.js `DEFAULT_URL` with an empty string to prevent it from attempting to load the unused `compressed.tracemonkey-pldi-09.pdf` file, fixing the initial loading error.

**Jira**

- https://2u-internal.atlassian.net/browse/TNL2-452

**Screenshot**

Before:
<img width="1712" height="860" alt="image" src="https://github.com/user-attachments/assets/3485ba10-d607-4790-ac3b-4dcb413adc38" />

After:
<img width="1712" height="860" alt="image" src="https://github.com/user-attachments/assets/26a6a96d-7616-4557-9af9-f585240b251c" />
