### PR TITLE
feat: add components from Outline page

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -33,6 +33,7 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
     use_video_gallery_flow = serializers.SerializerMethodField()
     enable_course_optimizer_check_prev_run_links = serializers.SerializerMethodField()
     enable_unit_expanded_view = serializers.SerializerMethodField()
+    enable_outline_component_creation = serializers.SerializerMethodField()
 
     def get_course_key(self):
         """
@@ -184,3 +185,10 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         """
         course_key = self.get_course_key()
         return toggles.enable_unit_expanded_view(course_key)
+
+    def get_enable_outline_component_creation(self, obj):
+        """
+        Method to get the enable_outline_component_creation waffle flag
+        """
+        course_key = self.get_course_key()
+        return toggles.enable_outline_component_creation(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -39,6 +39,7 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         "use_video_gallery_flow": False,
         "enable_course_optimizer_check_prev_run_links": False,
         "enable_unit_expanded_view": False,
+        "enable_outline_component_creation": False,
     }
 
     def setUp(self):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/unit_handler.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/unit_handler.py
@@ -10,7 +10,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from cms.djangoapps.contentstore.rest_api.v1.mixins import ContainerHandlerMixin
-from cms.djangoapps.contentstore.views.component import get_component_templates
 from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -114,18 +113,10 @@ class UnitComponentsView(APIView, ContainerHandlerMixin):
                         log.warning(f"Child block not found: {child_usage_key}")
                         continue
 
-            # Fetch the course to get component templates available for this unit
-            course_key = usage_key.course_key
-            course = modulestore().get_course(course_key)
-            component_templates = []
-            if course:
-                component_templates = get_component_templates(course)
-
             response_data = {
                 "unit_id": str(usage_key),
                 "display_name": unit_xblock.display_name_with_default,
                 "components": components,
-                "component_templates": component_templates,
             }
 
             return Response(response_data)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/unit_handler.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/unit_handler.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from cms.djangoapps.contentstore.rest_api.v1.mixins import ContainerHandlerMixin
+from cms.djangoapps.contentstore.views.component import get_component_templates
 from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -113,10 +114,18 @@ class UnitComponentsView(APIView, ContainerHandlerMixin):
                         log.warning(f"Child block not found: {child_usage_key}")
                         continue
 
+            # Fetch the course to get component templates available for this unit
+            course_key = usage_key.course_key
+            course = modulestore().get_course(course_key)
+            component_templates = []
+            if course:
+                component_templates = get_component_templates(course)
+
             response_data = {
                 "unit_id": str(usage_key),
                 "display_name": unit_xblock.display_name_with_default,
                 "components": components,
+                "component_templates": component_templates,
             }
 
             return Response(response_data)

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -702,3 +702,25 @@ def enable_unit_expanded_view(course_key):
     Returns a boolean if the Unit Expanded View feature is enabled for the given course.
     """
     return ENABLE_UNIT_EXPANDED_VIEW.is_enabled(course_key)
+
+
+# .. toggle_name: contentstore.enable_outline_component_creation
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, the Add Component widget is displayed inside each
+# ..   expanded unit on the Course Outline page, allowing authors to add new XBlocks
+# ..   directly without navigating to the unit page.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-03-24
+# .. toggle_target_removal_date: 2026-09-24
+# .. toggle_tickets: TNL2-533
+ENABLE_OUTLINE_COMPONENT_CREATION = CourseWaffleFlag(
+    f"{CONTENTSTORE_NAMESPACE}.enable_outline_component_creation", __name__
+)
+
+
+def enable_outline_component_creation(course_key):
+    """
+    Returns a boolean if the Add Component in Outline feature is enabled for the given course.
+    """
+    return ENABLE_OUTLINE_COMPONENT_CREATION.is_enabled(course_key)


### PR DESCRIPTION
## Description

- Added new waffle flag `enable_outline_component_creation` to control feature rollout.
- Exposed the flag via course waffle flags API and updated tests.
- Updated `UnitComponentsView` to return available `component_templates`.

This allows authors to add components directly from the course outline page when the feature is enabled.

## Jira

- https://2u-internal.atlassian.net/browse/TNL2-533