### PR TITLE
feat: Remove UPLOAD_VIA_BOTO3 rollout toggle

### DIFF
--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -13,10 +13,11 @@ import requests
 import shutil
 import pathlib
 import zipfile
-
 from contextlib import closing
 from datetime import datetime, timedelta
 from uuid import uuid4
+
+import boto3
 from boto.s3.connection import S3Connection
 from boto import s3
 from django.conf import settings
@@ -80,6 +81,17 @@ VIDEO_IMAGE_UPLOAD_ENABLED = WaffleSwitch(  # lint-amnesty, pylint: disable=togg
 
 # Waffle flag namespace for studio
 WAFFLE_STUDIO_FLAG_NAMESPACE = 'studio'
+
+# .. toggle_name: videos.upload_via_boto3
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Use boto3 for upload rather than boto. Intended for
+#   use during rollout, after which toggle will be removed and only boto3
+#   will be supported.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-02-17
+# .. toggle_target_removal_date: 2026-03-01
+UPLOAD_VIA_BOTO3 = WaffleSwitch(f'{WAFFLE_NAMESPACE}.upload_via_boto3', __name__)
 
 ENABLE_VIDEO_UPLOAD_PAGINATION = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     f'{WAFFLE_STUDIO_FLAG_NAMESPACE}.enable_video_upload_pagination', __name__
@@ -812,7 +824,11 @@ def videos_post(course, request):
     if error:
         return {'error': error}, 400
 
-    bucket = storage_service_bucket()
+    if UPLOAD_VIA_BOTO3.is_enabled():
+        s3_client = boto3.client('s3')
+    else:
+        bucket = storage_service_bucket()
+
     req_files = data['files']
     resp_files = []
 
@@ -826,7 +842,8 @@ def videos_post(course, request):
             return {'error': error_msg}, 400
 
         edx_video_id = str(uuid4())
-        key = storage_service_key(bucket, file_name=edx_video_id)
+        if not UPLOAD_VIA_BOTO3.is_enabled():
+            key = storage_service_key(bucket, file_name=edx_video_id)
 
         metadata_list = [
             ('client_video_id', file_name),
@@ -846,13 +863,25 @@ def videos_post(course, request):
             if transcript_preferences is not None:
                 metadata_list.append(('transcript_preferences', json.dumps(transcript_preferences)))
 
-        for metadata_name, value in metadata_list:
-            key.set_metadata(metadata_name, value)
-        upload_url = key.generate_url(
-            KEY_EXPIRATION_IN_SECONDS,
-            'PUT',
-            headers={'Content-Type': req_file['content_type']}
-        )
+        if UPLOAD_VIA_BOTO3.is_enabled():
+            upload_url = s3_client.generate_presigned_url(
+                ClientMethod='put_object',
+                Params={
+                    'Bucket': storage_service_bucket_name(),
+                    'Key': storage_service_key_name(edx_video_id),
+                    'ContentType': req_file['content_type'],
+                    'Metadata': dict(metadata_list),
+                },
+                ExpiresIn=KEY_EXPIRATION_IN_SECONDS,
+            )
+        else:
+            for metadata_name, value in metadata_list:
+                key.set_metadata(metadata_name, value)
+            upload_url = key.generate_url(
+                KEY_EXPIRATION_IN_SECONDS,
+                'PUT',
+                headers={'Content-Type': req_file['content_type']}
+            )
 
         # persist edx_video_id in VAL
         create_video({
@@ -869,9 +898,18 @@ def videos_post(course, request):
     return {'files': resp_files}, 200
 
 
+def storage_service_bucket_name():
+    """
+    Returns name of S3 bucket to use for video upload.
+    """
+    return settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET']
+
+
 def storage_service_bucket():
     """
     Returns an S3 bucket for video upload.
+
+    This is on the deprecated boto v1 pathway. See `UPLOAD_VIA_BOTO3`.
     """
     if ENABLE_DEVSTACK_VIDEO_UPLOADS.is_enabled():
         params = {
@@ -892,17 +930,26 @@ def storage_service_bucket():
     # set since behind the scenes it fires a HEAD request that is equivalent to get_all_keys()
     # meaning it would need ListObjects on the whole bucket, not just the path used in each
     # environment (since we share a single bucket for multiple deployments in some configurations)
-    return conn.get_bucket(settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET'], validate=False)
+    return conn.get_bucket(storage_service_bucket_name(), validate=False)
+
+
+def storage_service_key_name(file_name):
+    """
+    Returns the S3 object key to be used for a given video filename.
+    """
+    return "{}/{}".format(
+        settings.VIDEO_UPLOAD_PIPELINE.get("ROOT_PATH", ""),
+        file_name
+    )
 
 
 def storage_service_key(bucket, file_name):
     """
     Returns an S3 key to the given file in the given bucket.
+
+    This is used in the deprecated boto v1 pathway. See `UPLOAD_VIA_BOTO3`.
     """
-    key_name = "{}/{}".format(
-        settings.VIDEO_UPLOAD_PIPELINE.get("ROOT_PATH", ""),
-        file_name
-    )
+    key_name = storage_service_key_name(file_name)
     return s3.key.Key(bucket, key_name)
 
 

--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -18,8 +18,6 @@ from datetime import datetime, timedelta
 from uuid import uuid4
 
 import boto3
-from boto.s3.connection import S3Connection
-from boto import s3
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import FileResponse, HttpResponseNotFound, StreamingHttpResponse
@@ -56,10 +54,7 @@ from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE
-from openedx.core.djangoapps.video_pipeline.config.waffle import (
-    DEPRECATE_YOUTUBE,
-    ENABLE_DEVSTACK_VIDEO_UPLOADS,
-)
+from openedx.core.djangoapps.video_pipeline.config.waffle import DEPRECATE_YOUTUBE
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -81,17 +76,6 @@ VIDEO_IMAGE_UPLOAD_ENABLED = WaffleSwitch(  # lint-amnesty, pylint: disable=togg
 
 # Waffle flag namespace for studio
 WAFFLE_STUDIO_FLAG_NAMESPACE = 'studio'
-
-# .. toggle_name: videos.upload_via_boto3
-# .. toggle_implementation: WaffleSwitch
-# .. toggle_default: False
-# .. toggle_description: Use boto3 for upload rather than boto. Intended for
-#   use during rollout, after which toggle will be removed and only boto3
-#   will be supported.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2026-02-17
-# .. toggle_target_removal_date: 2026-03-01
-UPLOAD_VIA_BOTO3 = WaffleSwitch(f'{WAFFLE_NAMESPACE}.upload_via_boto3', __name__)
 
 ENABLE_VIDEO_UPLOAD_PAGINATION = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     f'{WAFFLE_STUDIO_FLAG_NAMESPACE}.enable_video_upload_pagination', __name__
@@ -824,10 +808,7 @@ def videos_post(course, request):
     if error:
         return {'error': error}, 400
 
-    if UPLOAD_VIA_BOTO3.is_enabled():
-        s3_client = boto3.client('s3')
-    else:
-        bucket = storage_service_bucket()
+    s3_client = boto3.client('s3')
 
     req_files = data['files']
     resp_files = []
@@ -842,8 +823,6 @@ def videos_post(course, request):
             return {'error': error_msg}, 400
 
         edx_video_id = str(uuid4())
-        if not UPLOAD_VIA_BOTO3.is_enabled():
-            key = storage_service_key(bucket, file_name=edx_video_id)
 
         metadata_list = [
             ('client_video_id', file_name),
@@ -863,25 +842,16 @@ def videos_post(course, request):
             if transcript_preferences is not None:
                 metadata_list.append(('transcript_preferences', json.dumps(transcript_preferences)))
 
-        if UPLOAD_VIA_BOTO3.is_enabled():
-            upload_url = s3_client.generate_presigned_url(
-                ClientMethod='put_object',
-                Params={
-                    'Bucket': storage_service_bucket_name(),
-                    'Key': storage_service_key_name(edx_video_id),
-                    'ContentType': req_file['content_type'],
-                    'Metadata': dict(metadata_list),
-                },
-                ExpiresIn=KEY_EXPIRATION_IN_SECONDS,
-            )
-        else:
-            for metadata_name, value in metadata_list:
-                key.set_metadata(metadata_name, value)
-            upload_url = key.generate_url(
-                KEY_EXPIRATION_IN_SECONDS,
-                'PUT',
-                headers={'Content-Type': req_file['content_type']}
-            )
+        upload_url = s3_client.generate_presigned_url(
+            ClientMethod='put_object',
+            Params={
+                'Bucket': storage_service_bucket_name(),
+                'Key': storage_service_key_name(edx_video_id),
+                'ContentType': req_file['content_type'],
+                'Metadata': dict(metadata_list),
+            },
+            ExpiresIn=KEY_EXPIRATION_IN_SECONDS,
+        )
 
         # persist edx_video_id in VAL
         create_video({
@@ -905,34 +875,6 @@ def storage_service_bucket_name():
     return settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET']
 
 
-def storage_service_bucket():
-    """
-    Returns an S3 bucket for video upload.
-
-    This is on the deprecated boto v1 pathway. See `UPLOAD_VIA_BOTO3`.
-    """
-    if ENABLE_DEVSTACK_VIDEO_UPLOADS.is_enabled():
-        params = {
-            'aws_access_key_id': settings.AWS_ACCESS_KEY_ID,
-            'aws_secret_access_key': settings.AWS_SECRET_ACCESS_KEY,
-            'security_token': settings.AWS_SECURITY_TOKEN
-
-        }
-    else:
-        params = {
-            'aws_access_key_id': settings.AWS_ACCESS_KEY_ID,
-            'aws_secret_access_key': settings.AWS_SECRET_ACCESS_KEY
-        }
-
-    conn = S3Connection(**params)
-
-    # We don't need to validate our bucket, it requires a very permissive IAM permission
-    # set since behind the scenes it fires a HEAD request that is equivalent to get_all_keys()
-    # meaning it would need ListObjects on the whole bucket, not just the path used in each
-    # environment (since we share a single bucket for multiple deployments in some configurations)
-    return conn.get_bucket(storage_service_bucket_name(), validate=False)
-
-
 def storage_service_key_name(file_name):
     """
     Returns the S3 object key to be used for a given video filename.
@@ -941,16 +883,6 @@ def storage_service_key_name(file_name):
         settings.VIDEO_UPLOAD_PIPELINE.get("ROOT_PATH", ""),
         file_name
     )
-
-
-def storage_service_key(bucket, file_name):
-    """
-    Returns an S3 key to the given file in the given bucket.
-
-    This is used in the deprecated boto v1 pathway. See `UPLOAD_VIA_BOTO3`.
-    """
-    key_name = storage_service_key_name(file_name)
-    return s3.key.Key(bucket, key_name)
 
 
 def send_video_status_update(updates):

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -15,7 +15,6 @@ import dateutil.parser
 from common.djangoapps.student.tests.factories import UserFactory
 import ddt
 import pytz
-from django.test import TestCase
 from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -33,10 +32,7 @@ from cms.djangoapps.contentstore.models import VideoUploadConfig
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
-from openedx.core.djangoapps.video_pipeline.config.waffle import (
-    DEPRECATE_YOUTUBE,
-    ENABLE_DEVSTACK_VIDEO_UPLOADS,
-)
+from openedx.core.djangoapps.video_pipeline.config.waffle import DEPRECATE_YOUTUBE
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -52,10 +48,7 @@ from cms.djangoapps.contentstore.video_storage_handlers import (
     TranscriptProvider,
     StatusDisplayStrings,
     convert_video_status,
-    storage_service_bucket,
-    storage_service_key,
     PUBLIC_VIDEO_SHARE,
-    UPLOAD_VIA_BOTO3,
 )
 
 # Constant defined to make it clear when we're grabbing the kwargs from a
@@ -254,102 +247,6 @@ class VideoUploadPostTestsMixin:
     """
     Shared test cases for video post tests.
     """
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
-    @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    def test_post_success_boto2(self, mock_conn, mock_key):
-        files = [
-            {
-                'file_name': 'first.mp4',
-                'content_type': 'video/mp4',
-            },
-            {
-                'file_name': 'second.mp4',
-                'content_type': 'video/mp4',
-            },
-            {
-                'file_name': 'third.mov',
-                'content_type': 'video/quicktime',
-            },
-            {
-                'file_name': 'fourth.mp4',
-                'content_type': 'video/mp4',
-            },
-        ]
-
-        bucket = Mock()
-        mock_conn.return_value = Mock(get_bucket=Mock(return_value=bucket))
-        mock_key_instances = [
-            Mock(
-                generate_url=Mock(
-                    return_value='http://example.com/url_{}'.format(file_info['file_name'])
-                )
-            )
-            for file_info in files
-        ]
-        # If extra calls are made, return a dummy
-        mock_key.side_effect = mock_key_instances + [Mock()]
-
-        response = self.client.post(
-            self.url,
-            json.dumps({'files': files}),
-            content_type='application/json'
-        )
-        self.assertEqual(response.status_code, 200)
-        response_obj = json.loads(response.content.decode('utf-8'))
-
-        mock_conn.assert_called_once_with(
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
-        )
-        self.assertEqual(len(response_obj['files']), len(files))
-        self.assertEqual(mock_key.call_count, len(files))
-        for i, file_info in enumerate(files):
-            # Ensure Key was set up correctly and extract id
-            key_call_args, __ = mock_key.call_args_list[i]
-            self.assertEqual(key_call_args[0], bucket)
-            path_match = re.match(
-                (
-                    settings.VIDEO_UPLOAD_PIPELINE['ROOT_PATH'] +
-                    '/([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})$'
-                ),
-                key_call_args[CALL_KW]
-            )
-            self.assertIsNotNone(path_match)
-            video_id = path_match.group(1)
-            mock_key_instance = mock_key_instances[i]
-
-            mock_key_instance.set_metadata.assert_any_call(
-                'course_video_upload_token',
-                self.test_token
-            )
-
-            mock_key_instance.set_metadata.assert_any_call(
-                'client_video_id',
-                file_info['file_name']
-            )
-            mock_key_instance.set_metadata.assert_any_call('course_key', str(self.course.id))
-            mock_key_instance.generate_url.assert_called_once_with(
-                KEY_EXPIRATION_IN_SECONDS,
-                'PUT',
-                headers={'Content-Type': file_info['content_type']}
-            )
-
-            # Ensure VAL was updated
-            val_info = get_video_info(video_id)
-            self.assertEqual(val_info['status'], 'upload')
-            self.assertEqual(val_info['client_video_id'], file_info['file_name'])
-            self.assertEqual(val_info['status'], 'upload')
-            self.assertEqual(val_info['duration'], 0)
-            self.assertEqual(val_info['courses'], [{str(self.course.id): None}])
-
-            # Ensure response is correct
-            response_file = response_obj['files'][i]
-            self.assertEqual(response_file['file_name'], file_info['file_name'])
-            self.assertEqual(response_file['upload_url'], mock_key_instance.generate_url())
-
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
     def test_post_success(self):
         files = [
             {
@@ -590,71 +487,6 @@ class VideosHandlerTestCase(
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'video_upload_pagination')
 
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
-    @override_settings(AWS_ACCESS_KEY_ID="test_key_id", AWS_SECRET_ACCESS_KEY="test_secret")
-    @patch("boto.s3.key.Key")
-    @patch("cms.djangoapps.contentstore.video_storage_handlers.S3Connection")
-    @ddt.data(
-        (
-            [
-                {
-                    "file_name": "supported-1.mp4",
-                    "content_type": "video/mp4",
-                },
-                {
-                    "file_name": "supported-2.mov",
-                    "content_type": "video/quicktime",
-                },
-            ],
-            200
-        ),
-        (
-            [
-                {
-                    "file_name": "unsupported-1.txt",
-                    "content_type": "text/plain",
-                },
-                {
-                    "file_name": "unsupported-2.png",
-                    "content_type": "image/png",
-                },
-            ],
-            400
-        )
-    )
-    @ddt.unpack
-    def test_video_supported_file_formats_boto2(self, files, expected_status, mock_conn, mock_key):
-        """
-        Test that video upload works correctly against supported and unsupported file formats.
-        """
-        mock_conn.get_bucket = Mock()
-        mock_key_instances = [
-            Mock(
-                generate_url=Mock(
-                    return_value="http://example.com/url_{}".format(file_info["file_name"])
-                )
-            )
-            for file_info in files
-        ]
-        # If extra calls are made, return a dummy
-        mock_key.side_effect = mock_key_instances + [Mock()]
-
-        # Check supported formats
-        response = self.client.post(
-            self.url,
-            json.dumps({"files": files}),
-            content_type="application/json"
-        )
-        self.assertEqual(response.status_code, expected_status)
-        response = json.loads(response.content.decode('utf-8'))
-
-        if expected_status == 200:
-            self.assertNotIn('error', response)
-        else:
-            self.assertIn('error', response)
-            self.assertEqual(response['error'], "Request 'files' entry contain unsupported content_type")
-
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
     @ddt.data(
         (
             [
@@ -704,30 +536,6 @@ class VideosHandlerTestCase(
             self.assertIn('error', response)
             self.assertEqual(response['error'], "Request 'files' entry contain unsupported content_type")
 
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
-    @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    def test_upload_with_non_ascii_characters_boto2(self, mock_conn):
-        """
-        Test that video uploads throws error message when file name contains special characters.
-        """
-        mock_conn.get_bucket = Mock()
-        file_name = 'test\u2019_file.mp4'
-        files = [{'file_name': file_name, 'content_type': 'video/mp4'}]
-
-        bucket = Mock()
-        mock_conn.return_value = Mock(get_bucket=Mock(return_value=bucket))
-
-        response = self.client.post(
-            self.url,
-            json.dumps({'files': files}),
-            content_type='application/json'
-        )
-        self.assertEqual(response.status_code, 400)
-        response = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(response['error'], 'The file name for %s must contain only ASCII characters.' % file_name)
-
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
     def test_upload_with_non_ascii_characters(self):
         """
         Test that video uploads throws error message when file name contains special characters.
@@ -743,79 +551,6 @@ class VideosHandlerTestCase(
         response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response['error'], 'The file name for %s must contain only ASCII characters.' % file_name)
 
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
-    @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret', AWS_SECURITY_TOKEN='token')
-    @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    @override_waffle_flag(ENABLE_DEVSTACK_VIDEO_UPLOADS, active=True)
-    def test_devstack_upload_connection_boto2(self, mock_conn, mock_key):
-        files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
-        mock_conn.get_bucket = Mock()
-        mock_key_instances = [
-            Mock(
-                generate_url=Mock(
-                    return_value='http://example.com/url_{}'.format(file_info['file_name'])
-                )
-            )
-            for file_info in files
-        ]
-        mock_key.side_effect = mock_key_instances
-        response = self.client.post(
-            self.url,
-            json.dumps({'files': files}),
-            content_type='application/json'
-        )
-
-        self.assertEqual(response.status_code, 200)
-        mock_conn.assert_called_once_with(
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            security_token=settings.AWS_SECURITY_TOKEN
-        )
-
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
-    @override_waffle_flag(ENABLE_DEVSTACK_VIDEO_UPLOADS, active=True)
-    def test_devstack_upload_connection(self):
-        files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
-        with self.patch_presign_url(files):
-            response = self.client.post(
-                self.url,
-                json.dumps({'files': files}),
-                content_type='application/json'
-            )
-        self.assertEqual(response.status_code, 200)
-
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
-    @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    def test_send_course_to_vem_pipeline_boto2(self, mock_conn, mock_key):
-        """
-        Test that uploads always go to VEM S3 bucket by default.
-        """
-        mock_conn.get_bucket = Mock()
-        files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
-        mock_key_instances = [
-            Mock(
-                generate_url=Mock(
-                    return_value='http://example.com/url_{}'.format(file_info['file_name'])
-                )
-            )
-            for file_info in files
-        ]
-        mock_key.side_effect = mock_key_instances
-
-        response = self.client.post(
-            self.url,
-            json.dumps({'files': files}),
-            content_type='application/json'
-        )
-
-        self.assertEqual(response.status_code, 200)
-        mock_conn.return_value.get_bucket.assert_called_once_with(
-            settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET'], validate=False  # pylint: disable=unsubscriptable-object
-        )
-
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
     def test_send_course_to_vem_pipeline(self):
         """
         Test that uploads always go to VEM S3 bucket by default.
@@ -834,75 +569,6 @@ class VideosHandlerTestCase(
             settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET']
         )
 
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
-    @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    @ddt.data(
-        {
-            'global_waffle': True,
-            'course_override': WaffleFlagCourseOverrideModel.ALL_CHOICES.off,
-            'expect_token': True
-        },
-        {
-            'global_waffle': False,
-            'course_override': WaffleFlagCourseOverrideModel.ALL_CHOICES.on,
-            'expect_token': False
-        },
-        {
-            'global_waffle': False,
-            'course_override': WaffleFlagCourseOverrideModel.ALL_CHOICES.off,
-            'expect_token': True
-        }
-    )
-    def test_video_upload_token_in_meta_boto2(self, data, mock_conn, mock_key):
-        """
-        Test video upload token in s3 metadata.
-        """
-        @contextmanager
-        def proxy_manager(manager, ignore_manager):
-            """
-            This acts as proxy to the original manager in the arguments given
-            the original manager is not set to be ignored.
-            """
-            if ignore_manager:
-                yield
-            else:
-                with manager:
-                    yield
-
-        file_data = {
-            'file_name': 'first.mp4',
-            'content_type': 'video/mp4',
-        }
-        mock_conn.get_bucket = Mock()
-        mock_key_instance = Mock(
-            generate_url=Mock(
-                return_value='http://example.com/url_{}'.format(file_data['file_name'])
-            )
-        )
-        # If extra calls are made, return a dummy
-        mock_key.side_effect = [mock_key_instance]
-
-        # expected args to be passed to `set_metadata`.
-        expected_args = ('course_video_upload_token', self.test_token)
-
-        with patch.object(WaffleFlagCourseOverrideModel, 'override_value', return_value=data['course_override']):
-            with override_waffle_flag(DEPRECATE_YOUTUBE, active=data['global_waffle']):
-                response = self.client.post(
-                    self.url,
-                    json.dumps({'files': [file_data]}),
-                    content_type='application/json'
-                )
-                self.assertEqual(response.status_code, 200)
-
-                with proxy_manager(self.assertRaises(AssertionError), data['expect_token']):
-                    # if we're not expecting token then following should raise assertion error and
-                    # if we're expecting token then we will be able to find the call to set the token
-                    # in s3 metadata.
-                    mock_key_instance.set_metadata.assert_any_call(*expected_args)
-
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
     @ddt.data(
         {
             'global_waffle': True,
@@ -1686,76 +1352,6 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
         preferences = get_transcript_preferences(course_id)
         self.assertIsNone(preferences)
 
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
-    @ddt.data(
-        (
-            None,
-            False
-        ),
-        (
-            {
-                'provider': TranscriptProvider.CIELO24,
-                'cielo24_fidelity': 'PROFESSIONAL',
-                'cielo24_turnaround': 'STANDARD',
-                'preferred_languages': ['en']
-            },
-            False
-        ),
-        (
-            {
-                'provider': TranscriptProvider.CIELO24,
-                'cielo24_fidelity': 'PROFESSIONAL',
-                'cielo24_turnaround': 'STANDARD',
-                'preferred_languages': ['en']
-            },
-            True
-        )
-    )
-    @ddt.unpack
-    @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    @patch('cms.djangoapps.contentstore.video_storage_handlers.get_transcript_preferences')
-    def test_transcript_preferences_metadata_boto2(self, transcript_preferences, is_video_transcript_enabled,
-                                                   mock_transcript_preferences, mock_conn, mock_key):
-        """
-        Tests that transcript preference metadata is only set if it is video transcript feature is enabled and
-        transcript preferences are already stored in the system.
-        """
-        file_name = 'test-video.mp4'
-        request_data = {'files': [{'file_name': file_name, 'content_type': 'video/mp4'}]}
-
-        mock_transcript_preferences.return_value = transcript_preferences
-
-        bucket = Mock()
-        mock_conn.return_value = Mock(get_bucket=Mock(return_value=bucket))
-        mock_key_instance = Mock(
-            generate_url=Mock(
-                return_value=f'http://example.com/url_{file_name}'
-            )
-        )
-        # If extra calls are made, return a dummy
-        mock_key.side_effect = [mock_key_instance] + [Mock()]
-
-        videos_handler_url = reverse_course_url('videos_handler', self.course.id)
-        with patch(
-            'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled'
-        ) as video_transcript_feature:
-            video_transcript_feature.return_value = is_video_transcript_enabled
-            response = self.client.post(videos_handler_url, json.dumps(request_data), content_type='application/json')
-
-        self.assertEqual(response.status_code, 200)
-
-        # Ensure `transcript_preferences` was set up in Key correctly if sent through request.
-        if is_video_transcript_enabled and transcript_preferences:
-            mock_key_instance.set_metadata.assert_any_call('transcript_preferences', json.dumps(transcript_preferences))
-        else:
-            with self.assertRaises(AssertionError):
-                mock_key_instance.set_metadata.assert_any_call(
-                    'transcript_preferences', json.dumps(transcript_preferences)
-                )
-
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
     @ddt.data(
         (
             None,
@@ -1954,31 +1550,6 @@ class GetVideoFeaturesTestCase(
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()[key], is_enabled)
-
-
-# TODO: Remove when UPLOAD_VIA_BOTO3 is removed.
-class GetStorageBucketTestCase(TestCase):
-    """ This test just check that connection works and returns the bucket.
-    It does not involve any mocking and triggers errors if has any import issue.
-    """
-    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
-    @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @override_settings(VIDEO_UPLOAD_PIPELINE={
-        "VEM_S3_BUCKET": "vem_test_bucket", "BUCKET": "test_bucket", "ROOT_PATH": "test_root"
-    })
-    def test_storage_bucket(self):
-        """ get bucket and generate url. It will not hit actual s3."""
-        bucket = storage_service_bucket()
-        edx_video_id = 'dummy_video'
-        key = storage_service_key(bucket, file_name=edx_video_id)
-        upload_url = key.generate_url(
-            KEY_EXPIRATION_IN_SECONDS,
-            'PUT',
-            headers={'Content-Type': 'mp4'}
-        )
-
-        self.assertIn("https://vem_test_bucket.s3.amazonaws.com:443/test_root/", upload_url)
-        self.assertIn(edx_video_id, upload_url)
 
 
 class CourseYoutubeEdxVideoIds(ModuleStoreTestCase):

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -9,7 +9,7 @@ import re
 from contextlib import contextmanager
 from datetime import datetime
 from io import StringIO
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import dateutil.parser
 from common.djangoapps.student.tests.factories import UserFactory
@@ -54,8 +54,13 @@ from cms.djangoapps.contentstore.video_storage_handlers import (
     convert_video_status,
     storage_service_bucket,
     storage_service_key,
-    PUBLIC_VIDEO_SHARE
+    PUBLIC_VIDEO_SHARE,
+    UPLOAD_VIA_BOTO3,
 )
+
+# Constant defined to make it clear when we're grabbing the kwargs from a
+# unittest.mock.call (which is a list of [args, kwargs]).
+CALL_KW = 1
 
 
 class VideoUploadTestBase:
@@ -167,6 +172,40 @@ class VideoUploadTestBase:
             if video["edx_video_id"] == edx_video_id
         )
 
+    @contextmanager
+    def patch_presign_url(self, files):
+        """
+        Decorator that patches boto3 to mock out S3 URL presigning.
+
+        Assumes that the only client in use is S3, and that only the presigning
+        method will be called. Makes assertions about what calls were made.
+
+        Decorator yields a result dictionary that will be populated *after* the
+        context closes. The one key is "calls", a list of call objects to the mock.
+
+        Arguments:
+          files: List of files to use for upload (dict of file_name and content_type)
+        """
+        mock_gen_url = Mock(side_effect=[
+            'http://example.com/url_{}'.format(file_info['file_name'])
+            for file_info in files
+        ])
+        mock_s3_client = Mock()
+        mock_s3_client.generate_presigned_url = mock_gen_url
+        with patch(
+                'cms.djangoapps.contentstore.video_storage_handlers.boto3.client',
+                return_value=mock_s3_client
+        ) as mock_boto_client:
+            results = {}
+            try:
+                yield results  # run wrapped block
+            finally:
+                results['calls'] = mock_gen_url.call_args_list
+
+        # Ensure that we're only trying to load the S3 client
+        for c in mock_boto_client.call_args_list:
+            self.assertEqual(c, call('s3'))
+
 
 class VideoStudioAccessTestsMixin:
     """
@@ -215,10 +254,11 @@ class VideoUploadPostTestsMixin:
     """
     Shared test cases for video post tests.
     """
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
     @patch('boto.s3.key.Key')
     @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    def test_post_success(self, mock_conn, mock_key):
+    def test_post_success_boto2(self, mock_conn, mock_key):
         files = [
             {
                 'file_name': 'first.mp4',
@@ -274,7 +314,7 @@ class VideoUploadPostTestsMixin:
                     settings.VIDEO_UPLOAD_PIPELINE['ROOT_PATH'] +
                     '/([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})$'
                 ),
-                key_call_args[1]
+                key_call_args[CALL_KW]
             )
             self.assertIsNotNone(path_match)
             video_id = path_match.group(1)
@@ -308,6 +348,77 @@ class VideoUploadPostTestsMixin:
             response_file = response_obj['files'][i]
             self.assertEqual(response_file['file_name'], file_info['file_name'])
             self.assertEqual(response_file['upload_url'], mock_key_instance.generate_url())
+
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
+    def test_post_success(self):
+        files = [
+            {
+                'file_name': 'first.mp4',
+                'content_type': 'video/mp4',
+            },
+            {
+                'file_name': 'second.mp4',
+                'content_type': 'video/mp4',
+            },
+            {
+                'file_name': 'third.mov',
+                'content_type': 'video/quicktime',
+            },
+            {
+                'file_name': 'fourth.mp4',
+                'content_type': 'video/mp4',
+            },
+        ]
+
+        with self.patch_presign_url(files) as presign_results:
+            response = self.client.post(
+                self.url,
+                json.dumps({'files': files}),
+                content_type='application/json'
+            )
+        self.assertEqual(response.status_code, 200)
+        response_obj = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(len(response_obj['files']), len(files))
+        presign_calls = presign_results['calls']
+        self.assertEqual(len(presign_calls), len(files))
+        for i, file_info in enumerate(files):
+            call_kwargs = presign_calls[i][CALL_KW]
+
+            self.assertEqual(call_kwargs['ClientMethod'], 'put_object')
+            path_match = re.match(
+                (
+                    settings.VIDEO_UPLOAD_PIPELINE['ROOT_PATH'] +
+                    '/([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})$'
+                ),
+                call_kwargs['Params']['Key']
+            )
+            self.assertIsNotNone(path_match)
+            video_id = path_match.group(1)
+
+            self.assertEqual(
+                call_kwargs['Params']['Metadata'],
+                {
+                    'course_video_upload_token': self.test_token,
+                    'client_video_id': file_info['file_name'],
+                    'course_key': str(self.course.id),
+                }
+            )
+            self.assertEqual(call_kwargs['Params']['ContentType'], file_info['content_type'])
+            self.assertEqual(call_kwargs['ExpiresIn'], KEY_EXPIRATION_IN_SECONDS)
+
+            # Ensure VAL was updated
+            val_info = get_video_info(video_id)
+            self.assertEqual(val_info['status'], 'upload')
+            self.assertEqual(val_info['client_video_id'], file_info['file_name'])
+            self.assertEqual(val_info['status'], 'upload')
+            self.assertEqual(val_info['duration'], 0)
+            self.assertEqual(val_info['courses'], [{str(self.course.id): None}])
+
+            # Ensure response is correct
+            response_file = response_obj['files'][i]
+            self.assertEqual(response_file['file_name'], file_info['file_name'])
+            self.assertEqual(response_file['upload_url'], f"http://example.com/url_{file_info['file_name']}")
 
     def test_post_non_json(self):
         response = self.client.post(self.url, {"files": []})
@@ -479,6 +590,7 @@ class VideosHandlerTestCase(
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'video_upload_pagination')
 
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
     @override_settings(AWS_ACCESS_KEY_ID="test_key_id", AWS_SECRET_ACCESS_KEY="test_secret")
     @patch("boto.s3.key.Key")
     @patch("cms.djangoapps.contentstore.video_storage_handlers.S3Connection")
@@ -511,7 +623,7 @@ class VideosHandlerTestCase(
         )
     )
     @ddt.unpack
-    def test_video_supported_file_formats(self, files, expected_status, mock_conn, mock_key):
+    def test_video_supported_file_formats_boto2(self, files, expected_status, mock_conn, mock_key):
         """
         Test that video upload works correctly against supported and unsupported file formats.
         """
@@ -542,9 +654,60 @@ class VideosHandlerTestCase(
             self.assertIn('error', response)
             self.assertEqual(response['error'], "Request 'files' entry contain unsupported content_type")
 
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
+    @ddt.data(
+        (
+            [
+                {
+                    "file_name": "supported-1.mp4",
+                    "content_type": "video/mp4",
+                },
+                {
+                    "file_name": "supported-2.mov",
+                    "content_type": "video/quicktime",
+                },
+            ],
+            200
+        ),
+        (
+            [
+                {
+                    "file_name": "unsupported-1.txt",
+                    "content_type": "text/plain",
+                },
+                {
+                    "file_name": "unsupported-2.png",
+                    "content_type": "image/png",
+                },
+            ],
+            400
+        )
+    )
+    @ddt.unpack
+    def test_video_supported_file_formats(self, files, expected_status):
+        """
+        Test that video upload works correctly against supported and unsupported file formats.
+        """
+        # Check supported formats
+        with self.patch_presign_url(files):
+            response = self.client.post(
+                self.url,
+                json.dumps({"files": files}),
+                content_type="application/json"
+            )
+        self.assertEqual(response.status_code, expected_status)
+        response = json.loads(response.content.decode('utf-8'))
+
+        if expected_status == 200:
+            self.assertNotIn('error', response)
+        else:
+            self.assertIn('error', response)
+            self.assertEqual(response['error'], "Request 'files' entry contain unsupported content_type")
+
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
     @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    def test_upload_with_non_ascii_charaters(self, mock_conn):
+    def test_upload_with_non_ascii_characters_boto2(self, mock_conn):
         """
         Test that video uploads throws error message when file name contains special characters.
         """
@@ -564,11 +727,28 @@ class VideosHandlerTestCase(
         response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response['error'], 'The file name for %s must contain only ASCII characters.' % file_name)
 
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
+    def test_upload_with_non_ascii_characters(self):
+        """
+        Test that video uploads throws error message when file name contains special characters.
+        """
+        file_name = 'test\u2019_file.mp4'
+        files = [{'file_name': file_name, 'content_type': 'video/mp4'}]
+        response = self.client.post(
+            self.url,
+            json.dumps({'files': files}),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
+        response = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response['error'], 'The file name for %s must contain only ASCII characters.' % file_name)
+
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret', AWS_SECURITY_TOKEN='token')
     @patch('boto.s3.key.Key')
     @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
     @override_waffle_flag(ENABLE_DEVSTACK_VIDEO_UPLOADS, active=True)
-    def test_devstack_upload_connection(self, mock_conn, mock_key):
+    def test_devstack_upload_connection_boto2(self, mock_conn, mock_key):
         files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
         mock_conn.get_bucket = Mock()
         mock_key_instances = [
@@ -593,9 +773,22 @@ class VideosHandlerTestCase(
             security_token=settings.AWS_SECURITY_TOKEN
         )
 
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
+    @override_waffle_flag(ENABLE_DEVSTACK_VIDEO_UPLOADS, active=True)
+    def test_devstack_upload_connection(self):
+        files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
+        with self.patch_presign_url(files):
+            response = self.client.post(
+                self.url,
+                json.dumps({'files': files}),
+                content_type='application/json'
+            )
+        self.assertEqual(response.status_code, 200)
+
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
     @patch('boto.s3.key.Key')
     @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
-    def test_send_course_to_vem_pipeline(self, mock_conn, mock_key):
+    def test_send_course_to_vem_pipeline_boto2(self, mock_conn, mock_key):
         """
         Test that uploads always go to VEM S3 bucket by default.
         """
@@ -622,6 +815,26 @@ class VideosHandlerTestCase(
             settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET'], validate=False  # pylint: disable=unsubscriptable-object
         )
 
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
+    def test_send_course_to_vem_pipeline(self):
+        """
+        Test that uploads always go to VEM S3 bucket by default.
+        """
+        files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
+        with self.patch_presign_url(files) as presign_results:
+            response = self.client.post(
+                self.url,
+                json.dumps({'files': files}),
+                content_type='application/json'
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            presign_results['calls'][0][CALL_KW]['Params']['Bucket'],
+            settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET']
+        )
+
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
     @patch('boto.s3.key.Key')
     @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
@@ -642,7 +855,7 @@ class VideosHandlerTestCase(
             'expect_token': True
         }
     )
-    def test_video_upload_token_in_meta(self, data, mock_conn, mock_key):
+    def test_video_upload_token_in_meta_boto2(self, data, mock_conn, mock_key):
         """
         Test video upload token in s3 metadata.
         """
@@ -688,6 +901,45 @@ class VideosHandlerTestCase(
                     # if we're expecting token then we will be able to find the call to set the token
                     # in s3 metadata.
                     mock_key_instance.set_metadata.assert_any_call(*expected_args)
+
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
+    @ddt.data(
+        {
+            'global_waffle': True,
+            'course_override': WaffleFlagCourseOverrideModel.ALL_CHOICES.off,
+            'expect_token': True
+        },
+        {
+            'global_waffle': False,
+            'course_override': WaffleFlagCourseOverrideModel.ALL_CHOICES.on,
+            'expect_token': False
+        },
+        {
+            'global_waffle': False,
+            'course_override': WaffleFlagCourseOverrideModel.ALL_CHOICES.off,
+            'expect_token': True
+        }
+    )
+    def test_video_upload_token_in_meta(self, data):
+        """
+        Test video upload token in s3 metadata.
+        """
+        file_data = {
+            'file_name': 'first.mp4',
+            'content_type': 'video/mp4',
+        }
+        with patch.object(WaffleFlagCourseOverrideModel, 'override_value', return_value=data['course_override']):
+            with override_waffle_flag(DEPRECATE_YOUTUBE, active=data['global_waffle']):
+                with self.patch_presign_url([file_data]) as presign_results:
+                    response = self.client.post(
+                        self.url,
+                        json.dumps({'files': [file_data]}),
+                        content_type='application/json'
+                    )
+                self.assertEqual(response.status_code, 200)
+
+        actual_token = presign_results['calls'][0][CALL_KW]['Params']['Metadata'].get('course_video_upload_token')
+        self.assertEqual(actual_token, self.test_token if data['expect_token'] else None)
 
     def _assert_video_removal(self, url, edx_video_id, deleted_videos):
         """
@@ -1434,6 +1686,7 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
         preferences = get_transcript_preferences(course_id)
         self.assertIsNone(preferences)
 
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
     @ddt.data(
         (
             None,
@@ -1463,8 +1716,8 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
     @patch('boto.s3.key.Key')
     @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
     @patch('cms.djangoapps.contentstore.video_storage_handlers.get_transcript_preferences')
-    def test_transcript_preferences_metadata(self, transcript_preferences, is_video_transcript_enabled,
-                                             mock_transcript_preferences, mock_conn, mock_key):
+    def test_transcript_preferences_metadata_boto2(self, transcript_preferences, is_video_transcript_enabled,
+                                                   mock_transcript_preferences, mock_conn, mock_key):
         """
         Tests that transcript preference metadata is only set if it is video transcript feature is enabled and
         transcript preferences are already stored in the system.
@@ -1501,6 +1754,65 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
                 mock_key_instance.set_metadata.assert_any_call(
                     'transcript_preferences', json.dumps(transcript_preferences)
                 )
+
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, True)
+    @ddt.data(
+        (
+            None,
+            False
+        ),
+        (
+            {
+                'provider': TranscriptProvider.CIELO24,
+                'cielo24_fidelity': 'PROFESSIONAL',
+                'cielo24_turnaround': 'STANDARD',
+                'preferred_languages': ['en']
+            },
+            False
+        ),
+        (
+            {
+                'provider': TranscriptProvider.CIELO24,
+                'cielo24_fidelity': 'PROFESSIONAL',
+                'cielo24_turnaround': 'STANDARD',
+                'preferred_languages': ['en']
+            },
+            True
+        )
+    )
+    @ddt.unpack
+    @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.get_transcript_preferences')
+    def test_transcript_preferences_metadata(self, transcript_preferences, is_video_transcript_enabled,
+                                             mock_transcript_preferences):
+        """
+        Tests that transcript preference metadata is only set if it is video transcript feature is enabled and
+        transcript preferences are already stored in the system.
+        """
+        file_name = 'test-video.mp4'
+        files = [{'file_name': file_name, 'content_type': 'video/mp4'}]
+
+        mock_transcript_preferences.return_value = transcript_preferences
+
+        videos_handler_url = reverse_course_url('videos_handler', self.course.id)
+        with patch(
+            'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled'
+        ) as video_transcript_feature:
+            video_transcript_feature.return_value = is_video_transcript_enabled
+            with self.patch_presign_url(files) as presign_results:
+                response = self.client.post(
+                    videos_handler_url, json.dumps({'files': files}),
+                    content_type='application/json',
+                )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Ensure `transcript_preferences` was set in metadata correctly if sent through request.
+        actual_value = presign_results['calls'][0][CALL_KW]['Params']['Metadata'].get('transcript_preferences')
+        if is_video_transcript_enabled and transcript_preferences:
+            self.assertEqual(actual_value, json.dumps(transcript_preferences))
+        else:
+            self.assertEqual(actual_value, None)
 
 
 @patch.dict("django.conf.settings.FEATURES", {"ENABLE_VIDEO_UPLOAD_PIPELINE": True})
@@ -1644,10 +1956,12 @@ class GetVideoFeaturesTestCase(
         self.assertEqual(response.json()[key], is_enabled)
 
 
+# TODO: Remove when UPLOAD_VIA_BOTO3 is removed.
 class GetStorageBucketTestCase(TestCase):
     """ This test just check that connection works and returns the bucket.
     It does not involve any mocking and triggers errors if has any import issue.
     """
+    @override_waffle_switch(UPLOAD_VIA_BOTO3, False)
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
     @override_settings(VIDEO_UPLOAD_PIPELINE={
         "VEM_S3_BUCKET": "vem_test_bucket", "BUCKET": "test_bucket", "ROOT_PATH": "test_root"

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -23,8 +23,6 @@ from cms.djangoapps.contentstore.video_storage_handlers import (
     videos_index_html as videos_index_html_source_function,
     videos_index_json as videos_index_json_source_function,
     videos_post as videos_post_source_function,
-    storage_service_bucket as storage_service_bucket_source_function,
-    storage_service_key as storage_service_key_source_function,
     send_video_status_update as send_video_status_update_source_function,
     is_status_update_request as is_status_update_request_source_function,
     get_course_youtube_edx_video_ids,
@@ -210,20 +208,6 @@ def videos_post(course, request):
     Exposes helper method without breaking existing bindings/dependencies
     """
     return videos_post_source_function(course, request)
-
-
-def storage_service_bucket():
-    """
-    Exposes helper method without breaking existing bindings/dependencies
-    """
-    return storage_service_bucket_source_function()
-
-
-def storage_service_key(bucket, file_name):
-    """
-    Exposes helper method without breaking existing bindings/dependencies
-    """
-    return storage_service_key_source_function(bucket, file_name)
 
 
 def send_video_status_update(updates):

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -3,8 +3,6 @@ This module contains configuration settings via waffle flags
 for the Video Pipeline app.
 """
 
-from edx_toggles.toggles import WaffleFlag
-
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Videos Namespace
@@ -20,19 +18,6 @@ LOG_PREFIX = 'Videos: '
 # .. toggle_creation_date: 2018-08-03
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/18765
 DEPRECATE_YOUTUBE = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.deprecate_youtube', __name__, LOG_PREFIX)
-
-# .. toggle_name: videos.enable_devstack_video_uploads
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: When enabled, use Multi-Factor Authentication (MFA) for authenticating to AWS. These short-
-#   lived access tokens are well suited for development (probably?). [At the time of annotation, the exact consequences
-#   of enabling this feature toggle are uncertain.]
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2020-03-12
-# .. toggle_warning: Enabling this feature requires that the ROLE_ARN, MFA_SERIAL_NUMBER, MFA_TOKEN settings are
-#   properly defined.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/23375
-ENABLE_DEVSTACK_VIDEO_UPLOADS = WaffleFlag(f'{WAFFLE_NAMESPACE}.enable_devstack_video_uploads', __name__, LOG_PREFIX)
 
 ENABLE_VEM_PIPELINE = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     f'{WAFFLE_NAMESPACE}.enable_vem_pipeline', __name__, LOG_PREFIX


### PR DESCRIPTION
Followup to https://github.com/edx/edx-platform/pull/127 which introduces the boto3 code path and the rollout toggle.

This also removes some wrapper functions that I'm reasonably sure are unused and that were exposing boto v2 code paths. For reference, they were introduced in <https://github.com/openedx/openedx-platform/pull/32803>. I've filed https://2u-internal.atlassian.net/browse/TNL2-545 to ensure that functionality is either confirmed to still work or is reimplemented as needed.

Merge waiting on:

- [x] Rollout toggle tested
  - [x] stage
  - [x] prod
  - [x] edge

BOMS-421, TNL-122
