### PR TITLE
fix: preserve angle bracket markup in discussion posts

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -2,7 +2,6 @@
 Discussion API serializers
 """
 
-import html
 import re
 from typing import Dict
 from urllib.parse import urlencode, urlunparse
@@ -165,7 +164,9 @@ def filter_spam_urls_from_html(html_string):
     Returns:
         clean_post, is_spam
     """
-    html_string = html.unescape(html_string)
+    # BeautifulSoup automatically handles HTML entities correctly.
+    # Do NOT call html.unescape() here as it breaks properly escaped content in code blocks
+    # (e.g., &lt;div&gt; inside <code> tags would become real <div> tags).
     soup = BeautifulSoup(html_string, "html.parser")
     patterns = []
     is_spam = False

--- a/lms/djangoapps/discussion/rest_api/tests/test_render.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_render.py
@@ -7,6 +7,7 @@ import ddt
 from django.test import TestCase
 
 from lms.djangoapps.discussion.rest_api.render import render_body
+from lms.djangoapps.discussion.rest_api.serializers import filter_spam_urls_from_html
 
 
 def _add_p_tags(raw_body):
@@ -103,3 +104,16 @@ class RenderBodyTest(TestCase):
             render_body('foo<i>bar<b>baz</i>quux</b>greg'),
             '<p>foo<i>bar<b>baz</b></i><b>quux</b>greg</p>',
         )
+
+    def test_full_pipeline_preserves_escaped_html_in_code(self):
+        """
+        Test that angle brackets in code blocks remain escaped after the full pipeline.
+        This prevents the regression where filter_spam_urls_from_html() would break
+        properly escaped content like `<div>` by converting &lt; back to <.
+        """
+        raw_body = '`<script>alert("xss")</script>`'
+        rendered = render_body(raw_body)
+        filtered, _ = filter_spam_urls_from_html(rendered)
+        # Angle brackets must remain escaped as HTML entities
+        assert '&lt;script&gt;' in filtered
+        assert '<script>' not in filtered


### PR DESCRIPTION
### Description
Angle bracket markup (e.g., < >) was being rendered as HTML upon submission, causing content to disappear or display incorrectly in discussion posts. While the content appeared correctly during authoring and preview, it was not
preserved after posting.
This issue affected both manually typed markup and content added via the "Insert/Edit Code Sample" toolbar option, making it difficult to share code snippets in programming-related discussions.
This fix ensures that angle brackets are properly escaped and preserved as plaintext, maintaining consistency between preview and final rendered posts.

### Ticket
[Cosmo2-791](https://2u-internal.atlassian.net/browse/COSMO2-791)