### PR TITLE
feat: open directly editor on add and update games icon size

### DIFF
--- a/cms/static/images/large-games-icon.svg
+++ b/cms/static/images/large-games-icon.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="34" height="34" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_11387_43979)">
 <path d="M19 5H17V3H7V5H5C3.9 5 3 5.9 3 7V8C3 10.55 4.92 12.63 7.39 12.94C8.02 14.44 9.37 15.57 11 15.9V19H7V21H17V19H13V15.9C14.63 15.57 15.98 14.44 16.61 12.94C19.08 12.63 21 10.55 21 8V7C21 5.9 20.1 5 19 5ZM5 8V7H7V10.82C5.84 10.4 5 9.3 5 8ZM19 8C19 9.3 18.16 10.4 17 10.82V7H19V8Z" fill="white"/>
 </g>

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -301,12 +301,6 @@ function($, _, Backbone, gettext, BasePage,
             this.xblockView.refresh(xblockView, block_added, is_duplicate);
             // Update publish and last modified information from the server.
             this.model.fetch();
-
-            // Auto-open editor for games blocks when first added
-            if (block_added && !is_duplicate && xblockView && xblockView.$el &&
-                xblockView.$el.find('.xblock-header-primary').attr('data-block-type') === 'games') {
-                setTimeout(function() { xblockView.$el.find('.edit-button').first().trigger('click'); }, 500);
-            }
         },
 
         renderAddXBlockComponents: function() {
@@ -1190,7 +1184,8 @@ function($, _, Backbone, gettext, BasePage,
             // open mfe editors for new blocks only and not for content imported from libraries
             if(!data.hasOwnProperty('upstreamRef') && ((useNewTextEditor === 'True' && blockType.includes('html'))
                     || (useNewVideoEditor === 'True' && blockType.includes('video'))
-                    || (useNewProblemEditor === 'True' && blockType.includes('problem')))
+                    || (useNewProblemEditor === 'True' && blockType.includes('problem'))
+                    || blockType.includes('games'))
             ){
                 if (this.options.isIframeEmbed && (this.isSplitTestContentPage || this.isVerticalContentPage)) {
                     return this.postMessageToParent({


### PR DESCRIPTION
**Description**

- Removes custom timeout-based logic for auto-opening the Games editor and instead includes Games blocks in the standard MFE editor launch flow. 
- Updates the large games icon to render at a larger size.

**Jira**

- https://2u-internal.atlassian.net/browse/TNL2-458

**Screenshot**

<img width="1190" height="459" alt="image (11)" src="https://github.com/user-attachments/assets/88203b22-4a2e-48ca-aed8-00a3fcddb79b" />
