### PR TITLE
feat: open invideoquiz editor after component creation on legacy unit…

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -1185,7 +1185,8 @@ function($, _, Backbone, gettext, BasePage,
             if(!data.hasOwnProperty('upstreamRef') && ((useNewTextEditor === 'True' && blockType.includes('html'))
                     || (useNewVideoEditor === 'True' && blockType.includes('video'))
                     || (useNewProblemEditor === 'True' && blockType.includes('problem'))
-                    || blockType.includes('games'))
+                    || blockType.includes('games')
+                    || blockType.includes('invideoquiz'))
             ){
                 if (this.options.isIframeEmbed && (this.isSplitTestContentPage || this.isVerticalContentPage)) {
                     return this.postMessageToParent({


### PR DESCRIPTION
## Description

 - When using the legacy unit page (non-MFE), creating a new invideoquiz component did not auto-open the authoring MFE editor
  - The onNewXBlock handler in container.js was missing invideoquiz from its block type check, even though the edit button click handler already included it
  - Added invideoquiz to the redirect condition so the editor opens immediately after creation, matching the behavior on the MFE unit page


The MFE unit page already handles this correctly , but staging/production still use the legacy unit page where the `legacy_studio.unit_editor waffle` flag is enabled. This fix closes the gap for the legacy path.



## Jira ticket 

[TNL2-543](https://2u-internal.atlassian.net/browse/TNL2-543)

## Testing instructions
 - Enable legacy_studio.unit_editor waffle flag to use the legacy unit page
  - Navigate to a Unit page in Studio
  - Add an invideoquiz component
  - Verify the invideoquiz editor opens automatically after creation
  - Save and verify the component renders on the unit page
  - Verify editing an existing invideoquiz component still works (regression check)

This affects Studio (CMS) content authoring roles — anyone who can add components to a unit page:

  - Global Staff — platform admins
  - Course Instructors — course-level admins
  - Course Staff — course content editors

  Learners/students are not affected — this is purely a Studio authoring workflow change