### PR TITLE
chore: bumped edx-enterprise vesrion from 6.6.5 to 6.6.7

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -42,7 +42,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -473,7 +473,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
@@ -563,7 +563,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-enterprise-integrated-channels==0.1.47
+enterprise-integrated-channels==0.1.48
     # via -r requirements/edx/bundled.in
 event-tracking==3.3.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
@@ -875,7 +875,7 @@ enmerkar-underscore==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-enterprise-integrated-channels==0.1.47
+enterprise-integrated-channels==0.1.48
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -557,7 +557,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
@@ -653,7 +653,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.47
+enterprise-integrated-channels==0.1.48
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -578,7 +578,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
@@ -676,7 +676,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.47
+enterprise-integrated-channels==0.1.48
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via


### PR DESCRIPTION
### Description
Updates the `edx-enterprise` package version in the base requirements file.

### Changes Made
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/edx/base.txt`
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/constraints.txt`
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/edx/testing.txt`
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/edx/development.txt`
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/edx/doc.txt`