### PR TITLE
fix: improve mysql query performance in instructor dashboard

### DIFF
--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -204,12 +204,18 @@ class CourseEnrollmentManager(models.Manager):
         """
         max_enrollments = settings.FEATURES.get("MAX_ENROLLMENT_INSTR_BUTTONS")
 
-        enrollment_number = super().get_queryset().filter(
-            course_id=course_id,
-            is_active=1
-        )[:max_enrollments + 1].count()
+        # Fetch limited records without ordering (clears default ordering for performance).
+        # Calling .count() on a sliced queryset creates a slow subquery with ORDER BY.
+        # Instead, fetch the limited records and check the length.
+        enrollments = list(
+            super().get_queryset()
+            .filter(course_id=course_id, is_active=1)
+            .order_by()  # Clear default ordering - not needed for counting
+            .values_list('id', flat=True)  # Only fetch IDs, not full objects
+            [:max_enrollments + 1]
+        )
 
-        return enrollment_number <= max_enrollments
+        return len(enrollments) <= max_enrollments
 
     def num_enrolled_in_exclude_admins(self, course_id):
         """


### PR DESCRIPTION
# Description 

There is an issue as described in Jira ticket where the instructor page for a course shows 504, but the django request works well. 

Datadog shows that django request works :- ([Datadog link reference ](https://app.datadoghq.com/apm/trace/69cb942000000000afb9a9312c57343b?graphType=service_map&shouldShowLegend=true&spanID=13946074634333219970&spanViewType=databases&timeHint=1774949408997.472&trace=69cb942000000000afb9a9312c57343b1993394573801030982&traceQuery=))

The most likely cause of this is because a MySQL query is taking long to respond. This PR tries to fix it. 

Relevant slack thread :- https://twou.slack.com/archives/C04ACDVM6A1/p1773409936850749

# Jira ticket 
- https://2u-internal.atlassian.net/browse/COSMO2-809 