### PR TITLE
fix: update DEFAULT_ADVANCED_MODULES to correct ubcpi entry & library_content

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -104,7 +104,7 @@ DEFAULT_ADVANCED_MODULES = [
     'invideoquiz',
     'lti_consumer',
     'oppia',
-    'ubcpi-xblock',
+    'ubcpi',
     'poll',
     'qualtricssurvey',
     'scorm',
@@ -113,6 +113,7 @@ DEFAULT_ADVANCED_MODULES = [
     'survey',
     'word_cloud',
     'recommender',
+    'library_content',
 ]
 
 


### PR DESCRIPTION
- fixed Peer Instruction Question xblock name from `ubcpi-xblock` to `ubcpi`
- Added `library_content` to randomise legacy library