### PR TITLE
feat: enterprise 6.6.8, begins decoupling retirement view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,7 @@ pii_report
 
 # Pyenv Python version file
 .python-version
+
+## AI Tools
+.claude/
+CLAUDE.md

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1219,7 +1219,12 @@ class AccountRetirementView(ViewSet):
             UnregisteredLearnerCohortAssignments.delete_by_user_value(original_email, field="email")
 
             # This signal allows code in higher points of LMS to retire the user as necessary
-            USER_RETIRE_LMS_CRITICAL.send(sender=self.__class__, user=user)
+            USER_RETIRE_LMS_CRITICAL.send(
+                sender=self.__class__,
+                user=user,
+                retired_email=retired_email,
+                retired_username=retired_username,
+            )
 
             user.first_name = ""
             user.last_name = ""

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -42,7 +42,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==6.6.7
+edx-enterprise==6.6.8
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -473,7 +473,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.6.7
+edx-enterprise==6.6.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.6.7
+edx-enterprise==6.6.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -557,7 +557,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.6.7
+edx-enterprise==6.6.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -578,7 +578,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.6.7
+edx-enterprise==6.6.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Includes logic to send signal with args now required by enterprise signal handlers in: https://github.com/openedx/edx-enterprise/pull/2559

Deployments of new edx-enterprise releases, including:
https://github.com/edx/edx-platform/pull/175/changes

are *blocked* until this PR is merged. They are blocked because CI fails on `pytest openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py` due to a signal expecting required args that are not present without this fix.
