### PR TITLE
bump integrated channels

### DIFF
--- a/openedx/core/djangoapps/cors_csrf/helpers.py
+++ b/openedx/core/djangoapps/cors_csrf/helpers.py
@@ -44,7 +44,7 @@ def is_cross_domain_request_allowed(request):
             return False
 
         if not referer_parts.scheme == 'https':
-            log.debug("Referer '%s' must have the scheme 'https'")
+            log.debug("Referer '%s' must have the scheme 'https'", str(referer))
             return False
 
     # Reduce the referer URL to just the scheme and authority

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -136,3 +136,9 @@ django-debug-toolbar<6.0.0
 # Issue: https://github.com/openedx/edx-platform/issues/37435
 cryptography<46.0.0
 pact-python<3.0.0
+
+# Date 2026-02-05
+# sphinx-autoapi==3.6.1 is incompatible with astroid==4.x under python 3.11. Since we (2U) currently
+# deploy edxapp to edx.org using python 3.11, we must pin sphinx-autoapi to avoid dependency
+# conflicts. Remove this constraint once we migrate to python 3.12.
+sphinx-autoapi<3.6.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -564,7 +564,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-enterprise-integrated-channels==0.1.36
+enterprise-integrated-channels==0.1.38
     # via -r requirements/edx/bundled.in
 event-tracking==3.3.0
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -113,7 +113,6 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-    #   snowflake-connector-python
 chardet==5.2.0
     # via pysrt
 charset-normalizer==3.4.3
@@ -1115,7 +1114,7 @@ slumber==0.7.1
     #   enterprise-integrated-channels
 sniffio==1.3.1
     # via anyio
-snowflake-connector-python==3.18.0
+snowflake-connector-python==4.2.0
     # via
     #   edx-enterprise
     #   enterprise-integrated-channels

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -876,7 +876,7 @@ enmerkar-underscore==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-enterprise-integrated-channels==0.1.36
+enterprise-integrated-channels==0.1.38
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -74,7 +74,7 @@ asn1crypto==1.5.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-astroid==3.3.11
+astroid==4.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -204,7 +204,6 @@ cffi==1.17.1
     #   cryptography
     #   pact-python
     #   pynacl
-    #   snowflake-connector-python
 chardet==5.2.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1594,7 +1593,7 @@ pylatexenc==2.10
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==3.3.9
+pylint==4.0.4
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1606,7 +1605,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1936,7 +1935,7 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==3.18.0
+snowflake-connector-python==4.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1981,8 +1980,10 @@ sphinx==8.2.3
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
     #   sphinxext-rediraffe
-sphinx-autoapi==3.6.1
-    # via -r requirements/edx/doc.txt
+sphinx-autoapi==3.6.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/edx/doc.txt
 sphinx-book-theme==1.1.4
     # via -r requirements/edx/doc.txt
 sphinx-design==0.6.1

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -654,7 +654,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.36
+enterprise-integrated-channels==0.1.38
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -55,7 +55,7 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==3.3.11
+astroid==4.0.3
     # via sphinx-autoapi
 attrs==25.4.0
     # via
@@ -155,7 +155,6 @@ cffi==1.17.1
     #   -r requirements/edx/base.txt
     #   cryptography
     #   pynacl
-    #   snowflake-connector-python
 chardet==5.2.0
     # via
     #   -r requirements/edx/base.txt
@@ -1366,7 +1365,7 @@ sniffio==1.3.1
     #   anyio
 snowballstemmer==3.0.1
     # via sphinx
-snowflake-connector-python==3.18.0
+snowflake-connector-python==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1405,8 +1404,10 @@ sphinx==8.2.3
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
     #   sphinxext-rediraffe
-sphinx-autoapi==3.6.1
-    # via -r requirements/edx/doc.in
+sphinx-autoapi==3.6.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/edx/doc.in
 sphinx-book-theme==1.1.4
     # via -r requirements/edx/doc.in
 sphinx-design==0.6.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -52,7 +52,7 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==3.3.11
+astroid==4.0.3
     # via
     #   pylint
     #   pylint-celery
@@ -154,7 +154,6 @@ cffi==1.17.1
     #   cryptography
     #   pact-python
     #   pynacl
-    #   snowflake-connector-python
 chardet==5.2.0
     # via
     #   -r requirements/edx/base.txt
@@ -1211,7 +1210,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==3.3.9
+pylint==4.0.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -1220,7 +1219,7 @@ pylint==3.3.9
     #   pylint-pytest
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
 pylint-plugin-utils==0.9.0
     # via
@@ -1474,7 +1473,7 @@ sniffio==1.3.1
     # via
     #   -r requirements/edx/base.txt
     #   anyio
-snowflake-connector-python==3.18.0
+snowflake-connector-python==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -677,7 +677,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.36
+enterprise-integrated-channels==0.1.38
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via


### PR DESCRIPTION
One commit cherry-picked from upstream openedx-platform, and an additional commit to fix outdated requirements.

```
commit f0931b16968bdc8c919a86accb5ecbc56837b942
Author: Troy Sankey <tsankey@2u.com>
Date:   Thu Feb 5 13:51:52 2026 -0800

    chore: fast-forward several requirements to match upstream openedx/openedx-platform
    
    Bumped:
    
    * astroid
    * pylint
    * pylint-django
    * snowflake-connector-python
    
    DOWNGRADED:
    
    * sphinx-autoapi
    
    These changes were needed to fix installing requirements after the last
    commit to bump enterprise-integrated-channels.

commit 606d431d2bf2d16ac5477bc321b2157edeb9b1d9
Author: Troy Sankey <tsankey@2u.com>
Date:   Wed Feb 4 12:18:40 2026 -0800

    chore: upgrade enterprise-integrated-channels to 0.1.38
    
    Also bump SQL queries by +2 for the test_read_and_update() unit test
    which triggers new synchronous signal handlers on grade change. See
    https://github.com/openedx/enterprise-integrated-channels/pull/109
    
    ENT-11229
```