### PR TITLE
feature: Allow 3rd party providers to send a post registration redire…

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -62,6 +62,7 @@ import base64
 import hashlib
 import hmac
 import json
+import urllib.parse
 from collections import OrderedDict
 from logging import getLogger
 from smtplib import SMTPException
@@ -101,6 +102,7 @@ from common.djangoapps.third_party_auth.utils import (
     is_saml_provider,
     user_exists,
 )
+from common.djangoapps.third_party_auth.toggles import is_tpa_next_url_on_dispatch_enabled
 from common.djangoapps.track import segment
 from common.djangoapps.util.json_request import JsonResponse
 
@@ -576,13 +578,23 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
     # It is important that we always execute the entire pipeline. Even if
     # behavior appears correct without executing a step, it means important
     # invariants have been violated and future misbehavior is likely.
+    def _build_redirect_url(base_url):
+        """Append ?next=… to the redirect URL if the session carries a destination."""
+        if not is_tpa_next_url_on_dispatch_enabled():
+            return base_url
+        next_url = strategy.session_get('next')
+        if next_url and isinstance(next_url, str):
+            separator = '&' if '?' in base_url else '?'
+            base_url = f'{base_url}{separator}next={urllib.parse.quote(next_url)}'
+        return base_url
+
     def dispatch_to_login():
         """Redirects to the login page."""
-        return redirect(AUTH_DISPATCH_URLS[AUTH_ENTRY_LOGIN])
+        return redirect(_build_redirect_url(AUTH_DISPATCH_URLS[AUTH_ENTRY_LOGIN]))
 
     def dispatch_to_register():
         """Redirects to the registration page."""
-        return redirect(AUTH_DISPATCH_URLS[AUTH_ENTRY_REGISTER])
+        return redirect(_build_redirect_url(AUTH_DISPATCH_URLS[AUTH_ENTRY_REGISTER]))
 
     def should_force_account_creation():
         """ For some third party providers, we auto-create user accounts """

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -379,6 +379,92 @@ class EnsureUserInformationTestCase(TestCase):
                     assert response.url == expected_redirect_url
 
 
+@ddt.ddt
+class EnsureUserInformationNextUrlTestCase(test.TestCase):
+    """Tests that ensure_user_information forwards session['next'] as a query parameter."""
+
+    def _call_ensure_user_information(self, session_next, auth_entry=pipeline.AUTH_ENTRY_LOGIN,
+                                      send_to_registration_first=True):
+        """Helper to call ensure_user_information with a controlled session_get('next') value."""
+        mock_provider = mock.MagicMock(
+            send_to_registration_first=send_to_registration_first,
+            skip_email_verification=False,
+        )
+        with mock.patch(
+            'common.djangoapps.third_party_auth.pipeline.provider.Registry.get_from_pipeline'
+        ) as get_from_pipeline:
+            get_from_pipeline.return_value = mock_provider
+            with mock.patch('social_core.pipeline.partial.partial_prepare') as partial_prepare:
+                partial_prepare.return_value = mock.MagicMock(token='')
+                strategy = mock.MagicMock()
+                strategy.session_get.side_effect = lambda key, *args: (
+                    session_next if key == 'next' else mock.DEFAULT
+                )
+                response = pipeline.ensure_user_information(
+                    strategy=strategy,
+                    backend=None,
+                    auth_entry=auth_entry,
+                    pipeline_index=0,
+                )
+                return response
+
+    @mock.patch(
+        'common.djangoapps.third_party_auth.pipeline.is_tpa_next_url_on_dispatch_enabled',
+        return_value=True,
+    )
+    @ddt.data(
+        # (session_next, send_to_registration_first, expected_url)
+        ('/courses/my-course', True, '/register?next=/courses/my-course'),
+        ('/courses/my-course', False, '/login?next=/courses/my-course'),
+        ('/dashboard', True, '/register?next=/dashboard'),
+    )
+    @ddt.unpack
+    def test_next_url_forwarded_to_redirect(self, session_next, send_to_registration_first, expected_url, _flag_mock):
+        """When session contains a 'next' URL, it should be appended as a query parameter."""
+        response = self._call_ensure_user_information(
+            session_next=session_next,
+            send_to_registration_first=send_to_registration_first,
+        )
+        assert response.status_code == 302
+        assert response.url == expected_url
+
+    @mock.patch(
+        'common.djangoapps.third_party_auth.pipeline.is_tpa_next_url_on_dispatch_enabled',
+        return_value=True,
+    )
+    @ddt.data(None, '')
+    def test_no_next_url_gives_bare_redirect(self, session_next, _flag_mock):
+        """When session has no 'next' URL, the redirect should be bare /register."""
+        response = self._call_ensure_user_information(session_next=session_next)
+        assert response.status_code == 302
+        assert response.url == '/register'
+
+    @mock.patch(
+        'common.djangoapps.third_party_auth.pipeline.is_tpa_next_url_on_dispatch_enabled',
+        return_value=True,
+    )
+    def test_next_url_with_special_characters_is_encoded(self, _flag_mock):
+        """Special characters in the next URL should be percent-encoded."""
+        response = self._call_ensure_user_information(
+            session_next='/courses/my course?foo=bar&baz=1',
+        )
+        assert response.status_code == 302
+        assert response.url.startswith('/register?next=')
+        # The space and & should be encoded
+        assert '%20' in response.url or '+' in response.url
+        assert 'foo%3Dbar' in response.url or 'foo=bar' in response.url
+
+    @mock.patch(
+        'common.djangoapps.third_party_auth.pipeline.is_tpa_next_url_on_dispatch_enabled',
+        return_value=False,
+    )
+    def test_flag_disabled_gives_bare_redirect(self, _flag_mock):
+        """When the waffle flag is disabled, the redirect should be bare even with session['next']."""
+        response = self._call_ensure_user_information(session_next='/courses/my-course')
+        assert response.status_code == 302
+        assert response.url == '/register'
+
+
 class UserDetailsForceSyncTestCase(TestCase):
     """Tests to ensure learner profile data is properly synced if the provider requires it."""
 

--- a/common/djangoapps/third_party_auth/toggles.py
+++ b/common/djangoapps/third_party_auth/toggles.py
@@ -43,3 +43,25 @@ def is_apple_user_migration_enabled():
     Returns a boolean if Apple users migration is in process.
     """
     return APPLE_USER_MIGRATION_FLAG.is_enabled()
+
+
+# .. toggle_name: third_party_auth.tpa_next_url_on_dispatch
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, the third-party auth pipeline will forward
+#    session['next'] as a ?next= query parameter when redirecting to the login or
+#    registration page. This ensures the post-auth destination is preserved for new
+#    users who must complete registration before being redirected.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-02-13
+# .. toggle_target_removal_date: 2026-06-01
+# .. toggle_warning: None.
+TPA_NEXT_URL_ON_DISPATCH_FLAG = WaffleFlag(f'{THIRD_PARTY_AUTH_NAMESPACE}.tpa_next_url_on_dispatch', __name__)
+
+
+def is_tpa_next_url_on_dispatch_enabled():
+    """
+    Returns True if the pipeline should forward session['next'] as a query parameter
+    when dispatching to login/register pages.
+    """
+    return TPA_NEXT_URL_ON_DISPATCH_FLAG.is_enabled()


### PR DESCRIPTION
## Description

This pull request adds functionality to allow 3rd party authentication providers to send a post-registration redirect path via the RelayState parameter during SAML authentication flows. The implementation ensures that when a 'next' URL is stored in the session (after validation), it gets properly appended as a query parameter when redirecting users to the login or registration pages.

FEATURE FLAG: **thirdpartyauth.tpa_next_url_on_dispatch**