### PR TITLE
fix: redacting user retirement data in lms

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1115,11 +1115,9 @@ class TestAccountRetirementCleanup(RetirementTestCase):
             f"UPDATE query missing '\"original_name\" = {redacted_name}': {sql_lower}"
         )
 
-        # Verify DELETE query is a single bulk operation (uses ID-based deletion after the update)
-        # Django optimizes by deleting the records using their IDs rather than re-filtering
+        # Verify DELETE is from the correct table
         delete_query = delete_queries[0]
         sql_lower = delete_query['sql']
-        # Ensure it's deleting from the UserRetirementStatus table
         assert 'user_api_userretirementstatus' in sql_lower, (
             f"DELETE query against unexpected table: {sql_lower}"
         )

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -14,7 +14,9 @@ from django.contrib.sites.models import Site
 from django.conf import settings
 from django.core import mail
 from django.core.cache import cache
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from enterprise.models import (
     EnterpriseCourseEnrollment,
@@ -1084,9 +1086,82 @@ class TestAccountRetirementCleanup(RetirementTestCase):
         assert response.status_code == expected_status
         return response
 
-    def test_simple_success(self):
-        self.cleanup_and_assert_status()
-        assert not UserRetirementStatus.objects.all()
+    def _assert_redacted_update_delete_queries(self, queries, redacted_username, redacted_email, redacted_name):
+        """
+        Helper method to verify UPDATE and DELETE queries contain correct field-value assignments.
+        Args:
+            queries: List of captured query dicts from CaptureQueriesContext
+            redacted_username: Expected redacted username value
+            redacted_email: Expected redacted email value
+            redacted_name: Expected redacted name value
+        """
+        update_queries = [q for q in queries if 'UPDATE' in q['sql'] and 'user_api_userretirementstatus' in q['sql']]
+        delete_queries = [q for q in queries if 'DELETE' in q['sql'] and 'user_api_userretirementstatus' in q['sql']]
+        # Should have 1 bulk UPDATE and 1 bulk DELETE query (not individual per-record queries)
+        assert len(update_queries) == 1, f"Expected 1 UPDATE query, found {len(update_queries)}"
+        assert len(delete_queries) == 1, f"Expected 1 DELETE query, found {len(delete_queries)}"
+        # Verify UPDATE query contains the correct field-value assignments
+        for update_query in update_queries:
+            sql_lower = update_query['sql']
+            # Check that the correct field is set with the correct value
+            # This ensures that if someone swaps the assignments, the test will fail
+            assert "original_username" in sql_lower and f"= '{redacted_username}'" in sql_lower, (
+                f"UPDATE query missing 'original_username = {redacted_username}': {sql_lower}"
+            )
+            assert "original_email" in sql_lower and f"= '{redacted_email}'" in sql_lower, (
+                f"UPDATE query missing 'original_email = {redacted_email}': {sql_lower}"
+            )
+            assert "original_name" in sql_lower and f"= '{redacted_name}'" in sql_lower, (
+                f"UPDATE query missing 'original_name = {redacted_name}': {sql_lower}"
+            )
+        # Verify DELETE query filters by the redacted values
+        for delete_query in delete_queries:
+            sql_lower = delete_query['sql']
+            # The DELETE should filter by the redacted values to ensure we're deleting the right records
+            assert f"original_username = '{redacted_username}'" in sql_lower, (
+                f"DELETE query missing 'original_username = {redacted_username}' in WHERE clause: {sql_lower}"
+            )
+            assert f"original_email = '{redacted_email}'" in sql_lower, (
+                f"DELETE query missing 'original_email = {redacted_email}' in WHERE clause: {sql_lower}"
+            )
+            assert f"original_name = '{redacted_name}'" in sql_lower, (
+                f"DELETE query missing 'original_name = {redacted_name}' in WHERE clause: {sql_lower}"
+            )
+
+    def test_default_redacted_values(self):
+        """
+        Test basic cleanup with default redacted values.
+        Verify that redaction (UPDATE) happens before deletion (DELETE).
+        Captures actual SQL queries to ensure UPDATE queries contain correct field-value assignments.
+        """
+        with CaptureQueriesContext(connection) as context:
+            self.cleanup_and_assert_status()
+        # Verify records are deleted after redaction
+        retirements = UserRetirementStatus.objects.all()
+        assert retirements.count() == 0
+        # Verify UPDATE and DELETE queries with default 'redacted' value
+        self._assert_redacted_update_delete_queries(context.captured_queries, 'redacted', 'redacted', 'redacted')
+
+    def test_custom_redacted_values(self):
+        """Test that custom redacted values are applied before deletion."""
+        custom_username = 'username-redacted-12345'
+        custom_email = 'email-redacted-67890'
+        custom_name = 'name-redacted-abcde'
+        data = {
+            'usernames': self.usernames,
+            'redacted_username': custom_username,
+            'redacted_email': custom_email,
+            'redacted_name': custom_name
+        }
+        with CaptureQueriesContext(connection) as context:
+            self.cleanup_and_assert_status(data=data)
+        # Verify records are deleted after redaction
+        retirements = UserRetirementStatus.objects.all()
+        assert retirements.count() == 0
+        # Verify UPDATE and DELETE queries with custom redacted values
+        self._assert_redacted_update_delete_queries(
+            context.captured_queries, custom_username, custom_email, custom_name
+        )
 
     def test_leaves_other_users(self):
         remaining_usernames = []

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1097,14 +1097,14 @@ class TestAccountRetirementCleanup(RetirementTestCase):
         """
         update_queries = [q for q in queries if 'UPDATE' in q['sql'] and 'user_api_userretirementstatus' in q['sql']]
         delete_queries = [q for q in queries if 'DELETE' in q['sql'] and 'user_api_userretirementstatus' in q['sql']]
-        # Should have 1 bulk UPDATE and 1 bulk DELETE query (not individual per-record queries)
+        # Should have exactly 1 bulk UPDATE and 1 bulk DELETE query (not individual per-record queries)
         assert len(update_queries) == 1, f"Expected 1 UPDATE query, found {len(update_queries)}"
         assert len(delete_queries) == 1, f"Expected 1 DELETE query, found {len(delete_queries)}"
-        # Verify UPDATE query contains the correct field-value assignments
+        
+        # Verify UPDATE query redacts records with the correct field-value assignments
         for update_query in update_queries:
             sql_lower = update_query['sql']
-            # Check that the correct field is set with the correct value
-            # This ensures that if someone swaps the assignments, the test will fail
+            # Ensure original_username, original_email, and original_name are set to redacted values
             assert "original_username" in sql_lower and f"= '{redacted_username}'" in sql_lower, (
                 f"UPDATE query missing 'original_username = {redacted_username}': {sql_lower}"
             )
@@ -1114,18 +1114,14 @@ class TestAccountRetirementCleanup(RetirementTestCase):
             assert "original_name" in sql_lower and f"= '{redacted_name}'" in sql_lower, (
                 f"UPDATE query missing 'original_name = {redacted_name}': {sql_lower}"
             )
-        # Verify DELETE query filters by the redacted values
+        
+        # Verify DELETE query is a single bulk operation (uses ID-based deletion after the update)
+        # Django optimizes by deleting the records using their IDs rather than re-filtering
         for delete_query in delete_queries:
             sql_lower = delete_query['sql']
-            # The DELETE should filter by the redacted values to ensure we're deleting the right records
-            assert f"original_username = '{redacted_username}'" in sql_lower, (
-                f"DELETE query missing 'original_username = {redacted_username}' in WHERE clause: {sql_lower}"
-            )
-            assert f"original_email = '{redacted_email}'" in sql_lower, (
-                f"DELETE query missing 'original_email = {redacted_email}' in WHERE clause: {sql_lower}"
-            )
-            assert f"original_name = '{redacted_name}'" in sql_lower, (
-                f"DELETE query missing 'original_name = {redacted_name}' in WHERE clause: {sql_lower}"
+            # Ensure it's a single DELETE statement for the UserRetirementStatus table
+            assert 'DELETE FROM' in sql_lower and 'user_api_userretirementstatus' in sql_lower, (
+                f"DELETE query doesn't match expected pattern: {sql_lower}"
             )
 
     def test_default_redacted_values(self):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1102,27 +1102,27 @@ class TestAccountRetirementCleanup(RetirementTestCase):
         assert len(delete_queries) == 1, f"Expected 1 DELETE query, found {len(delete_queries)}"
 
         # Verify UPDATE query redacts records with the correct field-value assignments
-        for update_query in update_queries:
-            sql_lower = update_query['sql']
-            # Ensure original_username, original_email, and original_name are set to redacted values
-            assert "original_username" in sql_lower and f"= '{redacted_username}'" in sql_lower, (
-                f"UPDATE query missing 'original_username = {redacted_username}': {sql_lower}"
-            )
-            assert "original_email" in sql_lower and f"= '{redacted_email}'" in sql_lower, (
-                f"UPDATE query missing 'original_email = {redacted_email}': {sql_lower}"
-            )
-            assert "original_name" in sql_lower and f"= '{redacted_name}'" in sql_lower, (
-                f"UPDATE query missing 'original_name = {redacted_name}': {sql_lower}"
-            )
+        update_query = update_queries[0]
+        sql_lower = update_query['sql']
+        # Ensure original_username, original_email, and original_name are set to redacted values
+        assert f'"original_username" = \'{redacted_username}\'' in sql_lower, (
+            f"UPDATE query missing '\"original_username\" = {redacted_username}': {sql_lower}"
+        )
+        assert f'"original_email" = \'{redacted_email}\'' in sql_lower, (
+            f"UPDATE query missing '\"original_email\" = {redacted_email}': {sql_lower}"
+        )
+        assert f'"original_name" = \'{redacted_name}\'' in sql_lower, (
+            f"UPDATE query missing '\"original_name\" = {redacted_name}': {sql_lower}"
+        )
 
         # Verify DELETE query is a single bulk operation (uses ID-based deletion after the update)
         # Django optimizes by deleting the records using their IDs rather than re-filtering
-        for delete_query in delete_queries:
-            sql_lower = delete_query['sql']
-            # Ensure it's a single DELETE statement for the UserRetirementStatus table
-            assert 'DELETE FROM' in sql_lower and 'user_api_userretirementstatus' in sql_lower, (
-                f"DELETE query doesn't match expected pattern: {sql_lower}"
-            )
+        delete_query = delete_queries[0]
+        sql_lower = delete_query['sql']
+        # Ensure it's deleting from the UserRetirementStatus table
+        assert 'user_api_userretirementstatus' in sql_lower, (
+            f"DELETE query against unexpected table: {sql_lower}"
+        )
 
     def test_default_redacted_values(self):
         """

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1100,7 +1100,7 @@ class TestAccountRetirementCleanup(RetirementTestCase):
         # Should have exactly 1 bulk UPDATE and 1 bulk DELETE query (not individual per-record queries)
         assert len(update_queries) == 1, f"Expected 1 UPDATE query, found {len(update_queries)}"
         assert len(delete_queries) == 1, f"Expected 1 DELETE query, found {len(delete_queries)}"
-        
+
         # Verify UPDATE query redacts records with the correct field-value assignments
         for update_query in update_queries:
             sql_lower = update_query['sql']
@@ -1114,7 +1114,7 @@ class TestAccountRetirementCleanup(RetirementTestCase):
             assert "original_name" in sql_lower and f"= '{redacted_name}'" in sql_lower, (
                 f"UPDATE query missing 'original_name = {redacted_name}': {sql_lower}"
             )
-        
+
         # Verify DELETE query is a single bulk operation (uses ID-based deletion after the update)
         # Django optimizes by deleting the records using their IDs rather than re-filtering
         for delete_query in delete_queries:

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1088,7 +1088,7 @@ class TestAccountRetirementCleanup(RetirementTestCase):
 
     def _assert_redacted_update_delete_queries(self, queries, redacted_username, redacted_email, redacted_name):
         """
-        Helper method to verify UPDATE and DELETE queries contain correct field-value assignments.
+        Helper method to verify UPDATE and DELETE queries use ID-based filtering and correct field-value assignments.
         Args:
             queries: List of captured query dicts from CaptureQueriesContext
             redacted_username: Expected redacted username value
@@ -1101,7 +1101,7 @@ class TestAccountRetirementCleanup(RetirementTestCase):
         assert len(update_queries) == 1, f"Expected 1 UPDATE query, found {len(update_queries)}"
         assert len(delete_queries) == 1, f"Expected 1 DELETE query, found {len(delete_queries)}"
 
-        # Verify UPDATE query redacts records with the correct field-value assignments
+        # Verify UPDATE query redacts records with the correct field-value assignments and uses ID-based filtering
         update_query = update_queries[0]
         sql_lower = update_query['sql']
         # Ensure original_username, original_email, and original_name are set to redacted values
@@ -1114,12 +1114,19 @@ class TestAccountRetirementCleanup(RetirementTestCase):
         assert f'"original_name" = \'{redacted_name}\'' in sql_lower, (
             f"UPDATE query missing '\"original_name\" = {redacted_name}': {sql_lower}"
         )
+        # Ensure UPDATE uses ID-based filtering
+        assert '"id" IN' in sql_lower or 'WHERE "id"' in sql_lower, (
+            f"UPDATE query should use ID filtering to prevent over-update, but got: {sql_lower}"
+        )
 
-        # Verify DELETE is from the correct table
+        # Verify DELETE is from the correct table and uses ID-based filtering
         delete_query = delete_queries[0]
         sql_lower = delete_query['sql']
         assert 'user_api_userretirementstatus' in sql_lower, (
             f"DELETE query against unexpected table: {sql_lower}"
+        )
+        assert '"id" IN' in sql_lower or 'WHERE "id"' in sql_lower, (
+            f"DELETE query should use ID filtering to prevent over-deletion, but got: {sql_lower}"
         )
 
     def test_default_redacted_values(self):
@@ -1191,6 +1198,31 @@ class TestAccountRetirementCleanup(RetirementTestCase):
         retirement.save()
 
         self.cleanup_and_assert_status(expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_does_not_delete_unrelated_redacted_records(self):
+        """
+        Verify cleanup doesn't delete unrelated records with coincidental redacted values.
+        Regression test for over-deletion bug where deletion was filtered by field values
+        (original_username='redacted') instead of by primary key.
+        """
+        # Create an unrelated record that already has redacted field values
+        other_user = UserFactory()
+        other_retirement = create_retirement_status(other_user, state=self.complete_state)
+        other_retirement.original_username = 'redacted'
+        other_retirement.original_email = 'redacted'
+        other_retirement.original_name = 'redacted'
+        other_retirement.save()
+        other_id = other_retirement.id
+
+        # Clean up only self.usernames records
+        self.cleanup_and_assert_status()
+
+        # Verify target records were deleted
+        target_count = UserRetirementStatus.objects.filter(user__username__in=self.usernames).count()
+        assert target_count == 0, f"Expected 0 target records, found {target_count}"
+
+        # Verify unrelated record was NOT deleted (not a target of cleanup)
+        assert UserRetirementStatus.objects.filter(id=other_id).exists()
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1029,14 +1029,20 @@ class AccountRetirementStatusView(ViewSet):
 
         ```
         {
-            'usernames': ['user1', 'user2', ...]
+            'usernames': ['user1', 'user2', ...],
+            'redacted_username': 'Value to store in username field',
+            'redacted_email': 'Value to store in email field',
+            'redacted_name': 'Value to store in name field'
         }
         ```
 
-        Deletes a batch of retirement requests by username.
+        Redacts a batch of retirement requests by redacting PII fields.
         """
         try:
             usernames = request.data["usernames"]
+            redacted_username = request.data.get("redacted_username", "redacted")
+            redacted_email = request.data.get("redacted_email", "redacted")
+            redacted_name = request.data.get("redacted_name", "redacted")
 
             if not isinstance(usernames, list):
                 raise TypeError("Usernames should be an array.")
@@ -1050,7 +1056,21 @@ class AccountRetirementStatusView(ViewSet):
             if len(usernames) != len(retirements):
                 raise UserRetirementStatus.DoesNotExist("Not all usernames exist in the COMPLETE state.")
 
-            retirements.delete()
+            # Redact PII fields first, then delete. In case an ETL tool is syncing data
+            # to a downstream data warehouse, and treats the deletes as soft-deletes,
+            # the data will have first been redacted, protecting the sensitive PII.
+            retirements.update(
+                original_username=redacted_username,
+                original_email=redacted_email,
+                original_name=redacted_name
+            )
+
+            UserRetirementStatus.objects.filter(
+                original_username=redacted_username,
+                original_email=redacted_email,
+                original_name=redacted_name,
+                current_state=complete_state
+            ).delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
         except (RetirementStateError, UserRetirementStatus.DoesNotExist, TypeError) as exc:
             return Response(str(exc), status=status.HTTP_400_BAD_REQUEST)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1036,7 +1036,7 @@ class AccountRetirementStatusView(ViewSet):
         }
         ```
 
-        Redacts a batch of retirement requests by redacting PII fields.
+        Redacts and then deletes a batch of retirement requests by username.
         """
         try:
             usernames = request.data["usernames"]
@@ -1048,6 +1048,7 @@ class AccountRetirementStatusView(ViewSet):
                 raise TypeError("Usernames should be an array.")
 
             complete_state = RetirementState.objects.get(state_name="COMPLETE")
+            # Get the retirement records to delete
             retirements = UserRetirementStatus.objects.filter(
                 original_username__in=usernames, current_state=complete_state
             )
@@ -1065,6 +1066,7 @@ class AccountRetirementStatusView(ViewSet):
                 original_name=redacted_name
             )
 
+            # Delete using fresh filter by the redacted values to ensure a single bulk DELETE query
             UserRetirementStatus.objects.filter(
                 original_username=redacted_username,
                 original_email=redacted_email,

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1060,19 +1060,18 @@ class AccountRetirementStatusView(ViewSet):
             # Redact PII fields first, then delete. In case an ETL tool is syncing data
             # to a downstream data warehouse, and treats the deletes as soft-deletes,
             # the data will have first been redacted, protecting the sensitive PII.
-            retirements.update(
+            # Get the IDs of the retirements to update/delete
+            retirement_ids = list(retirements.values_list('id', flat=True))
+
+            # Update by IDs
+            UserRetirementStatus.objects.filter(id__in=retirement_ids).update(
                 original_username=redacted_username,
                 original_email=redacted_email,
                 original_name=redacted_name
             )
 
-            # Delete using fresh filter by the redacted values to ensure a single bulk DELETE query
-            UserRetirementStatus.objects.filter(
-                original_username=redacted_username,
-                original_email=redacted_email,
-                original_name=redacted_name,
-                current_state=complete_state
-            ).delete()
+            # Delete by IDs
+            UserRetirementStatus.objects.filter(id__in=retirement_ids, current_state=complete_state).delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
         except (RetirementStateError, UserRetirementStatus.DoesNotExist, TypeError) as exc:
             return Response(str(exc), status=status.HTTP_400_BAD_REQUEST)

--- a/scripts/user_retirement/retirement_archive_and_cleanup.py
+++ b/scripts/user_retirement/retirement_archive_and_cleanup.py
@@ -18,14 +18,11 @@ import click
 from botocore.exceptions import BotoCoreError, ClientError
 from six import text_type
 
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+# Add top-level project path to sys.path before importing scripts code
+sys.path.append(path.abspath(path.join(path.dirname(__file__), '../..')))
 
 # pylint: disable=wrong-import-position
-from tubular.scripts.helpers import (
-    _config_or_exit, _fail, _fail_exception, _log, _setup_lms_api_or_exit
-)
-
+from scripts.user_retirement.utils.helpers import _config_or_exit, _fail, _fail_exception, _log, _setup_lms_api_or_exit
 
 SCRIPT_SHORTNAME = 'Archive and Cleanup'
 
@@ -65,8 +62,8 @@ def _fetch_learners_to_archive_or_exit(config, start_date, end_date, initial_sta
 
 def _batch_learners(learners=None, batch_size=None):
     """
-    To avoid potentially overwhelming the LMS with a large number of user retirements to
-    redact, create a list of smaller batches of users to iterate over. This has the
+    To avoid potentially overwheling the LMS with a large number of user retirements to
+    delete, create a list of smaller batches of users to iterate over. This has the
     added benefit of reducing the amount of user retirement archive requests that can
     get into a bad state should this script experience an error.
 
@@ -78,7 +75,7 @@ def _batch_learners(learners=None, batch_size=None):
     """
     if batch_size:
         return [
-            learners[i:i+batch_size] for i, _ in list(enumerate(learners))[::batch_size]
+            learners[i:i + batch_size] for i, _ in list(enumerate(learners))[::batch_size]
         ]
     else:
         return [learners]
@@ -199,16 +196,20 @@ def _archive_retirements_or_exit(config, learners, dry_run=False):
         FAIL_EXCEPTION(ERR_ARCHIVING, 'Unexpected error occurred archiving retirements!', exc)
 
 
-def _cleanup_retirements_or_exit(config, learners, redacted_username='redacted', redacted_email='redacted', redacted_name='redacted'):
+def _cleanup_retirements_or_exit(config, learners, redacted_username='redacted',
+                                 redacted_email='redacted', redacted_name='redacted'):
     """
-    Bulk redacts the retirements for this run
+    Bulk deletes the retirements for this run after redacting PII fields
     """
     LOG('Cleaning up retirements for {} learners'.format(len(learners)))
     try:
         usernames = [l['original_username'] for l in learners]
-        config['LMS'].bulk_cleanup_retirements(usernames, redacted_username, redacted_email, redacted_name)
+        config['LMS'].bulk_cleanup_retirements(
+            usernames, redacted_username, redacted_email, redacted_name
+        )
     except Exception as exc:  # pylint: disable=broad-except
-        FAIL_EXCEPTION(ERR_DELETING, 'Unexpected error occurred redacting retirements!', exc)
+        FAIL_EXCEPTION(ERR_DELETING, 'Unexpected error occurred redacting/deleting retirements!', exc)
+
 
 def _get_utc_now():
     """
@@ -224,7 +225,7 @@ def _get_utc_now():
 )
 @click.option(
     '--cool_off_days',
-    help='Number of days a retirement should exist before being archived and redacted.',
+    help='Number of days a retirement should exist before being archived and deleted.',
     type=int,
     default=37  # 7 days before retirement, 30 after
 )
@@ -263,39 +264,30 @@ def _get_utc_now():
 )
 @click.option(
     '--redacted_username',
-    help='Value to redact username field with',
+    help='Value to use for redacted username field',
     type=str,
     default='redacted'
 )
 @click.option(
     '--redacted_email',
-    help='Value to redact email field with',
+    help='Value to use for redacted email field',
     type=str,
     default='redacted'
 )
 @click.option(
     '--redacted_name',
-    help='Value to redact name field with',
+    help='Value to use for redacted name field',
     type=str,
     default='redacted'
 )
-def archive_and_cleanup(
-    config_file,
-    cool_off_days,
-    dry_run,
-    start_date,
-    end_date,
-    batch_size,
-    redacted_username,
-    redacted_email,
-    redacted_name,
-):
+def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_date, batch_size,
+                        redacted_username, redacted_email, redacted_name):
     """
     Cleans up UserRetirementStatus rows in LMS by:
     1- Getting all rows currently in COMPLETE that were created --cool_off_days ago or more,
         unless a specific timeframe is specified
     2- Archiving them to S3 in an Athena-queryable format
-    3- Redacting them from LMS (by username)
+    3- Deleting them from LMS (by username)
     """
     try:
         LOG('Starting bulk update script: Config: {}'.format(config_file))
@@ -344,7 +336,9 @@ def archive_and_cleanup(
                 if dry_run:
                     LOG('This is a dry-run. Exiting before any retirements are cleaned up')
                 else:
-                    _cleanup_retirements_or_exit(config, batch, redacted_username, redacted_email, redacted_name)
+                    _cleanup_retirements_or_exit(
+                        config, batch, redacted_username, redacted_email, redacted_name
+                    )
                     LOG('Archive and cleanup complete for batch #{}'.format(str(index + 1)))
                     time.sleep(DELAY)
         else:

--- a/scripts/user_retirement/retirement_archive_and_cleanup.py
+++ b/scripts/user_retirement/retirement_archive_and_cleanup.py
@@ -18,11 +18,14 @@ import click
 from botocore.exceptions import BotoCoreError, ClientError
 from six import text_type
 
-# Add top-level project path to sys.path before importing scripts code
-sys.path.append(path.abspath(path.join(path.dirname(__file__), '../..')))
+# Add top-level module path to sys.path before importing tubular code.
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 # pylint: disable=wrong-import-position
-from scripts.user_retirement.utils.helpers import _config_or_exit, _fail, _fail_exception, _log, _setup_lms_api_or_exit
+from tubular.scripts.helpers import (
+    _config_or_exit, _fail, _fail_exception, _log, _setup_lms_api_or_exit
+)
+
 
 SCRIPT_SHORTNAME = 'Archive and Cleanup'
 
@@ -62,8 +65,8 @@ def _fetch_learners_to_archive_or_exit(config, start_date, end_date, initial_sta
 
 def _batch_learners(learners=None, batch_size=None):
     """
-    To avoid potentially overwheling the LMS with a large number of user retirements to
-    delete, create a list of smaller batches of users to iterate over. This has the
+    To avoid potentially overwhelming the LMS with a large number of user retirements to
+    redact, create a list of smaller batches of users to iterate over. This has the
     added benefit of reducing the amount of user retirement archive requests that can
     get into a bad state should this script experience an error.
 
@@ -75,7 +78,7 @@ def _batch_learners(learners=None, batch_size=None):
     """
     if batch_size:
         return [
-            learners[i:i + batch_size] for i, _ in list(enumerate(learners))[::batch_size]
+            learners[i:i+batch_size] for i, _ in list(enumerate(learners))[::batch_size]
         ]
     else:
         return [learners]
@@ -196,17 +199,16 @@ def _archive_retirements_or_exit(config, learners, dry_run=False):
         FAIL_EXCEPTION(ERR_ARCHIVING, 'Unexpected error occurred archiving retirements!', exc)
 
 
-def _cleanup_retirements_or_exit(config, learners):
+def _cleanup_retirements_or_exit(config, learners, redacted_username='redacted', redacted_email='redacted', redacted_name='redacted'):
     """
-    Bulk deletes the retirements for this run
+    Bulk redacts the retirements for this run
     """
     LOG('Cleaning up retirements for {} learners'.format(len(learners)))
     try:
         usernames = [l['original_username'] for l in learners]
-        config['LMS'].bulk_cleanup_retirements(usernames)
+        config['LMS'].bulk_cleanup_retirements(usernames, redacted_username, redacted_email, redacted_name)
     except Exception as exc:  # pylint: disable=broad-except
-        FAIL_EXCEPTION(ERR_DELETING, 'Unexpected error occurred deleting retirements!', exc)
-
+        FAIL_EXCEPTION(ERR_DELETING, 'Unexpected error occurred redacting retirements!', exc)
 
 def _get_utc_now():
     """
@@ -222,7 +224,7 @@ def _get_utc_now():
 )
 @click.option(
     '--cool_off_days',
-    help='Number of days a retirement should exist before being archived and deleted.',
+    help='Number of days a retirement should exist before being archived and redacted.',
     type=int,
     default=37  # 7 days before retirement, 30 after
 )
@@ -259,13 +261,41 @@ def _get_utc_now():
     help='Number of user retirements to process',
     type=int
 )
-def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_date, batch_size):
+@click.option(
+    '--redacted_username',
+    help='Value to redact username field with',
+    type=str,
+    default='redacted'
+)
+@click.option(
+    '--redacted_email',
+    help='Value to redact email field with',
+    type=str,
+    default='redacted'
+)
+@click.option(
+    '--redacted_name',
+    help='Value to redact name field with',
+    type=str,
+    default='redacted'
+)
+def archive_and_cleanup(
+    config_file,
+    cool_off_days,
+    dry_run,
+    start_date,
+    end_date,
+    batch_size,
+    redacted_username,
+    redacted_email,
+    redacted_name,
+):
     """
     Cleans up UserRetirementStatus rows in LMS by:
     1- Getting all rows currently in COMPLETE that were created --cool_off_days ago or more,
         unless a specific timeframe is specified
     2- Archiving them to S3 in an Athena-queryable format
-    3- Deleting them from LMS (by username)
+    3- Redacting them from LMS (by username)
     """
     try:
         LOG('Starting bulk update script: Config: {}'.format(config_file))
@@ -314,7 +344,7 @@ def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_dat
                 if dry_run:
                     LOG('This is a dry-run. Exiting before any retirements are cleaned up')
                 else:
-                    _cleanup_retirements_or_exit(config, batch)
+                    _cleanup_retirements_or_exit(config, batch, redacted_username, redacted_email, redacted_name)
                     LOG('Archive and cleanup complete for batch #{}'.format(str(index + 1)))
                     time.sleep(DELAY)
         else:

--- a/scripts/user_retirement/tests/test_retirement_archive_and_cleanup.py
+++ b/scripts/user_retirement/tests/test_retirement_archive_and_cleanup.py
@@ -28,7 +28,8 @@ from scripts.user_retirement.tests.retirement_helpers import fake_config_file, g
 FAKE_BUCKET_NAME = "fake_test_bucket"
 
 
-def _call_script(cool_off_days=37, batch_size=None, dry_run=None, start_date=None, end_date=None):
+def _call_script(cool_off_days=37, batch_size=None, dry_run=None, start_date=None, end_date=None,
+                 redacted_username=None, redacted_email=None, redacted_name=None):
     """
     Call the archive script with the given params and a generic config file.
     Returns the CliRunner.invoke results
@@ -50,6 +51,12 @@ def _call_script(cool_off_days=37, batch_size=None, dry_run=None, start_date=Non
             base_args += ['--start_date', start_date]
         if end_date:
             base_args += ['--end_date', end_date]
+        if redacted_username:
+            base_args += ['--redacted_username', redacted_username]
+        if redacted_email:
+            base_args += ['--redacted_email', redacted_email]
+        if redacted_name:
+            base_args += ['--redacted_name', redacted_name]
 
         result = runner.invoke(archive_and_cleanup, args=base_args)
     print(result)
@@ -106,7 +113,7 @@ def test_successful(*args, **kwargs):
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
     mock_bulk_cleanup_retirements.assert_called_once_with(
-        ['test1', 'test2', 'test3'])
+        ['test1', 'test2', 'test3'], 'redacted', 'redacted', 'redacted')
 
     assert result.exit_code == 0
     assert 'Archive and cleanup complete' in result.output
@@ -134,12 +141,46 @@ def test_successful_with_batching(*args, **kwargs):
     # Called once to get the LMS token
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
-    get_learner_calls = [call(['test1', 'test2']), call(['test3'])]
+    get_learner_calls = [call(['test1', 'test2'], 'redacted', 'redacted', 'redacted'),
+                         call(['test3'], 'redacted', 'redacted', 'redacted')]
     mock_bulk_cleanup_retirements.assert_has_calls(get_learner_calls)
 
     assert result.exit_code == 0
     assert 'Archive and cleanup complete for batch #1' in result.output
     assert 'Archive and cleanup complete for batch #2' in result.output
+
+
+@patch('scripts.user_retirement.utils.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))
+@patch.multiple(
+    'scripts.user_retirement.utils.edx_api.LmsApi',
+    get_learners_by_date_and_status=DEFAULT,
+    bulk_cleanup_retirements=DEFAULT
+)
+@mock_aws
+def test_successful_with_custom_redaction_values(*args, **kwargs):
+    conn = boto3.resource('s3')
+    conn.create_bucket(Bucket=FAKE_BUCKET_NAME)
+
+    mock_get_access_token = args[0]
+    mock_get_learners = kwargs['get_learners_by_date_and_status']
+    mock_bulk_cleanup_retirements = kwargs['bulk_cleanup_retirements']
+
+    mock_get_learners.return_value = fake_learners_to_retire()
+
+    result = _call_script(
+        redacted_username='custom_user',
+        redacted_email='custom@example.com',
+        redacted_name='Custom Name'
+    )
+
+    # Called once to get the LMS token
+    assert mock_get_access_token.call_count == 1
+    mock_get_learners.assert_called_once()
+    mock_bulk_cleanup_retirements.assert_called_once_with(
+        ['test1', 'test2', 'test3'], 'custom_user', 'custom@example.com', 'Custom Name')
+
+    assert result.exit_code == 0
+    assert 'Archive and cleanup complete' in result.output
 
 
 @patch('scripts.user_retirement.utils.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))
@@ -216,7 +257,7 @@ def test_bad_fetch(*_):
 def test_bad_lms_deletion(*_):
     result = _call_script()
     assert result.exit_code == ERR_DELETING
-    assert 'Unexpected error occurred deleting retirements!' in result.output
+    assert 'Unexpected error occurred redacting/deleting retirements!' in result.output
 
 
 @patch('scripts.user_retirement.utils.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))

--- a/scripts/user_retirement/utils/edx_api.py
+++ b/scripts/user_retirement/utils/edx_api.py
@@ -352,11 +352,19 @@ class LmsApi(BaseApiClient):
         return self._request("POST", api_url)
 
     @_retry_lms_api()
-    def bulk_cleanup_retirements(self, usernames):
+    def bulk_cleanup_retirements(self, usernames, redacted_username=None,
+                                 redacted_email=None, redacted_name=None):
         """
-        Deletes the retirements for all given usernames
+        Redacts the retirements for all given usernames.
+        Optionally pass caller-defined redacted values for each PII field.
         """
-        data = {"usernames": usernames}
+        data = {'usernames': usernames}
+        if redacted_username is not None:
+            data['redacted_username'] = redacted_username
+        if redacted_email is not None:
+            data['redacted_email'] = redacted_email
+        if redacted_name is not None:
+            data['redacted_name'] = redacted_name
         api_url = self.get_api_url("api/user/v1/accounts/retirement_cleanup")
         return self._request("POST", api_url, json=data)
 

--- a/scripts/user_retirement/utils/edx_api.py
+++ b/scripts/user_retirement/utils/edx_api.py
@@ -355,8 +355,8 @@ class LmsApi(BaseApiClient):
     def bulk_cleanup_retirements(self, usernames, redacted_username=None,
                                  redacted_email=None, redacted_name=None):
         """
-        Redacts the retirements for all given usernames.
-        Optionally pass caller-defined redacted values for each PII field.
+        Redacts and then deletes the retirements for all given usernames.
+        Optionally pass caller-defined redacted values for each PII field before deletion.
         """
         data = {'usernames': usernames}
         if redacted_username is not None:


### PR DESCRIPTION
# Description
This PR adds a new option to the retirement cleanup script that lets you pass a custom placeholder value to replace user information. It then sends this value through to the LMS system so both systems can work together to redact user data.

# Private Link Ticket
https://2u-internal.atlassian.net/browse/BOMS-293