### PR TITLE
feat: enable MFE editor for InVideoQuiz XBlock

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -512,7 +512,7 @@ function($, _, Backbone, gettext, BasePage,
                 if((useNewTextEditor === 'True' && blockType === 'html')
                         || (useNewVideoEditor === 'True' && blockType === 'video')
                         || (useNewProblemEditor === 'True' && blockType === 'problem')
-                        || (blockType === 'games')
+                        || (blockType === 'games') || (blockType === 'invideoquiz')
                 ) {
                     var destinationUrl = primaryHeader.attr('authoring_MFE_base_url')
                         + '/' + blockType


### PR DESCRIPTION

## Description

Enable invideoquiz blocks to use the new authoring MFE editor, bringing them in line with other block types (html, video, problem, and games) that have already been migrated to the modernized editing experience.


Changes

  - Modified the block type routing logic in `cms/static/js/views/pages/container.js:515 ` to include invideoquiz blocks in the conditional that directs users to the authoring MFE base URL

## Supporting information

Jira ticket:

[TNL2-524](https://2u-internal.atlassian.net/browse/TNL2-524)


## Testing instructions

  - Create a new unit with an invideoquiz block
  - Verify that clicking to edit an invideoquiz block opens the authoring MFE editor instead of the legacy editor
  - Confirm that editing functionality works correctly in the new editor
  - Verify that existing invideoquiz blocks continue to work as expected

## Deadline

 - None

## Other information

 - None
