### PR TITLE
Spike: Subscriber platform plugin POC with Segment-based subscriber status

### DIFF
--- a/openedx/plugins/subscriber/MANIFEST.in
+++ b/openedx/plugins/subscriber/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst
+include openedx.yaml
+recursive-include subscriber *.py

--- a/openedx/plugins/subscriber/openedx.yaml
+++ b/openedx/plugins/subscriber/openedx.yaml
@@ -1,0 +1,5 @@
+lms:
+  django_apps:
+    - subscriber
+  urls:
+    - subscriber.urls

--- a/openedx/plugins/subscriber/setup.py
+++ b/openedx/plugins/subscriber/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="platform-plugin-subscriber",
+    version="0.1.0",
+    packages=find_packages(),
+    include_package_data=True,
+    package_data={
+        "": ["openedx.yaml"],
+    },
+    entry_points={
+        "lms.djangoapp": [
+            "subscriber = subscriber.apps:SubscriberConfig",
+        ],
+    },
+)

--- a/openedx/plugins/subscriber/subscriber/__init__.py
+++ b/openedx/plugins/subscriber/subscriber/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "subscriber.apps.SubscriberConfig"

--- a/openedx/plugins/subscriber/subscriber/apps.py
+++ b/openedx/plugins/subscriber/subscriber/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+
+
+class SubscriberConfig(AppConfig):
+    name = "subscriber"
+
+    plugin_app = {
+        "url_config": {
+            "lms.djangoapp": {
+                "namespace": "subscriber",
+                "regex": "^api/subscriber/",
+                "relative_path": "urls",
+            }
+        }
+    }

--- a/openedx/plugins/subscriber/subscriber/services.py
+++ b/openedx/plugins/subscriber/subscriber/services.py
@@ -1,17 +1,12 @@
 from common.djangoapps.student.models import CourseEnrollment
 
-# POC-only: hardcoded subscription catalog
+# TODO: Replace with Subscription Catalog API call
 SUBSCRIPTION_COURSE_IDS = [
     "course-v1:edX+DemoX+Demo_Course",
 ]
 
 
 def get_categorized_courses(user):
-    """
-    Fetch user's enrolled courses and categorize them
-    for the Subscriber Learner Dashboard.
-    """
-
     enrollments = CourseEnrollment.objects.filter(
         user=user,
         is_active=True
@@ -21,14 +16,21 @@ def get_categorized_courses(user):
     upgradeable_courses = []
     non_upgradeable_courses = []
 
-    # POC assumption: user is already a subscriber
+    # TODO: Replace with real subscription status check
     user_is_subscriber = True
+
+    subscription_catalog_courses = SUBSCRIPTION_COURSE_IDS
 
     for enrollment in enrollments:
         course_id = str(enrollment.course_id)
 
-        if course_id in SUBSCRIPTION_COURSE_IDS:
-            if user_is_subscriber:
+        is_in_catalog = course_id in subscription_catalog_courses
+
+        # TODO: Replace with enrollment mode / upgrade check
+        is_full_access = user_is_subscriber
+
+        if is_in_catalog:
+            if is_full_access:
                 subscription_courses.append(course_id)
             else:
                 upgradeable_courses.append(course_id)

--- a/openedx/plugins/subscriber/subscriber/services.py
+++ b/openedx/plugins/subscriber/subscriber/services.py
@@ -7,9 +7,56 @@ Structured to allow future integration with:
 - Subscription Catalog API
 - Subscriber entitlement service
 """
-
+import requests 
+from django.conf import settings
 from common.djangoapps.student.models import CourseEnrollment
 
+
+def get_segment_traits(user_id):
+    """
+    Fetch Segment profile traits for given LMS user_id.
+    """
+    # Safety check — prevents crashes if settings are not configured
+    if not getattr(settings, "SEGMENT_SPACE_ID", None) or not getattr(settings, "SEGMENT_PROFILE_API_TOKEN", None):
+        print("Segment configuration missing. Skipping API call.")
+        return {}
+    url = (
+        f"https://profiles.segment.com/v1/spaces/"
+        f"{settings.SEGMENT_SPACE_ID}/collections/users/"
+        f"profiles/user_id:{user_id}/traits"
+    )
+
+    try:
+        response = requests.get(
+            url,
+            auth=(settings.SEGMENT_PROFILE_API_TOKEN, ""),
+            timeout=5,
+        )
+
+        if response.status_code != 200:
+            print("Segment API non-200:", response.status_code)
+            return {}
+
+        data = response.json()
+        return data.get("traits", {})
+
+    except Exception as e:
+        print("Segment API error:", e)
+        return {}
+
+def get_segment_profile_data(user):
+    print("get_segment_profile_data called------")
+
+    traits = get_segment_traits(user.id)
+    print("traits-----", traits)
+
+    return {
+        "email": traits.get("email"),
+        "username": traits.get("username"),
+        "is_disabled": traits.get("is_disabled"),
+        "disabled_users": traits.get("disabled_users"),
+        "last_enrollment": traits.get("last_enrollment"),
+    }
 
 # TODO: Replace this with Subscription Catalog API call
 def get_subscription_catalog_course_ids():
@@ -81,9 +128,17 @@ def get_categorized_courses(user):
         # Course not part of subscription catalog
         else:
             non_upgradeable_courses.append(course_id)
+            
+    # Fetch Segment Profile Data
+    segment_profile = get_segment_profile_data(user)
+
+    # Example personalization flag derived from Segment
+    account_disabled = segment_profile.get("is_disabled")
 
     return {
         "subscription_courses": subscription_courses,
         "upgradeable_courses": upgradeable_courses,
         "non_upgradeable_courses": non_upgradeable_courses,
+        "segment_profile": segment_profile,
+        "account_disabled_from_segment": account_disabled,
     }

--- a/openedx/plugins/subscriber/subscriber/services.py
+++ b/openedx/plugins/subscriber/subscriber/services.py
@@ -1,39 +1,84 @@
+"""
+Subscriber services.
+
+This module handles course categorization logic for Subscriber Learner Dashboard.
+
+Structured to allow future integration with:
+- Subscription Catalog API
+- Subscriber entitlement service
+"""
+
 from common.djangoapps.student.models import CourseEnrollment
 
-# TODO: Replace with Subscription Catalog API call
-SUBSCRIPTION_COURSE_IDS = [
-    "course-v1:edX+DemoX+Demo_Course",
-]
+
+# TODO: Replace this with Subscription Catalog API call
+def get_subscription_catalog_course_ids():
+    """
+    Returns list of course IDs that are part of Subscription Catalog.
+
+    Currently hardcoded for POC.
+    Future: Fetch from Subscription Catalog Service API.
+    """
+    return [
+        "course-v1:edX+DemoX+Demo_Course",
+    ]
 
 
-def get_categorized_courses(user):
-    enrollments = CourseEnrollment.objects.filter(
+# TODO: Replace this with real subscription entitlement check
+def is_user_subscriber(user):
+    """
+    Returns True if user is an active subscriber.
+
+    Currently hardcoded for POC.
+    Future: Fetch from Subscription Entitlement Service.
+    """
+    return True
+
+
+def get_user_enrollments(user):
+    """
+    Fetch all active enrollments for the user.
+    """
+    return CourseEnrollment.objects.filter(
         user=user,
         is_active=True
     )
+
+
+def get_categorized_courses(user):
+    """
+    Categorize user courses into:
+
+    - subscription_courses
+    - upgradeable_courses
+    - non_upgradeable_courses
+    """
+
+    enrollments = get_user_enrollments(user)
+
+    subscription_catalog = get_subscription_catalog_course_ids()
+
+    user_is_subscriber = is_user_subscriber(user)
 
     subscription_courses = []
     upgradeable_courses = []
     non_upgradeable_courses = []
 
-    # TODO: Replace with real subscription status check
-    user_is_subscriber = True
-
-    subscription_catalog_courses = SUBSCRIPTION_COURSE_IDS
-
     for enrollment in enrollments:
+
         course_id = str(enrollment.course_id)
 
-        is_in_catalog = course_id in subscription_catalog_courses
+        # Course is part of subscription catalog
+        if course_id in subscription_catalog:
 
-        # TODO: Replace with enrollment mode / upgrade check
-        is_full_access = user_is_subscriber
-
-        if is_in_catalog:
-            if is_full_access:
+            # User has full access OR is subscriber
+            if enrollment.mode != "audit" or user_is_subscriber:
                 subscription_courses.append(course_id)
+
             else:
                 upgradeable_courses.append(course_id)
+
+        # Course not part of subscription catalog
         else:
             non_upgradeable_courses.append(course_id)
 

--- a/openedx/plugins/subscriber/subscriber/services.py
+++ b/openedx/plugins/subscriber/subscriber/services.py
@@ -1,0 +1,42 @@
+from common.djangoapps.student.models import CourseEnrollment
+
+# POC-only: hardcoded subscription catalog
+SUBSCRIPTION_COURSE_IDS = [
+    "course-v1:edX+DemoX+Demo_Course",
+]
+
+
+def get_categorized_courses(user):
+    """
+    Fetch user's enrolled courses and categorize them
+    for the Subscriber Learner Dashboard.
+    """
+
+    enrollments = CourseEnrollment.objects.filter(
+        user=user,
+        is_active=True
+    )
+
+    subscription_courses = []
+    upgradeable_courses = []
+    non_upgradeable_courses = []
+
+    # POC assumption: user is already a subscriber
+    user_is_subscriber = True
+
+    for enrollment in enrollments:
+        course_id = str(enrollment.course_id)
+
+        if course_id in SUBSCRIPTION_COURSE_IDS:
+            if user_is_subscriber:
+                subscription_courses.append(course_id)
+            else:
+                upgradeable_courses.append(course_id)
+        else:
+            non_upgradeable_courses.append(course_id)
+
+    return {
+        "subscription_courses": subscription_courses,
+        "upgradeable_courses": upgradeable_courses,
+        "non_upgradeable_courses": non_upgradeable_courses,
+    }

--- a/openedx/plugins/subscriber/subscriber/urls.py
+++ b/openedx/plugins/subscriber/subscriber/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+from .views import subscriber_courses
+
+urlpatterns = [
+    path(
+    "dashboard/courses/",
+    subscriber_courses,
+    name="subscriber-dashboard-courses",
+    ),
+]

--- a/openedx/plugins/subscriber/subscriber/views.py
+++ b/openedx/plugins/subscriber/subscriber/views.py
@@ -1,0 +1,13 @@
+from django.http import JsonResponse
+from django.contrib.auth.decorators import login_required
+from .services import get_categorized_courses
+
+
+@login_required
+def subscriber_courses(request):
+    """
+    API endpoint for Subscriber Learner Dashboard.
+    Returns user's enrolled courses grouped into categories.
+    """
+    data = get_categorized_courses(request.user)
+    return JsonResponse(data)


### PR DESCRIPTION
## Objective
POC to fetch subscriber status from Segment profile and use it in the Subscriber platform plugin to categorize learner courses.

## Changes
- Updated subscriber check to read `is_subscriber` trait from Segment profile
- Added Segment profile utility for LMS

## What this proves
- LMS plugin can access Segment traits
- Course categorization works based on subscriber status

## Status
Draft PR for spike validation.
