### PR TITLE
fix: fallback for tpa-saml SAMLAuthBackend

### DIFF
--- a/common/djangoapps/third_party_auth/provider.py
+++ b/common/djangoapps/third_party_auth/provider.py
@@ -16,6 +16,7 @@ from common.djangoapps.third_party_auth.models import (
     SAMLConfiguration,
     SAMLProviderConfig
 )
+from common.djangoapps.third_party_auth.toggles import is_saml_provider_site_fallback_enabled
 
 
 class Registry:
@@ -96,6 +97,19 @@ class Registry:
         for enabled in cls._enabled_providers():
             if enabled.is_active_for_pipeline(running_pipeline):
                 return enabled
+
+        # Fallback for SAML: SAMLAuthBackend.get_idp() uses SAMLProviderConfig.current()
+        # which has no site check. If the provider's site_id doesn't match the current
+        # site (or SAMLConfiguration isn't enabled for the current site), _enabled_providers()
+        # won't yield it — but the SAML handshake already completed. Look up the provider
+        # directly by idp_name so that pipeline steps like should_force_account_creation()
+        # can still read provider flags.
+        if is_saml_provider_site_fallback_enabled() and running_pipeline.get('backend') == 'tpa-saml':
+            try:
+                idp_name = running_pipeline['kwargs']['response']['idp_name']
+                return SAMLProviderConfig.current(idp_name)
+            except (KeyError, SAMLProviderConfig.DoesNotExist):
+                pass
 
     @classmethod
     def get_enabled_by_backend_name(cls, backend_name):

--- a/common/djangoapps/third_party_auth/toggles.py
+++ b/common/djangoapps/third_party_auth/toggles.py
@@ -65,3 +65,33 @@ def is_tpa_next_url_on_dispatch_enabled():
     when dispatching to login/register pages.
     """
     return TPA_NEXT_URL_ON_DISPATCH_FLAG.is_enabled()
+
+
+# .. toggle_name: third_party_auth.saml_provider_site_fallback
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, Registry.get_from_pipeline() will fall back to a
+#    site-independent SAMLProviderConfig lookup when the site-filtered registry returns no
+#    match for a running SAML pipeline. This handles cases where the SAMLProviderConfig or
+#    SAMLConfiguration is associated with a different Django site than the one currently
+#    serving the request, while SAML auth itself already completed (SAMLAuthBackend.get_idp()
+#    has no site check). Without this flag, pipeline steps such as should_force_account_creation()
+#    cannot read provider flags (e.g. send_to_registration_first), causing new users to land on
+#    the login page instead of registration.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-02-19
+# .. toggle_target_removal_date: 2026-06-01
+# .. toggle_warning: The underlying site configuration mismatch should still be fixed in Django
+#    admin (SAMLConfiguration and SAMLProviderConfig must reference the correct site). This flag
+#    is a temporary workaround until that is resolved.
+SAML_PROVIDER_SITE_FALLBACK_FLAG = WaffleFlag(
+    f'{THIRD_PARTY_AUTH_NAMESPACE}.saml_provider_site_fallback', __name__
+)
+
+
+def is_saml_provider_site_fallback_enabled():
+    """
+    Returns True if get_from_pipeline() should fall back to a site-independent
+    SAMLProviderConfig lookup when the site-filtered registry finds no match.
+    """
+    return SAML_PROVIDER_SITE_FALLBACK_FLAG.is_enabled()


### PR DESCRIPTION
- Added fallback for tpa-saml to use idp_name when finding site config.
- Waffle flag to avoid security holes.