### PR TITLE
fix: adding monitoring for management command

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -71,6 +71,34 @@ from openedx.core.lib.features_setting_proxy import FeaturesProxy
 # A proxy for feature flags stored in the settings namespace
 FEATURES = FeaturesProxy(globals())
 
+# .. setting_name: ENABLE_MANAGEMENT_COMMAND_MONITORING
+# .. setting_default: False
+# When True, enables APM monitoring of Django management command execution.
+# Monitoring emits custom Datadog attributes (name, service_variant, status, duration_seconds, etc.)
+# and traces to track command performance and failures. Set to True in production environments.
+ENABLE_MANAGEMENT_COMMAND_MONITORING = False
+
+# .. setting_name: MANAGEMENT_COMMAND_MONITORING_TRACE_NAME
+# .. setting_default: django.management.command
+# APM transaction name used when wrapping management command execution for tracing.
+# Customize this if your observability stack uses different naming conventions.
+MANAGEMENT_COMMAND_MONITORING_TRACE_NAME = 'django.management.command'
+
+# .. setting_name: OPEN_EDX_FILTERS_CONFIG
+# Register the default pipeline for management command execution monitoring.
+# edX can override this configuration to add custom monitoring or security pipeline steps
+# by modifying OPEN_EDX_FILTERS_CONFIG in environment-specific settings.
+OPEN_EDX_FILTERS_CONFIG = locals().get('OPEN_EDX_FILTERS_CONFIG', {})
+OPEN_EDX_FILTERS_CONFIG.setdefault(
+    'org.openedx.platform.management.command.execute.requested.v1',
+    {
+        'pipeline': [
+            'openedx.core.djangoapps.util.management_monitoring.ManagementCommandMonitoringPipelineStep',
+        ],
+        'fail_silently': True,
+    },
+)
+
 # pylint: enable=useless-suppression
 
 ############################ FEATURE CONFIGURATION #############################

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -71,23 +71,27 @@ from openedx.core.lib.features_setting_proxy import FeaturesProxy
 # A proxy for feature flags stored in the settings namespace
 FEATURES = FeaturesProxy(globals())
 
-# .. setting_name: ENABLE_MANAGEMENT_COMMAND_MONITORING
-# .. setting_default: False
-# When True, enables APM monitoring of Django management command execution.
-# Monitoring emits custom Datadog attributes (name, service_variant, status, duration_seconds, etc.)
-# and traces to track command performance and failures. Set to True in production environments.
-ENABLE_MANAGEMENT_COMMAND_MONITORING = False
+# .. toggle_name: FEATURES['ENABLE_MANAGEMENT_COMMAND_MONITORING']
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When True, enables APM monitoring of Django management command execution.
+#   Monitoring emits custom Datadog attributes (name, service_variant, status, duration_seconds, etc.)
+#   and traces to track command performance and failures. Set to True in production environments.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2026-03-23
+FEATURES['ENABLE_MANAGEMENT_COMMAND_MONITORING'] = False
 
 # .. setting_name: MANAGEMENT_COMMAND_MONITORING_TRACE_NAME
 # .. setting_default: django.management.command
-# APM transaction name used when wrapping management command execution for tracing.
-# Customize this if your observability stack uses different naming conventions.
+# .. setting_description: APM transaction name used when wrapping management command execution for tracing.
+#   Customize this if your observability stack uses different naming conventions.
 MANAGEMENT_COMMAND_MONITORING_TRACE_NAME = 'django.management.command'
 
 # .. setting_name: OPEN_EDX_FILTERS_CONFIG
-# Register the default pipeline for management command execution monitoring.
-# edX can override this configuration to add custom monitoring or security pipeline steps
-# by modifying OPEN_EDX_FILTERS_CONFIG in environment-specific settings.
+# .. setting_default: {}
+# .. setting_description: Register the default pipeline for management command execution monitoring.
+#   edX can override this configuration to add custom monitoring or security pipeline steps
+#   by modifying OPEN_EDX_FILTERS_CONFIG in environment-specific settings.
 OPEN_EDX_FILTERS_CONFIG = locals().get('OPEN_EDX_FILTERS_CONFIG', {})
 OPEN_EDX_FILTERS_CONFIG.setdefault(
     'org.openedx.platform.management.command.execute.requested.v1',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -73,23 +73,27 @@ from openedx.core.lib.features_setting_proxy import FeaturesProxy
 # A proxy for feature flags stored in the settings namespace
 FEATURES = FeaturesProxy(globals())
 
-# .. setting_name: ENABLE_MANAGEMENT_COMMAND_MONITORING
-# .. setting_default: False
-# When True, enables APM monitoring of Django management command execution.
-# Monitoring emits custom Datadog attributes (name, service_variant, status, duration_seconds, etc.)
-# and traces to track command performance and failures. Set to True in production environments.
-ENABLE_MANAGEMENT_COMMAND_MONITORING = False
+# .. toggle_name: FEATURES['ENABLE_MANAGEMENT_COMMAND_MONITORING']
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When True, enables APM monitoring of Django management command execution.
+#   Monitoring emits custom Datadog attributes (name, service_variant, status, duration_seconds, etc.)
+#   and traces to track command performance and failures. Set to True in production environments.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2026-03-23
+FEATURES['ENABLE_MANAGEMENT_COMMAND_MONITORING'] = False
 
 # .. setting_name: MANAGEMENT_COMMAND_MONITORING_TRACE_NAME
 # .. setting_default: django.management.command
-# APM transaction name used when wrapping management command execution for tracing.
-# Customize this if your observability stack uses different naming conventions.
+# .. setting_description: APM transaction name used when wrapping management command execution for tracing.
+#   Customize this if your observability stack uses different naming conventions.
 MANAGEMENT_COMMAND_MONITORING_TRACE_NAME = 'django.management.command'
 
 # .. setting_name: OPEN_EDX_FILTERS_CONFIG
-# Register the default pipeline for management command execution monitoring.
-# edX can override this configuration to add custom monitoring or security pipeline steps
-# by modifying OPEN_EDX_FILTERS_CONFIG in environment-specific settings.
+# .. setting_default: {}
+# .. setting_description: Register the default pipeline for management command execution monitoring.
+#   edX can override this configuration to add custom monitoring or security pipeline steps
+#   by modifying OPEN_EDX_FILTERS_CONFIG in environment-specific settings.
 OPEN_EDX_FILTERS_CONFIG = locals().get('OPEN_EDX_FILTERS_CONFIG', {})
 OPEN_EDX_FILTERS_CONFIG.setdefault(
     'org.openedx.platform.management.command.execute.requested.v1',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -73,6 +73,34 @@ from openedx.core.lib.features_setting_proxy import FeaturesProxy
 # A proxy for feature flags stored in the settings namespace
 FEATURES = FeaturesProxy(globals())
 
+# .. setting_name: ENABLE_MANAGEMENT_COMMAND_MONITORING
+# .. setting_default: False
+# When True, enables APM monitoring of Django management command execution.
+# Monitoring emits custom Datadog attributes (name, service_variant, status, duration_seconds, etc.)
+# and traces to track command performance and failures. Set to True in production environments.
+ENABLE_MANAGEMENT_COMMAND_MONITORING = False
+
+# .. setting_name: MANAGEMENT_COMMAND_MONITORING_TRACE_NAME
+# .. setting_default: django.management.command
+# APM transaction name used when wrapping management command execution for tracing.
+# Customize this if your observability stack uses different naming conventions.
+MANAGEMENT_COMMAND_MONITORING_TRACE_NAME = 'django.management.command'
+
+# .. setting_name: OPEN_EDX_FILTERS_CONFIG
+# Register the default pipeline for management command execution monitoring.
+# edX can override this configuration to add custom monitoring or security pipeline steps
+# by modifying OPEN_EDX_FILTERS_CONFIG in environment-specific settings.
+OPEN_EDX_FILTERS_CONFIG = locals().get('OPEN_EDX_FILTERS_CONFIG', {})
+OPEN_EDX_FILTERS_CONFIG.setdefault(
+    'org.openedx.platform.management.command.execute.requested.v1',
+    {
+        'pipeline': [
+            'openedx.core.djangoapps.util.management_monitoring.ManagementCommandMonitoringPipelineStep',
+        ],
+        'fail_silently': True,
+    },
+)
+
 ################################### FEATURES ###################################
 
 CC_MERCHANT_NAME = Derived(lambda settings: settings.PLATFORM_NAME)

--- a/manage.py
+++ b/manage.py
@@ -78,6 +78,26 @@ def parse_args():
     return edx_args, django_args
 
 
+def get_command_name(django_args):
+    """
+    Extract the Django management command name from parsed arguments.
+
+    Arguments:
+        django_args (list): Django command line arguments.
+
+    Returns:
+        str: Command name, or 'help' if no command is specified.
+    """
+    if not django_args:
+        return "help"
+
+    command_name = django_args[0]
+    if command_name.startswith("-"):
+        return "help"
+
+    return command_name
+
+
 if __name__ == "__main__":
     edx_args, django_args = parse_args()
 
@@ -96,4 +116,24 @@ if __name__ == "__main__":
         django_args.append('--help')
 
     from django.core.management import execute_from_command_line
-    execute_from_command_line([sys.argv[0]] + django_args)
+    from openedx.core.djangoapps.util.filters import ManagementCommandExecutionRequested
+
+    command_name = get_command_name(django_args)
+
+    def command_runner():
+        """Execute the Django management command."""
+        execute_from_command_line([sys.argv[0]] + django_args)
+
+    # Route management command execution through the filter pipeline.
+    # This allows edX and plugins to intercept and monitor command execution.
+    # Filter type: org.openedx.platform.management.command.execute.requested.v1
+    _, _, command_runner = ManagementCommandExecutionRequested.run_filter(
+        command_name=command_name,
+        service_variant=edx_args.service_variant,
+        command_runner=command_runner,
+    )
+
+    if not callable(command_runner):
+        raise TypeError("management command runner must be callable")
+
+    command_runner()

--- a/openedx/core/djangoapps/util/filters.py
+++ b/openedx/core/djangoapps/util/filters.py
@@ -1,0 +1,64 @@
+"""Open edX filters used by util app infrastructure code."""
+
+from typing import Callable
+
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+
+class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
+    """
+    Filter used to wrap Django management command execution.
+
+    Filter Type:
+        org.openedx.platform.management.command.execute.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: manage.py
+        - Function or Method: __main__ block
+    """
+
+    filter_type = "org.openedx.platform.management.command.execute.requested.v1"
+
+    @classmethod
+    def run_filter(
+        cls,
+        command_name: str,
+        service_variant: str,
+        command_runner: Callable,
+    ) -> tuple[str | None, str | None, Callable | None]:
+        """
+        Run the management command execution filter pipeline.
+
+        This filter allows pipeline steps to intercept and decorate management command
+        execution. The default pipeline includes a monitoring step that wraps command
+        execution with APM tracing and Datadog custom attributes.
+
+        Pipeline steps can modify or replace any of the filter arguments to customize
+        command execution behavior, perform additional monitoring, logging, or security checks.
+
+        Arguments:
+            command_name (str): Parsed Django management command name (e.g., 'migrate', 'shell').
+            service_variant (str): Service variant running the command ('lms', 'cms', etc.).
+            command_runner (Callable): Zero-argument callable that executes the command.
+
+        Returns:
+            tuple[str | None, str | None, Callable | None]: Three-element tuple containing:
+                - command_name: Command name, possibly modified by pipeline steps.
+                - service_variant: Service variant, possibly modified by pipeline steps.
+                - command_runner: Command executor callable, possibly wrapped/replaced by pipeline steps.
+
+        Example:
+            To add custom monitoring or security checks, implement a pipeline step:
+
+            class MyCustomPipelineStep(PipelineStep):
+                def run_filter(self, command_name, service_variant, command_runner):
+                    # Custom logic here
+                    return command_name, service_variant, command_runner
+        """
+        data = super().run_pipeline(
+            command_name=command_name,
+            service_variant=service_variant,
+            command_runner=command_runner,
+        )
+        return data.get("command_name"), data.get("service_variant"), data.get("command_runner")

--- a/openedx/core/djangoapps/util/management_monitoring.py
+++ b/openedx/core/djangoapps/util/management_monitoring.py
@@ -78,7 +78,7 @@ def monitor_django_management_command(command_name, service_variant='unknown'):
     Raises:
         Any exception raised by the command under monitoring context.
     """
-    monitoring_enabled = getattr(settings, "ENABLE_MANAGEMENT_COMMAND_MONITORING", False)
+    monitoring_enabled = settings.FEATURES.get("ENABLE_MANAGEMENT_COMMAND_MONITORING", False)
     if not monitoring_enabled:
         yield
         return

--- a/openedx/core/djangoapps/util/management_monitoring.py
+++ b/openedx/core/djangoapps/util/management_monitoring.py
@@ -1,0 +1,143 @@
+"""Monitoring utilities for Django management commands."""
+
+import logging
+import time
+from contextlib import contextmanager
+
+from django.conf import settings
+from edx_django_utils.monitoring import function_trace, set_custom_attribute, set_monitoring_transaction_name
+from openedx_filters import PipelineStep
+
+log = logging.getLogger(__name__)
+
+
+class ManagementCommandMonitoringPipelineStep(PipelineStep):
+    """
+    Pipeline step that wraps management command execution with APM monitoring.
+
+    This step is invoked by the ManagementCommandExecutionRequested filter pipeline to wrap
+    the command_runner callable with monitoring context. When executed, the original command
+    runs within monitoring context that emits APM traces and custom Datadog attributes.
+    """
+
+    def run_filter(self, command_name, service_variant, command_runner):  # pylint: disable=arguments-differ
+        """
+        Decorate command runner with monitoring context.
+
+        Arguments:
+            command_name (str): Django management command being executed.
+            service_variant (str): Service variant (lms, cms, etc.).
+            command_runner (Callable): Executable that runs the management command.
+
+        Returns:
+            dict: Filter data with potentially wrapped command_runner.
+        """
+        if not callable(command_runner):
+            return {
+                "command_name": command_name,
+                "service_variant": service_variant,
+                "command_runner": command_runner,
+            }
+
+        def wrapped_runner() -> None:
+            with monitor_django_management_command(command_name=command_name, service_variant=service_variant):
+                command_runner()
+
+        return {
+            "command_name": command_name,
+            "service_variant": service_variant,
+            "command_runner": wrapped_runner,
+        }
+
+
+@contextmanager
+def monitor_django_management_command(command_name, service_variant='unknown'):
+    """
+    Context manager that monitors Django management command execution.
+
+    Emits Datadog APM traces and custom attributes tracking command execution,
+    performance, and failure information. When monitoring is disabled via settings,
+    this context manager is a no-op with minimal overhead.
+
+    Custom Attributes Emitted:
+        - management_command.name: Command name
+        - management_command.service_variant: Service (lms/cms/etc.)
+        - management_command.transaction_name: APM transaction name
+        - management_command.status: success/failure
+        - management_command.duration_seconds: Execution duration
+        - management_command.exception_class: Exception type (on failure)
+        - management_command.exit_code: Exit code (for SystemExit)
+
+    Arguments:
+        command_name (str): Django management command name.
+        service_variant (str): Service variant (default: 'unknown').
+
+    Yields:
+        None
+
+    Raises:
+        Any exception raised by the command under monitoring context.
+    """
+    monitoring_enabled = getattr(settings, "ENABLE_MANAGEMENT_COMMAND_MONITORING", False)
+    if not monitoring_enabled:
+        yield
+        return
+
+    trace_name = getattr(settings, "MANAGEMENT_COMMAND_MONITORING_TRACE_NAME", "django.management.command")
+    transaction_name = f"{service_variant}.management.{command_name}"
+
+    set_monitoring_transaction_name(transaction_name)
+    set_custom_attribute("management_command.name", command_name)
+    set_custom_attribute("management_command.service_variant", service_variant)
+    set_custom_attribute("management_command.transaction_name", transaction_name)
+
+    start_time = time.monotonic()
+    status = "failure"
+    try:
+        with function_trace(trace_name):
+            log.info(
+                "Management command started",
+                extra={
+                    "command": command_name,
+                    "service_variant": service_variant,
+                }
+            )
+            yield
+            status = "success"
+    except Exception as exc:
+        set_custom_attribute("management_command.exception_class", exc.__class__.__name__)
+        log.exception(
+            "Management command failed",
+            extra={
+                "command": command_name,
+                "service_variant": service_variant,
+                "exception_class": exc.__class__.__name__,
+            }
+        )
+        raise
+    except (SystemExit, KeyboardInterrupt) as exc:
+        set_custom_attribute("management_command.exception_class", exc.__class__.__name__)
+        if isinstance(exc, SystemExit):
+            set_custom_attribute("management_command.exit_code", exc.code)
+        log.error(
+            "Management command failed",
+            extra={
+                "command": command_name,
+                "service_variant": service_variant,
+                "exception_class": exc.__class__.__name__,
+            }
+        )
+        raise
+    finally:
+        duration_seconds = time.monotonic() - start_time
+        set_custom_attribute("management_command.status", status)
+        set_custom_attribute("management_command.duration_seconds", duration_seconds)
+        log.info(
+            "Management command completed",
+            extra={
+                "command": command_name,
+                "service_variant": service_variant,
+                "status": status,
+                "duration_seconds": duration_seconds,
+            }
+        )

--- a/openedx/core/djangoapps/util/tests/test_management_acceptance.py
+++ b/openedx/core/djangoapps/util/tests/test_management_acceptance.py
@@ -1,0 +1,270 @@
+"""
+Acceptance tests for management command monitoring feature.
+
+These tests verify that the management command monitoring system meets the core requirements:
+- Commands are routed through the filter pipeline
+- Monitoring attributes are tracked correctly
+- The system is toggleable via settings
+- edX can override default monitoring via custom pipeline steps
+"""
+
+from contextlib import nullcontext
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+from openedx.core.djangoapps.util.filters import ManagementCommandExecutionRequested
+from openedx.core.djangoapps.util.management_monitoring import (
+    ManagementCommandMonitoringPipelineStep,
+    monitor_django_management_command,
+)
+
+
+class ManagementCommandMonitoringAcceptanceTests(TestCase):
+    """
+    Acceptance tests verifying management command monitoring meets requirements.
+
+    Test Coverage:
+    - Filter pipeline integration and command routing
+    - Monitoring attribute collection (name, service_variant, status, duration, etc.)
+    - Monitoring toggle via ENABLE_MANAGEMENT_COMMAND_MONITORING setting
+    - Custom pipeline step support for edX extensions
+    """
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace", return_value=nullcontext())
+    def test_filter_passes_command_through_pipeline(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify the filter correctly passes command details to the pipeline.
+
+        The filter should extract command name and service variant, then pass them
+        through the openedx_filters pipeline for potential modification by pipeline steps.
+        """
+        mock_runner = MagicMock(return_value=None)
+
+        with override_settings(
+            OPEN_EDX_FILTERS_CONFIG={
+                'org.openedx.platform.management.command.execute.requested.v1': {
+                    'pipeline': [],
+                    'fail_silently': False,
+                }
+            }
+        ):
+            cmd_name, svc_variant, runner = ManagementCommandExecutionRequested.run_filter(
+                command_name='migrate',
+                service_variant='lms',
+                command_runner=mock_runner,
+            )
+
+        assert cmd_name == 'migrate'
+        assert svc_variant == 'lms'
+        assert callable(runner)
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace", return_value=nullcontext())
+    def test_monitoring_collects_required_attributes(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify all required Datadog custom attributes are set when monitoring is enabled.
+
+        Required attributes for Datadog integration:
+        - management_command.name: Command name
+        - management_command.service_variant: LMS/CMS or custom variant
+        - management_command.transaction_name: Transaction name for APM
+        - management_command.status: success/failure
+        - management_command.duration_seconds: Execution time
+        """
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with monitor_django_management_command('migrate', 'lms'):
+                pass
+
+        # Collect all attribute keys set
+        called_attrs = {call.args[0] for call in mock_attr.call_args_list}
+
+        required_attrs = {
+            'management_command.name',
+            'management_command.service_variant',
+            'management_command.transaction_name',
+            'management_command.status',
+            'management_command.duration_seconds',
+        }
+        assert required_attrs.issubset(called_attrs), f"Missing: {required_attrs - called_attrs}"
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    def test_monitoring_disabled_has_zero_overhead(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify that monitoring has zero APM overhead when disabled.
+
+        When ENABLE_MANAGEMENT_COMMAND_MONITORING=False, no monitoring functions
+        should be called, ensuring production deployments incur no overhead.
+        """
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=False):
+            with monitor_django_management_command('migrate', 'lms'):
+                pass
+
+        mock_trace.assert_not_called()
+        mock_txn.assert_not_called()
+        mock_attr.assert_not_called()
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace", return_value=nullcontext())
+    def test_lms_and_cms_service_variants_tracked_separately(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify LMS and CMS service variants are distinguished in monitoring.
+
+        Transaction names should reflect the service variant:
+        - LMS commands: lms.management.{command}
+        - CMS commands: cms.management.{command}
+        """
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with monitor_django_management_command('migrate', 'lms'):
+                pass
+
+        lms_txn_call = mock_txn.call_args_list[0]
+        assert 'lms.management.migrate' in str(lms_txn_call)
+
+        mock_txn.reset_mock()
+
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with monitor_django_management_command('shell', 'cms'):
+                pass
+
+        cms_txn_call = mock_txn.call_args_list[0]
+        assert 'cms.management.shell' in str(cms_txn_call)
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace", return_value=nullcontext())
+    def test_success_status_set_on_normal_completion(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify status is set to 'success' when command completes without exception.
+        """
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with monitor_django_management_command('migrate', 'lms'):
+                pass
+
+        status_calls = [
+            call.args for call in mock_attr.call_args_list
+            if call.args[0] == 'management_command.status'
+        ]
+        assert len(status_calls) == 1
+        assert status_calls[0][1] == 'success'
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace", return_value=nullcontext())
+    def test_failure_status_and_exception_tracked_on_error(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify status is 'failure' and exception class is captured when command fails.
+
+        Exception information is essential for diagnosing management command issues.
+        """
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with self.assertRaises(RuntimeError):
+                with monitor_django_management_command('migrate', 'lms'):
+                    raise RuntimeError("Database connection failed")
+
+        status_calls = [
+            call.args for call in mock_attr.call_args_list
+            if call.args[0] == 'management_command.status'
+        ]
+        assert status_calls[0][1] == 'failure'
+
+        exception_calls = [
+            call.args for call in mock_attr.call_args_list
+            if call.args[0] == 'management_command.exception_class'
+        ]
+        assert exception_calls[0][1] == 'RuntimeError'
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace", return_value=nullcontext())
+    def test_system_exit_exit_code_captured(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify SystemExit exit code is captured for debugging.
+
+        SystemExit is a special case in management commands and the exit code
+        provides important debugging information.
+        """
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with self.assertRaises(SystemExit):
+                with monitor_django_management_command('migrate', 'lms'):
+                    raise SystemExit(2)
+
+        exit_code_calls = [
+            call.args for call in mock_attr.call_args_list
+            if call.args[0] == 'management_command.exit_code'
+        ]
+        assert len(exit_code_calls) == 1
+        assert exit_code_calls[0][1] == 2
+
+    def test_custom_pipeline_step_support(self):
+        """
+        Verify edX can extend monitoring via custom pipeline steps.
+
+        The OPEN_EDX_FILTERS_CONFIG allows edX to replace the default monitoring
+        pipeline step with custom implementations for specialized observability needs.
+        """
+        mock_runner = MagicMock(return_value=None)
+
+        class CustomMonitoringPipelineStep(MagicMock):
+            """Example custom monitoring step that edX would implement."""
+            def run_filter(self, command_name, service_variant, command_runner):
+                # Custom logic: log to custom service, trigger alerts, etc.
+                return command_name, service_variant, command_runner
+
+        custom_step = CustomMonitoringPipelineStep()
+
+        # Verify custom step receives the command
+        cmd_name, svc_var, runner = custom_step.run_filter(
+            command_name='migrate',
+            service_variant='lms',
+            command_runner=mock_runner,
+        )
+
+        assert cmd_name == 'migrate'
+        assert svc_var == 'lms'
+        assert runner is mock_runner
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    def test_custom_trace_name_from_settings(self, mock_trace):
+        """
+        Verify custom APM trace names can be configured via settings.
+
+        MANAGEMENT_COMMAND_MONITORING_TRACE_NAME allows operators to customize
+        the APM transaction naming for integration with monitoring backends.
+        """
+        mock_trace.return_value = nullcontext()
+
+        with override_settings(
+            ENABLE_MANAGEMENT_COMMAND_MONITORING=True,
+            MANAGEMENT_COMMAND_MONITORING_TRACE_NAME='custom.trace.name',
+        ):
+            with monitor_django_management_command('migrate', 'lms'):
+                pass
+
+        mock_trace.assert_called_once_with('custom.trace.name')
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    def test_duration_is_numeric(self, mock_attr):
+        """
+        Verify duration is captured as a numeric float value in seconds.
+        """
+        with patch('openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name'):
+            with patch('openedx.core.djangoapps.util.management_monitoring.function_trace', return_value=nullcontext()):
+                with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+                    with monitor_django_management_command('migrate', 'lms'):
+                        pass
+
+        duration_calls = [
+            call.args for call in mock_attr.call_args_list
+            if call.args[0] == 'management_command.duration_seconds'
+        ]
+        assert len(duration_calls) == 1
+        assert isinstance(duration_calls[0][1], float)
+        assert duration_calls[0][1] >= 0.0

--- a/openedx/core/djangoapps/util/tests/test_management_acceptance.py
+++ b/openedx/core/djangoapps/util/tests/test_management_acceptance.py
@@ -16,7 +16,6 @@ from django.test import override_settings
 
 from openedx.core.djangoapps.util.filters import ManagementCommandExecutionRequested
 from openedx.core.djangoapps.util.management_monitoring import (
-    ManagementCommandMonitoringPipelineStep,
     monitor_django_management_command,
 )
 
@@ -28,7 +27,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
     Test Coverage:
     - Filter pipeline integration and command routing
     - Monitoring attribute collection (name, service_variant, status, duration, etc.)
-    - Monitoring toggle via ENABLE_MANAGEMENT_COMMAND_MONITORING setting
+    - Monitoring toggle via FEATURES['ENABLE_MANAGEMENT_COMMAND_MONITORING']
     - Custom pipeline step support for edX extensions
     """
 
@@ -76,7 +75,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
         - management_command.status: success/failure
         - management_command.duration_seconds: Execution time
         """
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with monitor_django_management_command('migrate', 'lms'):
                 pass
 
@@ -99,10 +98,10 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
         """
         Verify that monitoring has zero APM overhead when disabled.
 
-        When ENABLE_MANAGEMENT_COMMAND_MONITORING=False, no monitoring functions
+        When FEATURES['ENABLE_MANAGEMENT_COMMAND_MONITORING']=False, no monitoring functions
         should be called, ensuring production deployments incur no overhead.
         """
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=False):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': False}):
             with monitor_django_management_command('migrate', 'lms'):
                 pass
 
@@ -121,7 +120,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
         - LMS commands: lms.management.{command}
         - CMS commands: cms.management.{command}
         """
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with monitor_django_management_command('migrate', 'lms'):
                 pass
 
@@ -130,7 +129,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
 
         mock_txn.reset_mock()
 
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with monitor_django_management_command('shell', 'cms'):
                 pass
 
@@ -144,7 +143,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
         """
         Verify status is set to 'success' when command completes without exception.
         """
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with monitor_django_management_command('migrate', 'lms'):
                 pass
 
@@ -164,7 +163,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
 
         Exception information is essential for diagnosing management command issues.
         """
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with self.assertRaises(RuntimeError):
                 with monitor_django_management_command('migrate', 'lms'):
                     raise RuntimeError("Database connection failed")
@@ -191,7 +190,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
         SystemExit is a special case in management commands and the exit code
         provides important debugging information.
         """
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with self.assertRaises(SystemExit):
                 with monitor_django_management_command('migrate', 'lms'):
                     raise SystemExit(2)
@@ -242,7 +241,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
         mock_trace.return_value = nullcontext()
 
         with override_settings(
-            ENABLE_MANAGEMENT_COMMAND_MONITORING=True,
+            FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True},
             MANAGEMENT_COMMAND_MONITORING_TRACE_NAME='custom.trace.name',
         ):
             with monitor_django_management_command('migrate', 'lms'):
@@ -257,7 +256,7 @@ class ManagementCommandMonitoringAcceptanceTests(TestCase):
         """
         with patch('openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name'):
             with patch('openedx.core.djangoapps.util.management_monitoring.function_trace', return_value=nullcontext()):
-                with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+                with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
                     with monitor_django_management_command('migrate', 'lms'):
                         pass
 

--- a/openedx/core/djangoapps/util/tests/test_management_command_filters.py
+++ b/openedx/core/djangoapps/util/tests/test_management_command_filters.py
@@ -1,0 +1,117 @@
+"""Tests for management command execution filter and pipeline integration.
+
+Test Coverage:
+- Filter functionality and pipeline traversal
+- Pipeline step wrapping and decoration of command runners
+- Settings-based pipeline configuration
+"""
+
+from contextlib import nullcontext
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from django.test import override_settings
+from openedx_filters import PipelineStep
+
+from openedx.core.djangoapps.util.filters import ManagementCommandExecutionRequested
+from openedx.core.djangoapps.util.management_monitoring import ManagementCommandMonitoringPipelineStep
+
+
+class TestCommandRunnerDecoratorStep(PipelineStep):
+    """Test pipeline step used to verify filter-based command decoration."""
+
+    def run_filter(self, command_name, service_variant, command_runner):  # pylint: disable=arguments-differ
+        def wrapped_runner():
+            return command_runner()
+
+        return {
+            "command_name": command_name,
+            "service_variant": service_variant,
+            "command_runner": wrapped_runner,
+        }
+
+
+class ManagementCommandExecutionRequestedTests(TestCase):
+    """Tests for util management command execution filter."""
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    def test_run_filter_without_configuration(self):
+        """Filter returns original values when no pipeline is configured."""
+        command_runner = Mock()
+
+        command_name, service_variant, returned_runner = ManagementCommandExecutionRequested.run_filter(
+            command_name="migrate",
+            service_variant="lms",
+            command_runner=command_runner,
+        )
+
+        self.assertEqual(command_name, "migrate")
+        self.assertEqual(service_variant, "lms")
+        self.assertIs(returned_runner, command_runner)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.platform.management.command.execute.requested.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.util.tests.test_management_command_filters.TestCommandRunnerDecoratorStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_run_filter_with_pipeline_step(self):
+        """Filter applies configured pipeline step and returns wrapped runner."""
+        command_runner = Mock()
+
+        _, _, wrapped_runner = ManagementCommandExecutionRequested.run_filter(
+            command_name="migrate",
+            service_variant="lms",
+            command_runner=command_runner,
+        )
+
+        self.assertTrue(callable(wrapped_runner))
+        wrapped_runner()
+        command_runner.assert_called_once_with()
+
+
+class ManagementCommandMonitoringPipelineStepTests(TestCase):
+    """Tests for the default monitoring pipeline step."""
+
+    def setUp(self):
+        super().setUp()
+        self.step = ManagementCommandMonitoringPipelineStep(
+            filter_type="org.openedx.platform.management.command.execute.requested.v1",
+            running_pipeline=[
+                "openedx.core.djangoapps.util.management_monitoring.ManagementCommandMonitoringPipelineStep",
+            ],
+        )
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.monitor_django_management_command")
+    def test_step_wraps_callable_runner(self, mock_monitor_context):
+        """Step decorates callable command runner with monitoring context."""
+        mock_monitor_context.return_value = nullcontext()
+        command_runner = Mock()
+
+        result = self.step.run_filter(
+            command_name="shell",
+            service_variant="cms",
+            command_runner=command_runner,
+        )
+
+        wrapped_runner = result.get("command_runner")
+        self.assertTrue(callable(wrapped_runner))
+
+        wrapped_runner()
+
+        mock_monitor_context.assert_called_once_with(command_name="shell", service_variant="cms")
+        command_runner.assert_called_once_with()
+
+    def test_step_preserves_non_callable_runner(self):
+        """Step preserves runner when provided command_runner is not callable."""
+        result = self.step.run_filter(
+            command_name="help",
+            service_variant="lms",
+            command_runner=None,
+        )
+
+        self.assertIsNone(result.get("command_runner"))

--- a/openedx/core/djangoapps/util/tests/test_management_monitoring.py
+++ b/openedx/core/djangoapps/util/tests/test_management_monitoring.py
@@ -25,7 +25,7 @@ class ManagementCommandMonitoringTests(TestCase):
     @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
     def test_monitoring_disabled(self, mock_set_custom_attribute, mock_set_transaction_name, mock_function_trace):
         """No monitoring calls should be made when disabled."""
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=False):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': False}):
             with monitor_django_management_command("migrate", "lms"):
                 pass
 
@@ -45,7 +45,7 @@ class ManagementCommandMonitoringTests(TestCase):
         """Expected monitoring metadata is set during successful execution."""
         mock_function_trace.return_value = nullcontext()
 
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with monitor_django_management_command("migrate", "lms"):
                 pass
 
@@ -71,7 +71,7 @@ class ManagementCommandMonitoringTests(TestCase):
         mock_function_trace.return_value = nullcontext()
 
         with override_settings(
-            ENABLE_MANAGEMENT_COMMAND_MONITORING=True,
+            FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True},
             MANAGEMENT_COMMAND_MONITORING_TRACE_NAME="custom.management.trace",
         ):
             with monitor_django_management_command("shell", "cms"):
@@ -93,7 +93,7 @@ class ManagementCommandMonitoringTests(TestCase):
         """Failure metadata should be set when command raises an exception."""
         mock_function_trace.return_value = nullcontext()
 
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with self.assertRaises(ValueError):
                 with monitor_django_management_command("migrate", "lms"):
                     raise ValueError("boom")
@@ -115,7 +115,7 @@ class ManagementCommandMonitoringTests(TestCase):
         """SystemExit failures should include exit code custom attribute."""
         mock_function_trace.return_value = nullcontext()
 
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with self.assertRaises(SystemExit):
                 with monitor_django_management_command("migrate", "lms"):
                     raise SystemExit(2)

--- a/openedx/core/djangoapps/util/tests/test_management_monitoring.py
+++ b/openedx/core/djangoapps/util/tests/test_management_monitoring.py
@@ -1,0 +1,127 @@
+"""Tests for management command monitoring context manager and APM integration.
+
+Test Coverage:
+- Monitoring enabled/disabled states
+- Datadog custom attribute collection
+- APM trace wrapping
+- Exception and SystemExit handling
+- Configurable trace names
+"""
+
+from contextlib import nullcontext
+from unittest import TestCase
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from openedx.core.djangoapps.util.management_monitoring import monitor_django_management_command
+
+
+class ManagementCommandMonitoringTests(TestCase):
+    """Tests for management command monitoring helpers."""
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    def test_monitoring_disabled(self, mock_set_custom_attribute, mock_set_transaction_name, mock_function_trace):
+        """No monitoring calls should be made when disabled."""
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=False):
+            with monitor_django_management_command("migrate", "lms"):
+                pass
+
+        mock_function_trace.assert_not_called()
+        mock_set_transaction_name.assert_not_called()
+        mock_set_custom_attribute.assert_not_called()
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    def test_monitoring_enabled_success(
+        self,
+        mock_set_custom_attribute,
+        mock_set_transaction_name,
+        mock_function_trace,
+    ):
+        """Expected monitoring metadata is set during successful execution."""
+        mock_function_trace.return_value = nullcontext()
+
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with monitor_django_management_command("migrate", "lms"):
+                pass
+
+        mock_function_trace.assert_called_once_with("django.management.command")
+        mock_set_transaction_name.assert_called_once_with("lms.management.migrate")
+        mock_set_custom_attribute.assert_any_call("management_command.name", "migrate")
+        mock_set_custom_attribute.assert_any_call("management_command.service_variant", "lms")
+        mock_set_custom_attribute.assert_any_call("management_command.transaction_name", "lms.management.migrate")
+        mock_set_custom_attribute.assert_any_call("management_command.status", "success")
+
+        duration_calls = [
+            call_args for call_args in mock_set_custom_attribute.call_args_list
+            if call_args.args[0] == "management_command.duration_seconds"
+        ]
+        assert len(duration_calls) == 1
+        assert isinstance(duration_calls[0].args[1], float)
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    def test_custom_trace_name(self, mock_set_custom_attribute, mock_set_transaction_name, mock_function_trace):
+        """Custom trace name should be honored when configured."""
+        mock_function_trace.return_value = nullcontext()
+
+        with override_settings(
+            ENABLE_MANAGEMENT_COMMAND_MONITORING=True,
+            MANAGEMENT_COMMAND_MONITORING_TRACE_NAME="custom.management.trace",
+        ):
+            with monitor_django_management_command("shell", "cms"):
+                pass
+
+        mock_function_trace.assert_called_once_with("custom.management.trace")
+        mock_set_transaction_name.assert_called_once_with("cms.management.shell")
+        mock_set_custom_attribute.assert_any_call("management_command.status", "success")
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    def test_monitoring_enabled_failure(
+        self,
+        mock_set_custom_attribute,
+        mock_set_transaction_name,
+        mock_function_trace,
+    ):
+        """Failure metadata should be set when command raises an exception."""
+        mock_function_trace.return_value = nullcontext()
+
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with self.assertRaises(ValueError):
+                with monitor_django_management_command("migrate", "lms"):
+                    raise ValueError("boom")
+
+        mock_function_trace.assert_called_once_with("django.management.command")
+        mock_set_transaction_name.assert_called_once_with("lms.management.migrate")
+        mock_set_custom_attribute.assert_any_call("management_command.status", "failure")
+        mock_set_custom_attribute.assert_any_call("management_command.exception_class", "ValueError")
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    def test_monitoring_enabled_system_exit_failure(
+        self,
+        mock_set_custom_attribute,
+        mock_set_transaction_name,
+        mock_function_trace,
+    ):
+        """SystemExit failures should include exit code custom attribute."""
+        mock_function_trace.return_value = nullcontext()
+
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with self.assertRaises(SystemExit):
+                with monitor_django_management_command("migrate", "lms"):
+                    raise SystemExit(2)
+
+        mock_function_trace.assert_called_once_with("django.management.command")
+        mock_set_transaction_name.assert_called_once_with("lms.management.migrate")
+        mock_set_custom_attribute.assert_any_call("management_command.status", "failure")
+        mock_set_custom_attribute.assert_any_call("management_command.exception_class", "SystemExit")
+        mock_set_custom_attribute.assert_any_call("management_command.exit_code", 2)

--- a/openedx/core/djangoapps/util/tests/test_management_recommendations.py
+++ b/openedx/core/djangoapps/util/tests/test_management_recommendations.py
@@ -32,10 +32,10 @@ class ManagementCommandMonitoringBestPractices(TestCase):
         """
         Verify disabled monitoring adds minimal overhead.
 
-        When ENABLE_MANAGEMENT_COMMAND_MONITORING is False, the monitoring context
+        When FEATURES['ENABLE_MANAGEMENT_COMMAND_MONITORING'] is False, the monitoring context
         should be a no-op to avoid performance impact in production deployments.
         """
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=False):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': False}):
             with monitor_django_management_command('migrate', 'lms'):
                 pass
 
@@ -59,7 +59,7 @@ class ManagementCommandMonitoringBestPractices(TestCase):
         for variant in variants:
             mock_txn.reset_mock()
 
-            with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
                 with monitor_django_management_command('migrate', variant):
                     pass
 
@@ -76,7 +76,7 @@ class ManagementCommandMonitoringBestPractices(TestCase):
         KeyboardInterrupt should be treated as abnormal termination and marked as
         a failure in monitoring for proper alerting.
         """
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             with self.assertRaises(KeyboardInterrupt):
                 with monitor_django_management_command('migrate', 'lms'):
                     raise KeyboardInterrupt()
@@ -98,7 +98,7 @@ class ManagementCommandMonitoringBestPractices(TestCase):
         """
         mock_trace.return_value = nullcontext()
 
-        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+        with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
             # Don't set MANAGEMENT_COMMAND_MONITORING_TRACE_NAME
             with monitor_django_management_command('migrate', 'lms'):
                 pass
@@ -142,7 +142,7 @@ class ManagementCommandMonitoringBestPractices(TestCase):
         """
         with patch('openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name'):
             with patch('openedx.core.djangoapps.util.management_monitoring.function_trace', return_value=nullcontext()):
-                with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+                with override_settings(FEATURES={'ENABLE_MANAGEMENT_COMMAND_MONITORING': True}):
                     with monitor_django_management_command('migrate', 'lms'):
                         pass
 

--- a/openedx/core/djangoapps/util/tests/test_management_recommendations.py
+++ b/openedx/core/djangoapps/util/tests/test_management_recommendations.py
@@ -1,0 +1,182 @@
+"""
+Recommendation tests for management command monitoring best practices.
+
+These tests validate:
+- Performance characteristics (zero overhead when disabled)
+- Edge case handling
+- Best practices for custom pipeline step implementation
+- Configuration flexibility
+"""
+
+from contextlib import nullcontext
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+from openedx.core.djangoapps.util.filters import ManagementCommandExecutionRequested
+from openedx.core.djangoapps.util.management_monitoring import monitor_django_management_command
+
+
+class ManagementCommandMonitoringBestPractices(TestCase):
+    """
+    Best practice tests for management command monitoring.
+
+    These tests verify recommended patterns and edge case handling.
+    """
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    def test_disabled_monitoring_minimal_overhead(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify disabled monitoring adds minimal overhead.
+
+        When ENABLE_MANAGEMENT_COMMAND_MONITORING is False, the monitoring context
+        should be a no-op to avoid performance impact in production deployments.
+        """
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=False):
+            with monitor_django_management_command('migrate', 'lms'):
+                pass
+
+        # No monitoring functions should be called
+        mock_trace.assert_not_called()
+        mock_txn.assert_not_called()
+        mock_attr.assert_not_called()
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace", return_value=nullcontext())
+    def test_multiple_service_variants_supported(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify custom service variants beyond 'lms' and 'cms' are supported.
+
+        The monitoring system should work with any service variant name, enabling
+        configuration for discovery, ecommerce, notes, and other services.
+        """
+        variants = ['lms', 'cms', 'discovery', 'ecommerce', 'notes']
+
+        for variant in variants:
+            mock_txn.reset_mock()
+
+            with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+                with monitor_django_management_command('migrate', variant):
+                    pass
+
+            expected_txn = f'{variant}.management.migrate'
+            mock_txn.assert_called_with(expected_txn)
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name")
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace", return_value=nullcontext())
+    def test_keyboard_interrupt_tracked_properly(self, mock_trace, mock_txn, mock_attr):
+        """
+        Verify KeyboardInterrupt (Ctrl+C) is tracked as a failure.
+
+        KeyboardInterrupt should be treated as abnormal termination and marked as
+        a failure in monitoring for proper alerting.
+        """
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            with self.assertRaises(KeyboardInterrupt):
+                with monitor_django_management_command('migrate', 'lms'):
+                    raise KeyboardInterrupt()
+
+        # Verify failure was tracked
+        status_calls = [
+            call.args for call in mock_attr.call_args_list
+            if call.args[0] == 'management_command.status'
+        ]
+        assert status_calls[0][1] == 'failure'
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.function_trace")
+    def test_missing_trace_name_setting_uses_default(self, mock_trace):
+        """
+        Verify missing MANAGEMENT_COMMAND_MONITORING_TRACE_NAME uses default.
+
+        When the custom trace name setting is not provided, the default trace name
+        'django.management.command' should be used for consistency.
+        """
+        mock_trace.return_value = nullcontext()
+
+        with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+            # Don't set MANAGEMENT_COMMAND_MONITORING_TRACE_NAME
+            with monitor_django_management_command('migrate', 'lms'):
+                pass
+
+        mock_trace.assert_called_once_with('django.management.command')
+
+    def test_filter_always_returns_callable_runner(self):
+        """
+        Verify filter always returns a callable command runner.
+
+        The filter output should always be a 3-tuple with the third element being
+        callable, ensuring the manage.py flow can execute it as: runner()
+        """
+        mock_runner = MagicMock(return_value=None)
+
+        with override_settings(
+            OPEN_EDX_FILTERS_CONFIG={
+                'org.openedx.platform.management.command.execute.requested.v1': {
+                    'pipeline': [],
+                    'fail_silently': False,
+                }
+            }
+        ):
+            cmd_name, svc_variant, runner = ManagementCommandExecutionRequested.run_filter(
+                command_name='migrate',
+                service_variant='lms',
+                command_runner=mock_runner,
+            )
+
+        assert cmd_name == 'migrate'
+        assert svc_variant == 'lms'
+        assert callable(runner)
+
+    @patch("openedx.core.djangoapps.util.management_monitoring.set_custom_attribute")
+    def test_duration_calculation_is_accurate(self, mock_attr):
+        """
+        Verify duration calculation captures approximate execution time.
+
+        Duration should be reasonable and increasing with actual command execution
+        time, providing accurate performance metrics for Datadog.
+        """
+        with patch('openedx.core.djangoapps.util.management_monitoring.set_monitoring_transaction_name'):
+            with patch('openedx.core.djangoapps.util.management_monitoring.function_trace', return_value=nullcontext()):
+                with override_settings(ENABLE_MANAGEMENT_COMMAND_MONITORING=True):
+                    with monitor_django_management_command('migrate', 'lms'):
+                        pass
+
+        duration_calls = [
+            call.args for call in mock_attr.call_args_list
+            if call.args[0] == 'management_command.duration_seconds'
+        ]
+        assert len(duration_calls) == 1
+        duration = duration_calls[0][1]
+        assert isinstance(duration, float)
+        assert duration >= 0.0
+
+    def test_filter_fail_silently_behavior(self):
+        """
+        Verify filter respects fail_silently setting in pipeline configuration.
+
+        When fail_silently is True, pipeline errors should not prevent command
+        execution, ensuring monitoring failures don't break production deployments.
+        """
+        with override_settings(
+            OPEN_EDX_FILTERS_CONFIG={
+                'org.openedx.platform.management.command.execute.requested.v1': {
+                    'pipeline': [],
+                    'fail_silently': True,
+                }
+            }
+        ):
+            mock_runner = MagicMock(return_value=None)
+
+            # Should not raise even if pipeline had issues
+            cmd_name, svc_var, runner = ManagementCommandExecutionRequested.run_filter(
+                command_name='migrate',
+                service_variant='lms',
+                command_runner=mock_runner,
+            )
+
+            assert callable(runner)


### PR DESCRIPTION
**Summary**
Implements observability for Django management commands using the Open edX filters framework, enabling Datadog APM monitoring of command execution across all environments.

**Changes Made**
Modified manage.py to route all management commands through filter pipeline
Added ManagementCommandExecutionRequested filter in openedx/core/djangoapps/util/filters.py
Implemented monitoring context manager and pipeline step in openedx/core/djangoapps/util/management_monitoring.py
Added configuration settings in lms/envs/common.py and cms/envs/common.py
Created comprehensive test coverage (unit, acceptance, best practices)

**Monitoring Data Captured**
Command name and service variant (LMS/CMS)
Execution duration (seconds)
Success/failure status
Exception details and exit codes
Custom transaction naming for APM

**Configuration**
Toggle monitoring: FEATURES['ENABLE_MANAGEMENT_COMMAND_MONITORING']
Custom trace name: MANAGEMENT_COMMAND_MONITORING_TRACE_NAME
Extensible pipeline: OPEN_EDX_FILTERS_CONFIG



 **Ticket Reference** 
https://2u-internal.atlassian.net/browse/BOMS-151