### PR TITLE
fix: add overflow scroll and sizing for video language selection

### DIFF
--- a/xmodule/js/src/video/09_video_caption.js
+++ b/xmodule/js/src/video/09_video_caption.js
@@ -732,6 +732,7 @@
 
                 this.scrollCaption();
                 this.setSubtitlesHeight();
+                this.setLanguageMenuMaxHeight();
             },
 
             /**
@@ -779,6 +780,8 @@
                     this.languageChooserEl,
                     HtmlUtils.HTML($menu)
                 );
+
+                this.setLanguageMenuMaxHeight();
 
                 $menu.on('click', '.control-lang', function(e) {
                     var el = $(e.currentTarget).parent(),
@@ -1455,6 +1458,17 @@
                 this.subtitlesEl.css({
                     maxHeight: this.captionHeight() - height
                 });
+            },
+
+            /**
+            * @desc Sets the max height of the language selection menu so it
+            *     cannot overflow the video player container.
+            *
+            */
+            setLanguageMenuMaxHeight: function() {
+                var controlsHeight = this.state.el.find('.video-controls').height() || 0;
+                var availableHeight = (this.captionHeight() - controlsHeight) * 0.9;
+                this.languageChooserEl.find('.menu').css('maxHeight', availableHeight);
             }
         };
 

--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -494,6 +494,8 @@
     box-shadow: none;
     background-color: #282c2e;
     list-style: none;
+    overflow-y: auto;
+    scrollbar-width: thin;
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .menu-container .menu li {


### PR DESCRIPTION

## Description

If there are too many transcript languages, the list can overflow and languages cannot be clickable by mouse users. This restricts the height of the bar to 90% of the video height and allows a scroll if it overflows.

## Testing instructions

Create a video, add as many transcripts as you can, and see that the list now scrolls.


## Video 

Ignore the fact that all the transcripts are in arabic - I just uploaded the same transcript file over and over again for my testing

https://github.com/user-attachments/assets/89957b0b-a7dd-46fa-baa6-8aa8907825a6

- [ ] Backported to teak
- [ ] Ported to openedx
