### PR TITLE
fix: add managemement command to filter hook

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -22,27 +22,37 @@ defuse_xml_libs()
 import os
 import sys
 from argparse import ArgumentParser
+from contextlib import nullcontext
 
 from openedx_filters.tooling import OpenEdxPublicFilter
 
 
-class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
+class ManagementCommandContextmanagerRequested(OpenEdxPublicFilter):
     """
     Filter triggered before a management command is executed.
+
+    Pipeline steps may provide a context manager to wrap command execution.
     """
 
-    filter_type = 'org.openedx.platform.management.command.execute.requested.v1'
+    filter_type = 'org.openedx.platform.management.command.contextmanager.requested.v1'
 
     @classmethod
-    def run_filter(cls, command_name, service_variant, command_runner):
+    def run_filter(cls, command_contextmanager, command_name, service_variant):
         """
-        Run the management command execution pipeline.
+        Run the management command context manager pipeline.
         """
-        return cls.run_pipeline(
+        pipeline_output = cls.run_pipeline(
+            command_contextmanager=command_contextmanager,
             command_name=command_name,
             service_variant=service_variant,
-            command_runner=command_runner,
         )
+
+        if isinstance(pipeline_output, dict):
+            contextmanager_result = pipeline_output.get('command_contextmanager', command_contextmanager)
+            if hasattr(contextmanager_result, '__enter__') and hasattr(contextmanager_result, '__exit__'):
+                return contextmanager_result
+
+        return command_contextmanager
 
 
 def parse_args():
@@ -120,21 +130,18 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
-    def command_runner():
-        return execute_from_command_line([sys.argv[0]] + django_args)
-
+    # django_args contains only the args that argparse did not consume.
+    # We treat the first non-option token as the Django command name.
+    # Example: django_args=['--verbosity', '2', 'migrate', '--noinput'] -> 'migrate'.
+    # If there is no non-option token (for example, django_args=['--help']),
+    # default to 'help' because Django will print command help in that case.
     command_name = next((arg for arg in django_args if not arg.startswith('-')), 'help')
 
-    pipeline_output = ManagementCommandExecutionRequested.run_filter(
+    command_contextmanager = ManagementCommandContextmanagerRequested.run_filter(
+        command_contextmanager=nullcontext(),
         command_name=command_name,
         service_variant=os.environ.get("SERVICE_VARIANT", edx_args.service_variant),
-        command_runner=command_runner,
     )
 
-    runner = command_runner
-    if isinstance(pipeline_output, dict):
-        runner = pipeline_output.get('command_runner', command_runner)
-    if not callable(runner):
-        runner = command_runner
-
-    runner()
+    with command_contextmanager:
+        execute_from_command_line([sys.argv[0]] + django_args)

--- a/manage.py
+++ b/manage.py
@@ -24,35 +24,7 @@ import sys
 from argparse import ArgumentParser
 from contextlib import nullcontext
 
-from openedx_filters.tooling import OpenEdxPublicFilter
-
-
-class ManagementCommandContextmanagerRequested(OpenEdxPublicFilter):
-    """
-    Filter triggered before a management command is executed.
-
-    Pipeline steps may provide a context manager to wrap command execution.
-    """
-
-    filter_type = 'org.openedx.platform.management.command.contextmanager.requested.v1'
-
-    @classmethod
-    def run_filter(cls, command_contextmanager, command_name, service_variant):
-        """
-        Run the management command context manager pipeline.
-        """
-        pipeline_output = cls.run_pipeline(
-            command_contextmanager=command_contextmanager,
-            command_name=command_name,
-            service_variant=service_variant,
-        )
-
-        if isinstance(pipeline_output, dict):
-            contextmanager_result = pipeline_output.get('command_contextmanager', command_contextmanager)
-            if hasattr(contextmanager_result, '__enter__') and hasattr(contextmanager_result, '__exit__'):
-                return contextmanager_result
-
-        return command_contextmanager
+from openedx_filters.management.filters import ManagementCommandContextmanagerRequested
 
 
 def parse_args():
@@ -130,14 +102,11 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
-    # django_args contains only args that argparse did not consume.
-    # Django treats the first positional token as the command name.
-    # Example: django_args=['migrate', '--noinput'] -> 'migrate'.
-    # If the first token is an option (for example, django_args=['--help']),
-    # default to 'help' so the filter sees a command-like label.
-    command_name = django_args[0] if django_args and not django_args[0].startswith('-') else 'help'
+    # First unconsumed argument is treated as the Django command name (e.g. 'migrate', 'runserver').
+    # Falls back to 'no-argument' if django_args is empty.
+    command_name = django_args[0] if django_args else 'no-argument'
 
-    command_contextmanager = ManagementCommandContextmanagerRequested.run_filter(
+    command_contextmanager, _, _ = ManagementCommandContextmanagerRequested.run_filter(
         command_contextmanager=nullcontext(),
         command_name=command_name,
         service_variant=os.environ.get("SERVICE_VARIANT", edx_args.service_variant),

--- a/manage.py
+++ b/manage.py
@@ -23,6 +23,14 @@ import os
 import sys
 from argparse import ArgumentParser
 
+from openedx_filters import OpenEdxPublicFilter
+
+
+class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
+    """Filter triggered before a management command is executed."""
+
+    FILTER_TYPE = 'org.openedx.platform.management.command.execute.requested.v1'
+
 
 def parse_args():
     """Parse edx specific arguments to manage.py"""
@@ -96,4 +104,22 @@ if __name__ == "__main__":
         django_args.append('--help')
 
     from django.core.management import execute_from_command_line
-    execute_from_command_line([sys.argv[0]] + django_args)
+
+    def command_runner():
+        return execute_from_command_line([sys.argv[0]] + django_args)
+
+    command_name = 'help'
+    if django_args and not django_args[0].startswith('-'):
+        command_name = django_args[0]
+
+    try:
+        pipeline_output = ManagementCommandExecutionRequested.run_filter(
+            command_name=command_name,
+            service_variant=os.environ.get("SERVICE_VARIANT", edx_args.service_variant),
+            command_runner=command_runner,
+        )
+        runner = pipeline_output.get('command_runner', command_runner)
+    except Exception:  # pylint: disable=broad-except
+        runner = command_runner
+
+    runner()

--- a/manage.py
+++ b/manage.py
@@ -23,13 +23,13 @@ import os
 import sys
 from argparse import ArgumentParser
 
-from openedx_filters import OpenEdxPublicFilter
+from openedx_filters.tooling import OpenEdxPublicFilter
 
 
 class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
     """Filter triggered before a management command is executed."""
 
-    FILTER_TYPE = 'org.openedx.platform.management.command.execute.requested.v1'
+    filter_type = 'org.openedx.platform.management.command.execute.requested.v1'
 
 
 def parse_args():

--- a/manage.py
+++ b/manage.py
@@ -27,13 +27,17 @@ from openedx_filters.tooling import OpenEdxPublicFilter
 
 
 class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
-    """Filter triggered before a management command is executed."""
+    """
+    Filter triggered before a management command is executed.
+    """
 
     filter_type = 'org.openedx.platform.management.command.execute.requested.v1'
 
     @classmethod
     def run_filter(cls, command_name, service_variant, command_runner):
-        """Run the management command execution pipeline."""
+        """
+        Run the management command execution pipeline.
+        """
         return cls.run_pipeline(
             command_name=command_name,
             service_variant=service_variant,
@@ -42,7 +46,9 @@ class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
 
 
 def parse_args():
-    """Parse edx specific arguments to manage.py"""
+    """
+    Parse edx specific arguments to manage.py
+    """
     parser = ArgumentParser()
     subparsers = parser.add_subparsers(title='system', description='edX service to run')
 

--- a/manage.py
+++ b/manage.py
@@ -123,18 +123,18 @@ if __name__ == "__main__":
     def command_runner():
         return execute_from_command_line([sys.argv[0]] + django_args)
 
-    command_name = 'help'
-    if django_args and not django_args[0].startswith('-'):
-        command_name = django_args[0]
+    command_name = next((arg for arg in django_args if not arg.startswith('-')), 'help')
 
-    try:
-        pipeline_output = ManagementCommandExecutionRequested.run_filter(
-            command_name=command_name,
-            service_variant=os.environ.get("SERVICE_VARIANT", edx_args.service_variant),
-            command_runner=command_runner,
-        )
+    pipeline_output = ManagementCommandExecutionRequested.run_filter(
+        command_name=command_name,
+        service_variant=os.environ.get("SERVICE_VARIANT", edx_args.service_variant),
+        command_runner=command_runner,
+    )
+
+    runner = command_runner
+    if isinstance(pipeline_output, dict):
         runner = pipeline_output.get('command_runner', command_runner)
-    except Exception:  # pylint: disable=broad-except
+    if not callable(runner):
         runner = command_runner
 
     runner()

--- a/manage.py
+++ b/manage.py
@@ -31,6 +31,15 @@ class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
 
     filter_type = 'org.openedx.platform.management.command.execute.requested.v1'
 
+    @classmethod
+    def run_filter(cls, command_name, service_variant, command_runner):
+        """Run the management command execution pipeline."""
+        return cls.run_pipeline(
+            command_name=command_name,
+            service_variant=service_variant,
+            command_runner=command_runner,
+        )
+
 
 def parse_args():
     """Parse edx specific arguments to manage.py"""

--- a/manage.py
+++ b/manage.py
@@ -24,7 +24,33 @@ import sys
 from argparse import ArgumentParser
 from contextlib import nullcontext
 
-from openedx_filters.management.filters import ManagementCommandContextmanagerRequested
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+
+class ManagementCommandContextmanagerRequested(OpenEdxPublicFilter):
+    """
+    Filter triggered before a management command is executed.
+
+    Pipeline steps may provide a context manager to wrap command execution.
+    """
+
+    filter_type = 'org.openedx.platform.management.command.contextmanager.requested.v1'
+
+    @classmethod
+    def run_filter(cls, command_contextmanager, command_name, service_variant):
+        """
+        Run the management command context manager pipeline.
+        """
+        data = super().run_pipeline(
+            command_contextmanager=command_contextmanager,
+            command_name=command_name,
+            service_variant=service_variant,
+        )
+        return (
+            data.get('command_contextmanager', command_contextmanager),
+            data.get('command_name', command_name),
+            data.get('service_variant', service_variant),
+        )
 
 
 def parse_args():

--- a/manage.py
+++ b/manage.py
@@ -130,12 +130,12 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
-    # django_args contains only the args that argparse did not consume.
-    # We treat the first non-option token as the Django command name.
-    # Example: django_args=['--verbosity', '2', 'migrate', '--noinput'] -> 'migrate'.
-    # If there is no non-option token (for example, django_args=['--help']),
-    # default to 'help' because Django will print command help in that case.
-    command_name = next((arg for arg in django_args if not arg.startswith('-')), 'help')
+    # django_args contains only args that argparse did not consume.
+    # Django treats the first positional token as the command name.
+    # Example: django_args=['migrate', '--noinput'] -> 'migrate'.
+    # If the first token is an option (for example, django_args=['--help']),
+    # default to 'help' so the filter sees a command-like label.
+    command_name = django_args[0] if django_args and not django_args[0].startswith('-') else 'help'
 
     command_contextmanager = ManagementCommandContextmanagerRequested.run_filter(
         command_contextmanager=nullcontext(),


### PR DESCRIPTION
# Description
Add a pluggable filter hook in manage.py so Django management command execution can be intercepted by configured Open edX filter pipelines. This keeps edx-platform limited to the public integration point and avoids embedding org-specific monitoring logic here

# Reference Ticket
https://2u-internal.atlassian.net/browse/BOMS-151