### PR TITLE
feat: add endpoint to get value of unified translations toggle

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3448,6 +3448,7 @@ class CourseAboutViewTests(ModuleStoreTestCase):
             else:
                 assert response.status_code == 200
 
+
 @ddt.ddt
 class UnifiedSiteAndTranslationLanguageEnabledViewTests(TestCase):
     """
@@ -3461,4 +3462,3 @@ class UnifiedSiteAndTranslationLanguageEnabledViewTests(TestCase):
         with override_waffle_flag(ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE, enabled):
             response = self.client.get(url)
         assert response.json()['enabled'] == enabled
-

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3457,8 +3457,7 @@ class UnifiedSiteAndTranslationLanguageEnabledViewTests(TestCase):
 
     @ddt.data(True, False)
     def test_view(self, enabled):
-        course_id = 'course-v1:org+course+run'
-        url = reverse('unified_translations_enabled_view', args=[course_id])
+        url = reverse('unified_translations_enabled_view')
         with override_waffle_flag(ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE, enabled):
             response = self.client.get(url)
         assert response.json()['enabled'] == enabled

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -79,6 +79,7 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR,
     COURSEWARE_MICROFRONTEND_SEARCH_ENABLED,
     COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
+    ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE,
 )
 from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
@@ -3446,3 +3447,18 @@ class CourseAboutViewTests(ModuleStoreTestCase):
                 assert response.url == "http://example.com/catalog/courses/{}/about".format(self.course.id)
             else:
                 assert response.status_code == 200
+
+@ddt.ddt
+class UnifiedSiteAndTranslationLanguageEnabledViewTests(TestCase):
+    """
+    Tests for the unified_site_and_translation_language_enabled view
+    """
+
+    @ddt.data(True, False)
+    def test_view(self, enabled):
+        course_id = 'course-v1:org+course+run'
+        url = reverse('unified_translations_enabled_view', args=[course_id])
+        with override_waffle_flag(ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE, enabled):
+            response = self.client.get(url)
+        assert response.json()['enabled'] == enabled
+

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3454,10 +3454,18 @@ class UnifiedSiteAndTranslationLanguageEnabledViewTests(TestCase):
     """
     Tests for the unified_site_and_translation_language_enabled view
     """
+    @override_waffle_flag(ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE, True)
+    def test_view_logged_out(self):
+        url = reverse('unified_translations_enabled_view')
+        self.client.logout()
+        response = self.client.get(url)
+        assert response.status_code == 302
 
     @ddt.data(True, False)
     def test_view(self, enabled):
         url = reverse('unified_translations_enabled_view')
+        user = UserFactory.create()
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         with override_waffle_flag(ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE, enabled):
             response = self.client.get(url)
         assert response.json()['enabled'] == enabled

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -2,7 +2,7 @@
 Toggles for courseware in-course experience.
 """
 
-from edx_toggles.toggles import SettingToggle, WaffleFlag, WaffleSwitch
+from edx_toggles.toggles import SettingToggle, WaffleSwitch
 
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -169,7 +169,7 @@ ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER = WaffleSwitch(
 )
 
 # .. toggle_name: courseware.unify_site_and_translation_language
-# .. toggle_implementation: WaffleFlag
+# .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Update LMS to use site language for xpert unit translations and enable new header site language switcher.
 # .. toggle_use_cases: opt_in
@@ -177,7 +177,7 @@ ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER = WaffleSwitch(
 # .. toggle_target_removal_date: None
 # .. toggle_warning: None.
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/81
-ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE = WaffleFlag(
+ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE = CourseWaffleFlag(
     f'{WAFFLE_FLAG_NAMESPACE}.unify_site_and_translation_language', __name__
 )
 
@@ -215,3 +215,10 @@ def courseware_disable_navigation_sidebar_blocks_caching(course_key=None):
     Return whether the courseware.disable_navigation_sidebar_blocks_caching flag is on.
     """
     return COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING.is_enabled(course_key)
+
+
+def unified_site_and_translation_language_is_enabled(course_key=None):
+    """
+    Return whether the courseware.unify_site_and_translation_language flag is on.
+    """
+    return ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE.is_enabled(course_key)

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -2,7 +2,7 @@
 Toggles for courseware in-course experience.
 """
 
-from edx_toggles.toggles import SettingToggle, WaffleSwitch
+from edx_toggles.toggles import SettingToggle, WaffleSwitch, WaffleFlag
 
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
@@ -169,7 +169,7 @@ ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER = WaffleSwitch(
 )
 
 # .. toggle_name: courseware.unify_site_and_translation_language
-# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Update LMS to use site language for xpert unit translations and enable new header site language switcher.
 # .. toggle_use_cases: opt_in
@@ -177,7 +177,7 @@ ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER = WaffleSwitch(
 # .. toggle_target_removal_date: None
 # .. toggle_warning: None.
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/81
-ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE = CourseWaffleFlag(
+ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE = WaffleFlag(
     f'{WAFFLE_FLAG_NAMESPACE}.unify_site_and_translation_language', __name__
 )
 
@@ -217,8 +217,8 @@ def courseware_disable_navigation_sidebar_blocks_caching(course_key=None):
     return COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING.is_enabled(course_key)
 
 
-def unified_site_and_translation_language_is_enabled(course_key=None):
+def unified_site_and_translation_language_is_enabled():
     """
     Return whether the courseware.unify_site_and_translation_language flag is on.
     """
-    return ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE.is_enabled(course_key)
+    return ENABLE_UNIFIED_SITE_AND_TRANSLATION_LANGUAGE.is_enabled()

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -2405,6 +2405,7 @@ def courseware_mfe_navigation_sidebar_toggles(request, course_id=None):
     })
 
 
+@login_required
 @api_view(['GET'])
 def unified_site_and_translation_language_enabled(request):
     """

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -159,6 +159,7 @@ from ..tabs import _get_dynamic_tabs
 from ..toggles import (
     COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
     ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER,
+    unified_site_and_translation_language_is_enabled,
 )
 
 log = logging.getLogger("edx.courseware")
@@ -2402,3 +2403,11 @@ def courseware_mfe_navigation_sidebar_toggles(request, course_id=None):
         # Add completion tracking status for the sidebar use while a global place for switches is put in place
         "enable_completion_tracking": ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled()
     })
+
+@api_view(['GET'])
+def unified_site_and_translation_language_enabled(request, course_id=None):
+    """
+    Simple GET endpoint to expose whether the user/course has access to the unified translations feature
+    """
+    course_key = CourseKey.from_string(course_id) if course_id else None
+    return JsonResponse({'enabled': unified_site_and_translation_language_is_enabled(course_key)})

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -2404,10 +2404,14 @@ def courseware_mfe_navigation_sidebar_toggles(request, course_id=None):
         "enable_completion_tracking": ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled()
     })
 
+
 @api_view(['GET'])
 def unified_site_and_translation_language_enabled(request, course_id=None):
     """
     Simple GET endpoint to expose whether the user/course has access to the unified translations feature
     """
-    course_key = CourseKey.from_string(course_id) if course_id else None
+    try:
+        course_key = CourseKey.from_string(course_id) if course_id else None
+    except InvalidKeyError:
+        return JsonResponse({"error": "Invalid course_id"})
     return JsonResponse({'enabled': unified_site_and_translation_language_is_enabled(course_key)})

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -2406,12 +2406,8 @@ def courseware_mfe_navigation_sidebar_toggles(request, course_id=None):
 
 
 @api_view(['GET'])
-def unified_site_and_translation_language_enabled(request, course_id=None):
+def unified_site_and_translation_language_enabled(request):
     """
     Simple GET endpoint to expose whether the user/course has access to the unified translations feature
     """
-    try:
-        course_key = CourseKey.from_string(course_id) if course_id else None
-    except InvalidKeyError:
-        return JsonResponse({"error": "Invalid course_id"})
-    return JsonResponse({'enabled': unified_site_and_translation_language_is_enabled(course_key)})
+    return JsonResponse({'enabled': unified_site_and_translation_language_is_enabled()})

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -760,7 +760,7 @@ urlpatterns += [
 
 urlpatterns += [
     re_path(
-        fr'^courses/{settings.COURSE_ID_PATTERN}/unified-translations/enabled',
+        fr'^courses/{settings.COURSE_ID_PATTERN}/unified-translations/enabled/$',
         courseware_views.unified_site_and_translation_language_enabled,
         name='unified_translations_enabled_view'
     )

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -760,7 +760,7 @@ urlpatterns += [
 
 urlpatterns += [
     re_path(
-        fr'^courses/unified-translations/enabled/$',
+        r'^api/unified-translations/enabled/$',
         courseware_views.unified_site_and_translation_language_enabled,
         name='unified_translations_enabled_view'
     )

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -760,7 +760,7 @@ urlpatterns += [
 
 urlpatterns += [
     re_path(
-        fr'^courses/{settings.COURSE_ID_PATTERN}/unified-translations/enabled/$',
+        fr'^courses/unified-translations/enabled/$',
         courseware_views.unified_site_and_translation_language_enabled,
         name='unified_translations_enabled_view'
     )

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -760,6 +760,14 @@ urlpatterns += [
 
 urlpatterns += [
     re_path(
+        fr'^courses/{settings.COURSE_ID_PATTERN}/unified-translations/enabled',
+        courseware_views.unified_site_and_translation_language_enabled,
+        name='unified_translations_enabled_view'
+    )
+]
+
+urlpatterns += [
+    re_path(
         r'^courses/{}/lti_tab/(?P<provider_uuid>[^/]+)/$'.format(
             settings.COURSE_ID_PATTERN,
         ),


### PR DESCRIPTION
Adds an endpoint  `LMS_BASE/api/unified-translations/enabled` that returns `{'enabled': bool}` to identify if the unified site translations feature is enabled or not.

