### PR TITLE
fix: prevent bulk email history failures when email_id is missing

### DIFF
--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -93,9 +93,7 @@ def get_instructor_task_history(course_id, usage_key=None, student=None, task_ty
     # Bulk email history is user-facing; only show tasks that represent
     # real delivered emails (SUCCESS with succeeded > 0) or future scheduled sends.
     if task_type == InstructorTaskTypes.BULK_COURSE_EMAIL:
-        instructor_tasks = InstructorTask.objects.filter(
-            course_id=course_id
-        ).filter(
+        instructor_tasks = instructor_tasks.filter(
             # SUCCESS tasks must have delivery results, while SCHEDULED tasks
             # have no task_output yet and must be included explicitly.
             Q(


### PR DESCRIPTION
**Summary**

Fixes an issue where the Bulk Email → Sent Email History page could fail to load due to legacy instructor tasks missing email_id.

**Root Cause:**

Some historical instructor task records do not include email_id. When these records were included in the bulk email history query, the API failed while extracting email details.

**Fix:**

Restricts the history query to bulk_course_email tasks only, ensuring that only records with valid email metadata are processed.

**Impact**

- Prevents intermittent sent email history load failures

- Restores visibility for valid sent and scheduled emails

- Maintains existing filtering behavior for bulk email history

@asharma4-sonata Please review my PR and let me know if any changes need to be done.