### PR TITLE
feat(xblock): support safe returnTo redirect for XBlock edit view

### DIFF
--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -1,8 +1,10 @@
 """Views for blocks."""
 
 import logging
+import re
 from collections import OrderedDict
 from functools import partial
+from urllib.parse import urlparse
 
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
@@ -305,6 +307,43 @@ def xblock_view_handler(request, usage_key_string, view_name):
         return HttpResponse(status=406)
 
 
+def _get_safe_return_to(request):
+    """
+    Read and validate the ``returnTo`` query parameter for the XBlock edit view.
+
+    Returns the parameter value if it is a safe same-origin URL (i.e. an
+    absolute-path reference that starts with ``/`` but not ``//``), or ``None``
+    if the parameter is absent or fails validation.  This prevents open-redirect
+    attacks via protocol-relative URLs such as ``//evil.com/path``.
+    """
+    return_to = request.GET.get('returnTo', '').strip()
+    if not return_to:
+        return None
+
+    if re.search(r'[\x00-\x1f\x7f]', return_to):
+        return None
+
+    if len(return_to) > 2048:
+        return None
+
+    parsed = urlparse(return_to)
+    if parsed.scheme or parsed.netloc:
+        request_origin = '{scheme}://{host}'.format(
+            scheme=request.scheme,
+            host=request.get_host(),
+        )
+        url_origin = '{scheme}://{host}'.format(
+            scheme=parsed.scheme,
+            host=parsed.netloc,
+        )
+        if request_origin != url_origin:
+            return None
+    elif not return_to.startswith('/') or return_to.startswith('//'):
+        return None
+
+    return return_to
+
+
 @xframe_options_exempt
 @require_http_methods(["GET"])
 @login_required
@@ -313,6 +352,10 @@ def xblock_edit_view(request, usage_key_string):
     Return rendered xblock edit view.
 
     Allows editing of an XBlock specified by the usage key.
+
+    Supports an optional ``returnTo`` query parameter.  When present and
+    pointing to a same-origin URL, the editor will redirect the browser to
+    that URL after the user saves or cancels instead of leaving the page blank.
     """
     usage_key = usage_key_with_run(usage_key_string)
     if not has_studio_read_access(request.user, usage_key.course_key):
@@ -333,6 +376,7 @@ def xblock_edit_view(request, usage_key_string):
         container_handler_context.update({
             "action_name": "edit",
             "resources": list(hashed_resources.items()),
+            "return_to": _get_safe_return_to(request),
         })
 
         return render_to_response('container_editor.html', container_handler_context)

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -76,6 +76,7 @@ from lms.djangoapps.lms_xblock.mixin import NONSENSICAL_ACCESS_RESTRICTION
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from openedx.core.djangoapps.content_tagging import api as tagging_api
 
+from ..block import _get_safe_return_to
 from ..component import component_handler, get_component_templates
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import (
     ALWAYS,
@@ -4635,3 +4636,93 @@ class TestXblockEditView(CourseTestCase):
 
         self.assertGreater(len(resource_links), 0, f"No CSS resources found in HTML. Found: {resource_links}")
         self.assertGreater(len(script_sources), 0, f"No JS resources found in HTML. Found: {script_sources}")
+
+
+class TestGetSafeReturnTo(TestCase):
+    """
+    Tests for _get_safe_return_to validation.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+
+    def _make_request(self, return_to=None):
+        """Build a GET request with an optional returnTo query parameter."""
+        url = '/dummy'
+        if return_to is not None:
+            url = f'/dummy?returnTo={return_to}'
+        return self.factory.get(url)
+
+    # -- valid inputs --------------------------------------------------------
+
+    def test_valid_relative_path(self):
+        request = self._make_request('/course/123')
+        self.assertEqual(_get_safe_return_to(request), '/course/123')
+
+    def test_valid_root_path(self):
+        request = self._make_request('/')
+        self.assertEqual(_get_safe_return_to(request), '/')
+
+    def test_valid_relative_path_with_query_string(self):
+        request = self.factory.get('/dummy', {'returnTo': '/course/123?tab=outline'})
+        self.assertEqual(_get_safe_return_to(request), '/course/123?tab=outline')
+
+    def test_valid_absolute_url_same_origin(self):
+        request = self.factory.get('/dummy', {'returnTo': 'http://testserver/course/123'})
+        self.assertEqual(_get_safe_return_to(request), 'http://testserver/course/123')
+
+    # -- empty / missing values ----------------------------------------------
+
+    def test_missing_parameter(self):
+        request = self.factory.get('/dummy')
+        self.assertIsNone(_get_safe_return_to(request))
+
+    def test_empty_string(self):
+        request = self._make_request('')
+        self.assertIsNone(_get_safe_return_to(request))
+
+    def test_whitespace_only(self):
+        request = self.factory.get('/dummy', {'returnTo': '   '})
+        self.assertIsNone(_get_safe_return_to(request))
+
+    # -- protocol-relative / different origin --------------------------------
+
+    def test_protocol_relative_url_rejected(self):
+        request = self._make_request('//evil.com/path')
+        self.assertIsNone(_get_safe_return_to(request))
+
+    def test_absolute_url_different_origin_rejected(self):
+        request = self.factory.get('/dummy', {'returnTo': 'https://evil.com/steal'})
+        self.assertIsNone(_get_safe_return_to(request))
+
+    def test_absolute_url_different_scheme_rejected(self):
+        request = self.factory.get('/dummy', {'returnTo': 'https://testserver/course'})
+        self.assertIsNone(_get_safe_return_to(request))
+
+    # -- relative paths that don't start with / ------------------------------
+
+    def test_bare_relative_path_rejected(self):
+        request = self._make_request('course/123')
+        self.assertIsNone(_get_safe_return_to(request))
+
+    # -- control characters --------------------------------------------------
+
+    def test_null_byte_rejected(self):
+        request = self.factory.get('/dummy', {'returnTo': '/course/\x00'})
+        self.assertIsNone(_get_safe_return_to(request))
+
+    def test_newline_rejected(self):
+        request = self.factory.get('/dummy', {'returnTo': '/course/\n/path'})
+        self.assertIsNone(_get_safe_return_to(request))
+
+    def test_tab_character_rejected(self):
+        request = self.factory.get('/dummy', {'returnTo': '/course/\t/path'})
+        self.assertIsNone(_get_safe_return_to(request))
+
+    # -- length limit --------------------------------------------------------
+
+    def test_url_over_2048_chars_rejected(self):
+        long_url = '/' + 'a' * 2048
+        request = self.factory.get('/dummy', {'returnTo': long_url})
+        self.assertIsNone(_get_safe_return_to(request))

--- a/cms/static/js/spec/views/modals/edit_xblock_spec.js
+++ b/cms/static/js/spec/views/modals/edit_xblock_spec.js
@@ -185,6 +185,68 @@ describe('EditXBlockModal', function() {
         });
     });
 
+    describe('isSafeReturnTo', function() {
+        var isSafeReturnTo = EditXBlockModal.isSafeReturnTo;
+
+        // -- valid inputs ---------------------------------------------------
+
+        it('accepts a root-relative path', function() {
+            expect(isSafeReturnTo('/course/123')).toBe(true);
+        });
+
+        it('accepts the root path', function() {
+            expect(isSafeReturnTo('/')).toBe(true);
+        });
+
+        it('accepts a root-relative path with query string', function() {
+            expect(isSafeReturnTo('/course/123?tab=outline')).toBe(true);
+        });
+
+        it('accepts an absolute URL with the same origin', function() {
+            expect(isSafeReturnTo(window.location.origin + '/course/123')).toBe(true);
+        });
+
+        // -- empty / missing values -----------------------------------------
+
+        it('rejects an empty string', function() {
+            expect(isSafeReturnTo('')).toBe(false);
+        });
+
+        it('rejects null', function() {
+            expect(isSafeReturnTo(null)).toBe(false);
+        });
+
+        it('rejects undefined', function() {
+            expect(isSafeReturnTo(undefined)).toBe(false);
+        });
+
+        it('rejects a non-string value', function() {
+            expect(isSafeReturnTo(42)).toBe(false);
+        });
+
+        // -- protocol-relative / different origin ---------------------------
+
+        it('rejects protocol-relative URLs', function() {
+            expect(isSafeReturnTo('//evil.com/path')).toBe(false);
+        });
+
+        it('rejects an absolute URL with a different origin', function() {
+            expect(isSafeReturnTo('https://evil.com/steal')).toBe(false);
+        });
+
+        // -- relative paths without leading / -------------------------------
+
+        it('rejects a bare relative path', function() {
+            expect(isSafeReturnTo('course/123')).toBe(false);
+        });
+
+        // -- javascript: scheme ---------------------------------------------
+
+        it('rejects javascript: scheme', function() {
+            expect(isSafeReturnTo('javascript:alert(1)')).toBe(false);  // eslint-disable-line no-script-url
+        });
+    });
+
     describe('XModule Editor (settings only)', function() {
         var mockXModuleEditorHtml;
 

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -336,5 +336,8 @@ function($, _, Backbone, gettext, BaseModal, ViewUtils, XBlockViewUtils, XBlockE
 
     });
 
+    // Expose for unit testing.
+    EditXBlockModal.isSafeReturnTo = isSafeReturnTo;
+
     return EditXBlockModal;
 });

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -8,6 +8,27 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/modals/base_mod
 function($, _, Backbone, gettext, BaseModal, ViewUtils, XBlockViewUtils, XBlockEditorView) {
     'use strict';
 
+    /**
+     * Returns true when ``url`` is safe to use as a same-origin redirect
+     * destination.  Accepted values are:
+     *   - Root-relative paths beginning with '/' but NOT '//' (protocol-
+     *     relative URLs such as //evil.com would bypass the check).
+     *   - Absolute URLs whose origin matches the current page's origin.
+     */
+    function isSafeReturnTo(url) {
+        if (typeof url !== 'string' || url.length === 0) {
+            return false;
+        }
+        if (url.charAt(0) === '/' && url.charAt(1) !== '/') {
+            return true;
+        }
+        try {
+            return new URL(url).origin === window.location.origin;
+        } catch (e) {
+            return false;
+        }
+    }
+
     var EditXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
             'click .action-save': 'save',
@@ -234,10 +255,29 @@ function($, _, Backbone, gettext, BaseModal, ViewUtils, XBlockViewUtils, XBlockE
                 console.error(e);
             }
 
+            var returnTo = this.editOptions && this.editOptions.returnTo;
+            if (returnTo && isSafeReturnTo(returnTo)) {
+                this.hide();
+                window.location.href = returnTo;
+                return;
+            }
+
             var refresh = this.editOptions.refresh;
             this.hide();
             if (refresh) {
                 refresh(this.xblockInfo);
+            }
+        },
+
+        cancel: function(event) {
+            if (event) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
+            this.hide();
+            var returnTo = this.editOptions && this.editOptions.returnTo;
+            if (returnTo && isSafeReturnTo(returnTo)) {
+                window.location.href = returnTo;
             }
         },
 

--- a/cms/templates/container_editor.html
+++ b/cms/templates/container_editor.html
@@ -119,12 +119,13 @@ from openedx.core.release import RELEASE_LINE
             function (XBlockInfo, EditXBlockModal) {
                 var decodedActionName = '${action_name|n, decode.utf8}';
                 var encodedXBlockDetails = ${xblock_info | n, dump_js_escaped_json};
+                var returnTo = '${return_to or "" | n, js_escaped_string}';
 
                 if (decodedActionName === 'edit') {
                     var editXBlockModal = new EditXBlockModal();
                     var xblockInfoInstance = new XBlockInfo(encodedXBlockDetails);
 
-                    editXBlockModal.edit([], xblockInfoInstance, {});
+                    editXBlockModal.edit([], xblockInfoInstance, {returnTo: returnTo || null});
                 }
             });
         </%static:webpack>


### PR DESCRIPTION
### Description 

This PR adds support for a returnTo query parameter in the XBlock edit view (/xblock/<usage_key>/edit) to enable redirecting users back to the originating page after save or cancel.
 
**Key changes:**
 

- Adds server-side validation via _get_safe_return_to in [block.py](http://block.py/) to prevent open-redirect vulnerabilities.
- Implements client-side validation using isSafeReturnTo in edit_xblock.js.
- Passes the returnTo parameter through container_editor.html into EditXBlockModal options.
- Adds cancel handler support in EditXBlockModal that respects the returnTo redirect.
- This improves editor navigation while maintaining security against unsafe redirects.

**Jira ticket** 
[TNL2-532](https://2u-internal.atlassian.net/browse/TNL2-532)