### PR TITLE
feat(ACT-432): add Group Community TA audience for cohorted content_reported notifications

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -382,9 +382,17 @@ class DiscussionNotificationSender:
             'content': thread_body,
             'email_content': clean_thread_html_body(thread_body)
         }
-        audience_filters = {'discussion_roles': [
-            FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA
-        ]}
+        group_id = self.thread.attributes.get('group_id')
+        cohort_ids = [int(group_id)] if group_id is not None else []
+
+        audience_filters = {
+            'discussion_roles': [
+                FORUM_ROLE_ADMINISTRATOR,
+                FORUM_ROLE_MODERATOR,
+                FORUM_ROLE_COMMUNITY_TA,
+            ],
+            'cohort_for_group_tas': cohort_ids,
+        }
         self._send_course_wide_notification("content_reported", audience_filters, context)
 
     def _populate_context_with_ids_for_mobile(self, context, notification_type):

--- a/lms/djangoapps/discussion/rest_api/tests/test_discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_discussions_notifications.py
@@ -51,10 +51,11 @@ class TestDiscussionNotificationSender(unittest.TestCase):
             'email_content': 'Thread body',
         })
         self.assertEqual(audience_filters, {
-            'discussion_roles': ['Administrator', 'Moderator', 'Community TA']
+            'discussion_roles': ['Administrator', 'Moderator', 'Community TA'],
+            'cohort_for_group_tas': [1],
         })
-        self.assertEqual(len(audience_filters), 1)
-        self.assertEqual(list(audience_filters.keys()), ['discussion_roles'])
+        self.assertEqual(len(audience_filters), 2)
+        self.assertEqual(list(audience_filters.keys()), ['discussion_roles', 'cohort_for_group_tas'])
 
     def test_send_reported_content_notification_for_response(self, mock_send_notification, mock_create_audience):
         """

--- a/openedx/core/djangoapps/notifications/audience_filters.py
+++ b/openedx/core/djangoapps/notifications/audience_filters.py
@@ -251,7 +251,8 @@ class NotificationFilter:
             )
             user_ids = getattr(self, filter_name)(user_ids, course)
         return user_ids
-    
+
+
 class GroupTAinCohortFilter(NotificationAudienceFilterBase):
     """
     Returns Group Community TA (Group Moderator) user ids for the provided cohort IDs.

--- a/openedx/core/djangoapps/notifications/audience_filters.py
+++ b/openedx/core/djangoapps/notifications/audience_filters.py
@@ -251,3 +251,40 @@ class NotificationFilter:
             )
             user_ids = getattr(self, filter_name)(user_ids, course)
         return user_ids
+    
+class GroupTAinCohortFilter(NotificationAudienceFilterBase):
+    """
+    Returns Group Community TA (Group Moderator) user ids for the provided cohort IDs.
+    Expected param: a list of cohort ids (integers).
+    """
+    # we accept any values (cohort ids), so allowed_filters can stay empty
+    allowed_filters = []
+
+    def filter(self, cohort_ids):
+        """
+        cohort_ids: list of cohort id integers (or strings)
+        return: iterable of user ids
+        """
+        if not cohort_ids:
+            return []
+
+        # Get user ids who are members of the cohort group(s)
+        cohort_users_qs = CourseUserGroup.objects.filter(
+            course_id=self.course_key,
+            id__in=cohort_ids,
+            group_type=CourseUserGroup.COHORT
+        ).values_list("users__id", flat=True)
+
+        # If no users in cohort, short-circuit
+        cohort_user_ids = list(cohort_users_qs)
+        if not cohort_user_ids:
+            return []
+
+        # Now get those users who have the Group Moderator forum role in this course
+        group_moderator_user_ids_qs = Role.objects.filter(
+            course_id=self.course_key,
+            name=FORUM_ROLE_GROUP_MODERATOR,
+            users__id__in=cohort_user_ids
+        ).values_list("users__id", flat=True)
+
+        return list(group_moderator_user_ids_qs)

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -141,6 +141,10 @@ COURSE_NOTIFICATION_TYPES = {
             'replier_name': 'replier name',
         },
         'email_template': '',
+        'filters': [
+            FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE,
+            "GroupTAinCohortFilter",
+        ],
         'visible_to': [FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA]
     },
     'response_endorsed_on_thread': {


### PR DESCRIPTION
What: Added GroupTAinCohortFilter to include Group Community TA (Group Moderator) users in content_reported notifications only when they belong to the same cohort as the reported content.

How:

Added new audience filter GroupTAinCohortFilter in notifications.

Added filter to content_reported in base_notification.py.

Updated discussion notification sender to pass cohort_for_group_tas (from thread group_id) into audience_filters.

Testing (devstack): UI blocked due to Discussion/MongoDB hostname issue, so validated via Django shell:

Cohort A → returns group_ta_a

Cohort B → returns group_ta_b

Empty cohort list → []

Negative: removing group_ta_a from Cohort A makes filter return [], adding back restores.

Files changed:

openedx/core/djangoapps/notifications/audience_filters.py

openedx/core/djangoapps/notifications/base_notification.py

lms/djangoapps/discussion/rest_api/discussions_notifications.py

@asharma4-sonata please review this