### PR TITLE
fix: resolve cross-team discussion visibility issue

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -188,6 +188,12 @@ def get_threads(request, course, user_info, discussion_id=None, per_page=THREADS
         if 'pinned' not in thread:
             thread['pinned'] = False
 
+    # Filter team discussions - only team members can see team posts
+    if discussion_id is not None and not is_privileged_user(course.id, request.user):
+        team = team_api.get_team_by_discussion(discussion_id)
+        if team and not team.users.filter(id=request.user.id).exists():
+            threads = []
+
     query_params['page'] = paginated_results.page
     query_params['num_pages'] = paginated_results.num_pages
     query_params['corrected_text'] = paginated_results.corrected_text


### PR DESCRIPTION
## Description

This PR resolves an issue where discussion posts within team exercises were visible across all teams instead of being restricted to their respective team members.

## Problem

When navigating to a team exercise and selecting any individual team, the same collection of posts was displayed regardless of the selected team. Team discussions were not properly isolated at the team level.

## Expected Behavior

Each team should only be able to view discussion posts created by members of their own team.

## Actual Behavior

All teams were seeing identical posts within the exercise, indicating missing or incorrect filtering by team_id.

## Ticket
[Cosmo2-731](https://2u-internal.atlassian.net/browse/COSMO2-731)
