### PR TITLE
fix: show staff tag for global staff in discussion forum

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -273,6 +273,8 @@ class _ContentSerializer(serializers.Serializer):
         Returns the role label (i.e. "Staff", "Moderator" or "Community TA") for the user
         with the given id.
         """
+        if User.objects.get(id=user_id).is_staff:
+            return "Staff"
         is_staff = user_id in self.context["course_staff_user_ids"]
         is_moderator = user_id in self.context["moderator_user_ids"]
         is_ta = user_id in self.context["ta_user_ids"]


### PR DESCRIPTION
## Description

Global staff users were being displayed as learners in the discussion forum, and the staff tag was not shown.

### Issue :
The course staff check was overriding the global staff check. As a result, if a user was not marked as course staff, they were displayed as a learner even if they had global staff privileges.

### Ticket :
[COSMO2-842](https://2u-internal.atlassian.net/browse/COSMO2-842)