### PR TITLE
 feat: Support IdP-initiated SAML auth with redirect destination in RelayState

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -18,7 +18,7 @@ from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAML
 from social_core.exceptions import AuthForbidden, AuthMissingParameter
 
 from openedx.core.djangoapps.theming.helpers import get_current_request
-from common.djangoapps.student.helpers import is_safe_login_or_logout_redirect
+from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
 from common.djangoapps.third_party_auth.exceptions import IncorrectConfigurationException
 
 STANDARD_SAML_PROVIDER_KEY = 'standard_saml_provider'
@@ -148,6 +148,9 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
             require_https=request.is_secure(),
         ):
             request.session['next'] = next_decoded
+        else:
+            # RelayState included an unsafe destination; clear any stale 'next' value
+            request.session.pop('next', None)
 
         # Always rewrite RelayState to just the IdP slug so the SAML backend can locate the provider.
         post_copy = request.POST.copy()
@@ -291,24 +294,14 @@ class EdXSAMLIdentityProvider(SAMLIdentityProvider):
         unless self.conf[conf_key] overrides the default by specifying
         another attribute to use.
         """
-        # social-core versions differ in how they pass default attributes:
-        # - Older: a single attribute name string
-        # - Newer: a tuple of candidate attribute names
-        configured = self.conf.get(conf_key)
-
-        if configured is None:
-            candidates = default_attribute if isinstance(default_attribute, (tuple, list)) else (default_attribute,)
-            key = next((candidate for candidate in candidates if candidate in attributes), None)
-        else:
-            key = configured
-
+        key = self.conf.get(conf_key, default_attribute)
         if key in attributes:
-            value = attributes.get(key)
-            if isinstance(value, list):
-                return value[0] if value else None
-            return value
-
-        return self.conf.get('attr_defaults', {}).get(conf_key) or None
+            try:
+                return attributes[key][0]
+            except IndexError:
+                log.warning('[THIRD_PARTY_AUTH] SAML attribute value not found. '
+                            'SamlAttribute: {attribute}'.format(attribute=key))
+        return self.conf['attr_defaults'].get(conf_key) or None
 
     @property
     def saml_sp_configuration(self):

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -4,6 +4,7 @@ Slightly customized python-social-auth backend for SAML 2.0 support
 
 
 import logging
+from urllib.parse import unquote
 from copy import deepcopy
 
 import requests
@@ -17,6 +18,7 @@ from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAML
 from social_core.exceptions import AuthForbidden, AuthMissingParameter
 
 from openedx.core.djangoapps.theming.helpers import get_current_request
+from common.djangoapps.student.helpers import is_safe_login_or_logout_redirect
 from common.djangoapps.third_party_auth.exceptions import IncorrectConfigurationException
 
 STANDARD_SAML_PROVIDER_KEY = 'standard_saml_provider'
@@ -89,12 +91,68 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
         """
         Handle exceptions that happen during SAML authentication
         """
+        # For IdP-initiated flows (where the user doesn't first hit /auth/login/...),
+        # allow callers to provide a post-auth redirect by packing it into RelayState.
+        # Store it in the session so the rest of the pipeline behaves consistently.
+        try:
+            request = get_current_request()
+            # Allow RelayState to carry both IdP slug and a post-auth destination.
+            # Format: "<idp_slug>|<next>", where <next> is typically a relative LMS path.
+            self._maybe_set_next_url_from_relay_state(request)
+        except Exception:  # pylint: disable=broad-exception-caught  # pragma: no cover
+            # Never fail auth due to redirect bookkeeping.
+            pass
+
         try:
             return super().auth_complete(*args, **kwargs)
         # We are seeing errors of MultiValueDictKeyError looking for the parameter 'RelayState'.
         # We would like to have a more specific error to handle for observability purposes.
         except MultiValueDictKeyError as e:
-            raise AuthMissingParameter(self.name, e.args[0]) from e
+            raise AuthMissingParameter(self.name, e.args[0] if e.args else '') from e
+
+    @staticmethod
+    def _maybe_set_next_url_from_relay_state(request):
+        """Optionally extract a safe `next` from RelayState and rewrite RelayState to the IdP slug.
+
+        This is specifically to support IdP-initiated flows where Auth0 (and some IdPs) can only
+        reliably influence the SAML POST via RelayState.
+        """
+        if request is None or not hasattr(request, 'POST'):
+            return
+        if not hasattr(request, 'session'):
+            return
+
+        relay_state = None
+        try:
+            relay_state = request.POST.get('RelayState')
+        except Exception:  # pylint: disable=broad-exception-caught  # pragma: no cover
+            relay_state = None
+
+        if not relay_state or '|' not in str(relay_state):
+            return
+
+        slug_part, next_part = str(relay_state).split('|', 1)
+        slug_part = slug_part.strip()
+        next_part = next_part.strip()
+        if not slug_part or not next_part:
+            return
+
+        # URL-decode next (Auth0 or callers may URL-encode it).
+        next_decoded = unquote(next_part)
+
+        # Only store next if it's safe per existing Open edX redirect policy.
+        if is_safe_login_or_logout_redirect(
+            redirect_to=next_decoded,
+            request_host=request.get_host(),
+            dot_client_id=(request.GET.get('client_id') if hasattr(request, 'GET') else None),
+            require_https=request.is_secure(),
+        ):
+            request.session['next'] = next_decoded
+
+        # Always rewrite RelayState to just the IdP slug so the SAML backend can locate the provider.
+        post_copy = request.POST.copy()
+        post_copy['RelayState'] = slug_part
+        request._post = post_copy  # pylint: disable=protected-access
 
     def get_user_id(self, details, response):
         """
@@ -233,14 +291,24 @@ class EdXSAMLIdentityProvider(SAMLIdentityProvider):
         unless self.conf[conf_key] overrides the default by specifying
         another attribute to use.
         """
-        key = self.conf.get(conf_key, default_attribute)
+        # social-core versions differ in how they pass default attributes:
+        # - Older: a single attribute name string
+        # - Newer: a tuple of candidate attribute names
+        configured = self.conf.get(conf_key)
+
+        if configured is None:
+            candidates = default_attribute if isinstance(default_attribute, (tuple, list)) else (default_attribute,)
+            key = next((candidate for candidate in candidates if candidate in attributes), None)
+        else:
+            key = configured
+
         if key in attributes:
-            try:
-                return attributes[key][0]
-            except IndexError:
-                log.warning('[THIRD_PARTY_AUTH] SAML attribute value not found. '
-                            'SamlAttribute: {attribute}'.format(attribute=key))
-        return self.conf['attr_defaults'].get(conf_key) or None
+            value = attributes.get(key)
+            if isinstance(value, list):
+                return value[0] if value else None
+            return value
+
+        return self.conf.get('attr_defaults', {}).get(conf_key) or None
 
     @property
     def saml_sp_configuration(self):

--- a/common/djangoapps/third_party_auth/tests/test_saml.py
+++ b/common/djangoapps/third_party_auth/tests/test_saml.py
@@ -35,13 +35,7 @@ class TestEdXSAMLIdentityProvider(SAMLTestCase):
 
     def test_get_user_details(self):
         """ test get_attr and get_user_details of EdXSAMLIdentityProvider"""
-        # social-core changed SAMLIdentityProvider.__init__ signature; newer versions require
-        # (backend, name, **kwargs). Use the new signature.
-        edx_saml_identity_provider = EdXSAMLIdentityProvider(
-            mock.Mock(),  # pylint: disable=too-many-function-args
-            'demo',
-            **mock_conf
-        )
+        edx_saml_identity_provider = EdXSAMLIdentityProvider('demo', **mock_conf)
         assert edx_saml_identity_provider.get_user_details(mock_attributes) == expected_user_details
 
 

--- a/common/djangoapps/third_party_auth/tests/test_saml.py
+++ b/common/djangoapps/third_party_auth/tests/test_saml.py
@@ -5,7 +5,9 @@ Unit tests for third_party_auth SAML auth providers
 
 from unittest import mock
 
+from django.test import RequestFactory
 from django.utils.datastructures import MultiValueDictKeyError
+from django.contrib.sessions.middleware import SessionMiddleware
 from social_core.exceptions import AuthMissingParameter
 
 from common.djangoapps.third_party_auth.saml import EdXSAMLIdentityProvider, get_saml_idp_class, SAMLAuthBackend
@@ -33,12 +35,26 @@ class TestEdXSAMLIdentityProvider(SAMLTestCase):
 
     def test_get_user_details(self):
         """ test get_attr and get_user_details of EdXSAMLIdentityProvider"""
-        edx_saml_identity_provider = EdXSAMLIdentityProvider('demo', **mock_conf)
+        # social-core changed SAMLIdentityProvider.__init__ signature; newer versions require
+        # (backend, name, **kwargs). Use the new signature.
+        edx_saml_identity_provider = EdXSAMLIdentityProvider(
+            mock.Mock(),  # pylint: disable=too-many-function-args
+            'demo',
+            **mock_conf
+        )
         assert edx_saml_identity_provider.get_user_details(mock_attributes) == expected_user_details
 
 
 class TestSAMLAuthBackend(SAMLTestCase):
     """ Tests for the SAML backend. """
+
+    @staticmethod
+    def _add_session(request):
+        """Attach a Django session to a RequestFactory request."""
+        middleware = SessionMiddleware(lambda req: None)
+        middleware.process_request(request)
+        request.session.save()
+        return request
 
     @mock.patch('common.djangoapps.third_party_auth.saml.SAMLAuth.auth_complete')
     def test_saml_auth_complete(self, super_auth_complete):
@@ -48,3 +64,49 @@ class TestSAMLAuthBackend(SAMLTestCase):
             backend.auth_complete()
 
         assert cm.exception.parameter == 'RelayState'
+
+    @mock.patch('common.djangoapps.third_party_auth.saml.get_current_request')
+    @mock.patch('common.djangoapps.third_party_auth.saml.SAMLAuth.auth_complete')
+    def test_relaystate_splits_and_sets_next_when_safe(self, super_auth_complete, get_current_request_mock):
+        """RelayState may include both the IdP slug and a safe `next` destination."""
+        rf = RequestFactory()
+        request = rf.post(
+            '/auth/complete/tpa-saml/',
+            data={
+                'SAMLResponse': 'ignored',
+                'RelayState': 'example-idp|/courses/course-v1:edX+DemoX+Demo_Course/course/',
+            },
+            HTTP_HOST=self.hostname,
+        )
+        self._add_session(request)
+        get_current_request_mock.return_value = request
+
+        super_auth_complete.return_value = 'ok'
+        backend = SAMLAuthBackend()
+        assert backend.auth_complete() == 'ok'
+
+        assert request.POST.get('RelayState') == 'example-idp'
+        assert request.session.get('next') == '/courses/course-v1:edX+DemoX+Demo_Course/course/'
+
+    @mock.patch('common.djangoapps.third_party_auth.saml.get_current_request')
+    @mock.patch('common.djangoapps.third_party_auth.saml.SAMLAuth.auth_complete')
+    def test_relaystate_drops_unsafe_next(self, super_auth_complete, get_current_request_mock):
+        """If RelayState contains an unsafe `next`, it is ignored but the slug is preserved."""
+        rf = RequestFactory()
+        request = rf.post(
+            '/auth/complete/tpa-saml/',
+            data={
+                'SAMLResponse': 'ignored',
+                'RelayState': 'example-idp|https%3A%2F%2Fevil.example.com%2Fpwn',
+            },
+            HTTP_HOST=self.hostname,
+        )
+        self._add_session(request)
+        get_current_request_mock.return_value = request
+
+        super_auth_complete.return_value = 'ok'
+        backend = SAMLAuthBackend()
+        assert backend.auth_complete() == 'ok'
+
+        assert request.POST.get('RelayState') == 'example-idp'
+        assert request.session.get('next') is None


### PR DESCRIPTION
## Summary
- Add support for IdP-initiated SAML authentication flows by allowing RelayState to carry both the IdP slug and a post-auth redirect URL
- RelayState format: <idp_slug>|<next_url> (e.g., skillsoft-percipio|/courses/course-v1:Org+Course+Run/course/)
- Validate redirect URLs against Open edX's existing 
- Update EdXSAMLIdentityProvider.get_attr() for compatibility with newer social-core versions                                                                                                                                         

## Context
This change enables Skillsoft Percipio integration using SAML IdP-initiated authentication. In IdP-initiated flows, users start authentication from the identity provider (Percipio) rather than the LMS, so there's no opportunity to set a next URL via the normal SP-initiated flow.     

By packing the destination URL into the RelayState parameter (separated by |), IdPs can now specify where users should land after successful authentication. The next URL is URL-decoded, validated for safety, and stored in the session where the existing authentication pipeline expects it.

## Test plan
- Verify RelayState with slug|next format correctly splits and stores next in session
- Verify unsafe redirect URLs (external domains) are rejected
- Verify plain RelayState (slug only, no pipe) continues to 
- Existing SAML tests pass  