### PR TITLE
fix: removing enterprise-specific code from edx-platform

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -10,7 +10,6 @@ import ddt
 import pytz
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
-from django.conf import settings
 from django.core import mail
 from django.core.cache import cache
 from django.db import connection
@@ -80,6 +79,7 @@ from .retirement_helpers import (  # pylint: disable=unused-import
     fake_completed_retirement,
     setup_retirement_states
 )
+
 
 def build_jwt_headers(user):
     """

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import ddt
 import pytz
-from consent.models import DataSharingConsent
+from zoneinfo import ZoneInfo
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
 from django.conf import settings
@@ -18,12 +18,6 @@ from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
-from enterprise.models import (
-    EnterpriseCourseEnrollment,
-    EnterpriseCustomer,
-    EnterpriseCustomerUser,
-    PendingEnterpriseCustomerUser
-)
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from social_django.models import UserSocialAuth
@@ -67,7 +61,6 @@ from openedx.core.djangoapps.credit.models import (
 )
 from openedx.core.djangoapps.external_user_ids.models import ExternalIdType
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
-from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.user_api.accounts.views import AccountRetirementPartnerReportView
 from openedx.core.djangoapps.user_api.models import (
     RetirementState,
@@ -1396,33 +1389,6 @@ class TestAccountRetirementPost(RetirementTestCase):
         self.cache_key = UserProfile.country_cache_key_name(self.test_user.id)
         cache.set(self.cache_key, 'Timor-leste')
 
-        # Enterprise model setup
-        self.course_id = 'course-v1:edX+DemoX.1+2T2017'
-        self.enterprise_customer = EnterpriseCustomer.objects.create(
-            name='test_enterprise_customer',
-            site=SiteFactory.create()
-        )
-        self.enterprise_user = EnterpriseCustomerUser.objects.create(
-            enterprise_customer=self.enterprise_customer,
-            user_id=self.test_user.id,
-        )
-        self.enterprise_enrollment = EnterpriseCourseEnrollment.objects.create(
-            enterprise_customer_user=self.enterprise_user,
-            course_id=self.course_id
-        )
-        self.pending_enterprise_user = PendingEnterpriseCustomerUser.objects.create(
-            enterprise_customer_id=self.enterprise_user.enterprise_customer_id,
-            user_email=self.test_user.email
-        )
-        self.sapsf_audit = SapSuccessFactorsLearnerDataTransmissionAudit.objects.create(
-            sapsf_user_id=self.test_user.id,
-            enterprise_course_enrollment_id=self.enterprise_enrollment.id,
-        )
-        self.consent = DataSharingConsent.objects.create(
-            username=self.test_user.username,
-            enterprise_customer=self.enterprise_customer,
-        )
-
         # Entitlement model setup
         self.entitlement = CourseEntitlementFactory.create(user=self.test_user)
         self.entitlement_support_detail = CourseEntitlementSupportDetail.objects.create(
@@ -1455,45 +1421,12 @@ class TestAccountRetirementPost(RetirementTestCase):
         self.headers['content_type'] = "application/json"
         self.url = reverse('accounts_retire')
 
-    def _data_sharing_consent_assertions(self):
-        """
-        Helper method for asserting that ``DataSharingConsent`` objects are retired.
-        """
-        self.consent.refresh_from_db()
-        assert self.retired_username == self.consent.username
-        test_users_data_sharing_consent = DataSharingConsent.objects.filter(
-            username=self.original_username
-        )
-        assert not test_users_data_sharing_consent.exists()
-
     def _entitlement_support_detail_assertions(self):
         """
         Helper method for asserting that ``CourseEntitleSupportDetail`` objects are retired.
         """
         self.entitlement_support_detail.refresh_from_db()
         assert '' == self.entitlement_support_detail.comments
-
-    def _pending_enterprise_customer_user_assertions(self):
-        """
-        Helper method for asserting that ``PendingEnterpriseCustomerUser`` objects are retired.
-        """
-        self.pending_enterprise_user.refresh_from_db()
-        assert self.retired_email == self.pending_enterprise_user.user_email
-        pending_enterprise_users = PendingEnterpriseCustomerUser.objects.filter(
-            user_email=self.original_email
-        )
-        assert not pending_enterprise_users.exists()
-
-    def _sapsf_audit_assertions(self):
-        """
-        Helper method for asserting that ``SapSuccessFactorsLearnerDataTransmissionAudit`` objects are retired.
-        """
-        self.sapsf_audit.refresh_from_db()
-        assert '' == self.sapsf_audit.sapsf_user_id
-        audits_for_original_user_id = SapSuccessFactorsLearnerDataTransmissionAudit.objects.filter(
-            sapsf_user_id=self.test_user.id,
-        )
-        assert not audits_for_original_user_id.exists()
 
     def post_and_assert_status(self, data, expected_status=status.HTTP_204_NO_CONTENT):
         """
@@ -1570,9 +1503,6 @@ class TestAccountRetirementPost(RetirementTestCase):
 
         assert cache.get(self.cache_key) is None
 
-        self._data_sharing_consent_assertions()
-        self._sapsf_audit_assertions()
-        self._pending_enterprise_customer_user_assertions()
         self._entitlement_support_detail_assertions()
 
         assert not PendingEmailChange.objects.filter(user=self.test_user).exists()
@@ -1586,6 +1516,21 @@ class TestAccountRetirementPost(RetirementTestCase):
         self.post_and_assert_status(data)
         fake_completed_retirement(self.test_user)
         self.post_and_assert_status(data)
+
+    @mock.patch('openedx.core.djangoapps.user_api.accounts.views.USER_RETIRE_LMS_CRITICAL')
+    def test_retirement_sends_critical_signal_with_retirement_data(self, mock_signal):
+        """
+        USER_RETIRE_LMS_CRITICAL is sent with retired_username and retired_email kwargs.
+        """
+        data = {'username': self.original_username}
+        self.post_and_assert_status(data)
+
+        mock_signal.send.assert_called_once_with(
+            sender=mock_signal.send.call_args[1]['sender'],
+            user=mock_signal.send.call_args[1]['user'],
+            retired_username=self.retired_username,
+            retired_email=self.retired_email,
+        )
 
     def test_deletes_pii_from_user_profile(self):
         for model_field, value_to_assign in USER_PROFILE_PII.items():
@@ -1626,18 +1571,6 @@ class TestAccountRetirementPost(RetirementTestCase):
     def test_can_delete_user_profiles_country_cache(self):
         AccountRetirementView.delete_users_country_cache(self.test_user)
         assert cache.get(self.cache_key) is None
-
-    def test_can_retire_users_datasharingconsent(self):
-        AccountRetirementView.retire_users_data_sharing_consent(self.test_user.username, self.retired_username)
-        self._data_sharing_consent_assertions()
-
-    def test_can_retire_users_sap_success_factors_audits(self):
-        AccountRetirementView.retire_sapsf_data_transmission(self.test_user)
-        self._sapsf_audit_assertions()
-
-    def test_can_retire_user_from_pendingenterprisecustomeruser(self):
-        AccountRetirementView.retire_user_from_pending_enterprise_customer_user(self.test_user, self.retired_email)
-        self._pending_enterprise_customer_user_assertions()
 
     def test_course_entitlement_support_detail_comments_are_retired(self):
         AccountRetirementView.retire_entitlement_support_detail(self.test_user)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import ddt
 import pytz
-from zoneinfo import ZoneInfo
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
 from django.conf import settings
@@ -81,13 +80,6 @@ from .retirement_helpers import (  # pylint: disable=unused-import
     fake_completed_retirement,
     setup_retirement_states
 )
-
-# This is a temporary import path while we transition from integrated_channels to channel_integrations
-if getattr(settings, 'ENABLE_LEGACY_INTEGRATED_CHANNELS', True):
-    from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
-else:
-    from channel_integrations.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
-
 
 def build_jwt_headers(user):
     """

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -10,7 +10,6 @@ import logging
 from functools import wraps
 
 import pytz
-from zoneinfo import ZoneInfo
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, logout
@@ -94,15 +93,6 @@ from .serializers import (
 )
 from .signals import USER_RETIRE_LMS_CRITICAL, USER_RETIRE_LMS_MISC, USER_RETIRE_MAILINGS
 from .utils import create_retirement_request_and_deactivate_account, username_suffix_generator
-
-# This is a temporary import path while we transition from integrated_channels to channel_integrations
-if getattr(settings, 'ENABLE_LEGACY_INTEGRATED_CHANNELS', True):
-    from integrated_channels.degreed.models import DegreedLearnerDataTransmissionAudit
-    from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
-else:
-    from channel_integrations.degreed2.models import Degreed2LearnerDataTransmissionAudit \
-        as DegreedLearnerDataTransmissionAudit
-    from channel_integrations.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
 
 log = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -10,7 +10,7 @@ import logging
 from functools import wraps
 
 import pytz
-from consent.models import DataSharingConsent
+from zoneinfo import ZoneInfo
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, logout
@@ -26,7 +26,6 @@ from edx_ace.recipient import Recipient
 from edx_django_utils.monitoring import record_exception
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
-from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, PendingEnterpriseCustomerUser
 from rest_framework import permissions, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import UnsupportedMediaType
@@ -1203,11 +1202,6 @@ class AccountRetirementView(ViewSet):
             # Retire user information from any certificate records associated with the learner
             self.clear_pii_from_certificate_records(user)
 
-            # Retire data from Enterprise models
-            self.retire_users_data_sharing_consent(username, retired_username)
-            self.retire_sapsf_data_transmission(user)
-            self.retire_degreed_data_transmission(user)
-            self.retire_user_from_pending_enterprise_customer_user(user, retired_email)
             self.retire_entitlement_support_detail(user)
 
             # Retire misc. models that may contain PII of this user
@@ -1262,32 +1256,6 @@ class AccountRetirementView(ViewSet):
     def delete_users_country_cache(user):
         cache_key = UserProfile.country_cache_key_name(user.id)
         cache.delete(cache_key)
-
-    @staticmethod
-    def retire_users_data_sharing_consent(username, retired_username):
-        DataSharingConsent.objects.filter(username=username).update(username=retired_username)
-
-    @staticmethod
-    def retire_sapsf_data_transmission(user):  # lint-amnesty, pylint: disable=missing-function-docstring
-        for ent_user in EnterpriseCustomerUser.objects.filter(user_id=user.id):
-            for enrollment in EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=ent_user):
-                audits = SapSuccessFactorsLearnerDataTransmissionAudit.objects.filter(
-                    enterprise_course_enrollment_id=enrollment.id
-                )
-                audits.update(sapsf_user_id="")
-
-    @staticmethod
-    def retire_degreed_data_transmission(user):  # lint-amnesty, pylint: disable=missing-function-docstring
-        for ent_user in EnterpriseCustomerUser.objects.filter(user_id=user.id):
-            for enrollment in EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=ent_user):
-                audits = DegreedLearnerDataTransmissionAudit.objects.filter(
-                    enterprise_course_enrollment_id=enrollment.id
-                )
-                audits.update(degreed_user_email="")
-
-    @staticmethod
-    def retire_user_from_pending_enterprise_customer_user(user, retired_email):
-        PendingEnterpriseCustomerUser.objects.filter(user_email=user.email).update(user_email=retired_email)
 
     @staticmethod
     def retire_entitlement_support_detail(user):


### PR DESCRIPTION
Removing enterprise specific code, sister PR to this one in openedx-platform [here](https://github.com/openedx/openedx-platform/pull/38117).

[Jira ticket  
](https://2u-internal.atlassian.net/browse/ENT-11476)

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
