### PR TITLE
feat: add SES delivery support for course update emails

### DIFF
--- a/openedx/core/djangoapps/ace_common/utils.py
+++ b/openedx/core/djangoapps/ace_common/utils.py
@@ -2,8 +2,16 @@
 Utility functions for edx-ace.
 """
 import logging
+from openedx.features.course_experience import (
+    ENABLE_SES_FOR_COURSEUPDATE,
+)
 
 log = logging.getLogger(__name__)
+
+
+SES_MESSAGE_FLAG_MAP = {
+    'course_update': ENABLE_SES_FOR_COURSEUPDATE,
+}
 
 
 def setup_firebase_app(firebase_credentials, app_name='fcm-app'):
@@ -19,3 +27,18 @@ def setup_firebase_app(firebase_credentials, app_name='fcm-app'):
             certificate = firebase_admin.credentials.Certificate(firebase_credentials)
             app = firebase_admin.initialize_app(certificate, name=app_name)
         return app
+
+
+def should_route_to_ses(msg):
+    """
+    Determine whether an ACE message should be routed via SES.
+
+    Routing is controlled by message-specific waffle flags.
+    """
+    flag = SES_MESSAGE_FLAG_MAP.get(msg.name)
+
+    if not flag:
+        return False
+
+    # Environment-level flag (not course-scoped)
+    return flag.is_enabled()

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -12,6 +12,7 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.db.utils import DatabaseError
 from edx_ace import ace
+from edx_ace.errors import RecoverableChannelDeliveryError
 from edx_ace.message import Message
 from edx_ace.utils.date import deserialize, serialize
 from edx_django_utils.monitoring import (
@@ -23,6 +24,7 @@ from eventtracking import tracker
 from importlib import import_module
 from opaque_keys.edx.keys import CourseKey
 
+from openedx.core.djangoapps.ace_common.utils import should_route_to_ses
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.schedules import message_types, resolvers
 from openedx.core.djangoapps.schedules.models import Schedule, ScheduleConfig
@@ -283,7 +285,6 @@ def _schedule_send(msg_str, site_id, delivery_config_var, log_prefix):  # lint-a
     if _is_delivery_enabled(site, delivery_config_var, log_prefix):
         msg = Message.from_string(msg_str)
         msg.options['skip_disable_user_policy'] = True
-
         user = User.objects.get(id=msg.recipient.lms_user_id)
         if not user.has_usable_password():
             LOG.info(f'{delivery_config_var} Scheduled email User is disabled {user.username}')
@@ -291,7 +292,28 @@ def _schedule_send(msg_str, site_id, delivery_config_var, log_prefix):  # lint-a
         with emulate_http_request(site=site, user=user):
             _annonate_send_task_for_monitoring(msg)
             LOG.debug('%s: Sending message = %s', log_prefix, msg_str)
-            ace.send(msg)
+            if should_route_to_ses(msg):
+                msg.options.update({
+                    'from_address': settings.LMS_COMM_DEFAULT_FROM_EMAIL,
+                    'override_default_channel': 'django_email',
+                    'transactional': True,
+                })
+
+            try:
+                ace.send(msg)
+            except RecoverableChannelDeliveryError:
+                LOG.warning(
+                    '%s: SES send failed for user %s, raising for retry',
+                    log_prefix,
+                    user.id,
+                )
+                raise
+            LOG.info(
+                '%s: Course Update email for user %s sent via %s',
+                log_prefix,
+                user.id,
+                'SES' if should_route_to_ses(msg) else 'default ACE channel',
+            )
             _track_message_sent(site, user, msg)
 
 

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -83,6 +83,16 @@ RELATIVE_DATES_DISABLE_RESET_FLAG = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.r
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-36
 CALENDAR_SYNC_FLAG = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.calendar_sync', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
+# .. toggle_name: course_experience.enable_ses_for_courseupdate
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Used to determine whether or not to use AWS SES to send Course Update emails for the course.
+# .. toggle_use_cases: opt_in, temporary
+# .. toggle_creation_date: 2026-01-27
+# .. toggle_target_removal_date: None
+# .. toggle_warning: This temporary feature toggle does not have a target removal date.
+ENABLE_SES_FOR_COURSEUPDATE = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.enable_ses_for_courseupdate', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
+
 
 def course_home_page_title(_course):
     """


### PR DESCRIPTION
### Summary
Introduces an opt-in Course Waffle Flag to enable sending Course Update emails via AWS SES.

### Details
- Added `course_experience.enable_ses_for_courseupdate` waffle flag (default: disabled).
- Updated schedule email delivery logic to route Course Update emails through SES when the flag is enabled for the course.
- Preserves existing behavior for all other scheduled emails.

### Testing
- Verified locally via Django shell:
  - Course Update emails use SES when the flag is enabled.
  - Course Update emails fall back to the default ACE channel when disabled.
  - Recurring Nudge and other schedule emails remain unaffected.

### Rollout
- Flag-controlled and opt-in per course.
- No behavior change unless explicitly enabled.


@asharma4-sonata Please review my PR and let me know if any changes need to be done.