### PR TITLE
fix: update release-ulmo branch triggers for pylint and dunder init workflows

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -7,6 +7,7 @@ name: Consistent Python dependencies
 
 on:
   pull_request:
+  merge_group:
 
 defaults:
   run:

--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -2,6 +2,7 @@ name: Check Python Dependencies
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   check_dependencies:

--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -1,6 +1,8 @@
 name: Static analysis
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   tests:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,7 +3,8 @@
 name: Lint Commit Messages
 
 on:
-  - pull_request
+  pull_request:
+  merge_group:
 
 jobs:
   commitlint:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -2,6 +2,7 @@ name: Javascript tests
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -2,6 +2,7 @@ name: Lint Python Imports
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - release-ulmo
   pull_request:
+  merge_group:
 
 jobs:
   version-check:

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -3,6 +3,7 @@ name: Check Django Migrations
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - release-ulmo
 
 jobs:
   run-pylint:

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -2,6 +2,7 @@ name: Pylint Checks
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -2,6 +2,7 @@ name: Quality checks
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,6 +7,7 @@ name: Semgrep code quality
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,6 +7,7 @@ name: ShellCheck
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -2,6 +2,7 @@ name: static assets check for lms and cms
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,7 @@ name: unit-tests
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/units-test-scripts-structures-pruning.yml
+++ b/.github/workflows/units-test-scripts-structures-pruning.yml
@@ -2,6 +2,7 @@ name: units-test-scripts-common
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/units-test-scripts-user-retirement.yml
+++ b/.github/workflows/units-test-scripts-user-retirement.yml
@@ -2,6 +2,7 @@ name: units-test-scripts-user-retirement
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo

--- a/.github/workflows/verify-dunder-init.yml
+++ b/.github/workflows/verify-dunder-init.yml
@@ -2,10 +2,10 @@ name: Verify Dunder __init__.py Files
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - release-ulmo
-  merge_group:
 
 jobs:
   verify_dunder_init:

--- a/.github/workflows/verify-dunder-init.yml
+++ b/.github/workflows/verify-dunder-init.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - release-ulmo
+  merge_group:
 
 jobs:
   verify_dunder_init:

--- a/.github/workflows/verify-dunder-init.yml
+++ b/.github/workflows/verify-dunder-init.yml
@@ -2,6 +2,7 @@ name: Verify Dunder __init__.py Files
 
 on:
   pull_request:
+  push:
     branches:
       - release-ulmo
 


### PR DESCRIPTION
### Description:

Updates GitHub Actions workflow triggers so the `release-ulmo` branch is included for `pylint` and `dunder-__init__.py` verification runs, aligning these checks with the release branch workflow.

### Changes:

- Added a push trigger for the `dunder __init__.py` verification workflow on `release-ulmo`.
- Updated the pylint workflow push branch filter from `master` to `release-ulmo`.