### PR TITLE
fix: add additional logging to course overview integrityerror

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -326,7 +326,7 @@ class CourseOverview(TimeStampedModel):
                         CourseOverviewImageSet.objects.filter(course_overview=course_overview).delete()
                         CourseOverviewImageSet.create(course_overview, course)
 
-                except IntegrityError:
+                except IntegrityError as e:
                     # There is a rare race condition that will occur if
                     # CourseOverview.get_from_id is called while a
                     # another identical overview is already in the process
@@ -336,9 +336,13 @@ class CourseOverview(TimeStampedModel):
                     # to save a duplicate.
                     # (see: https://openedx.atlassian.net/browse/TNL-2854).
                     log.info(
-                        "Multiple CourseOverviews for course %s requested "
-                        "simultaneously; will only save one.",
+                        (
+                            "IntegrityError when saving CourseOverview for course %s: %s. This is likely due to "
+                            "multiple CourseOverviews being requested simultaneously; will only save one."
+                        ),
                         course_id,
+                        e,
+                        exc_info=True
                     )
                 except Exception:
                     log.exception(

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -458,8 +458,10 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
                         # Make sure that tbe second call skips the cache and
                         # IntegrityError is triggered and handled gracefully
                         mock_log.info.assert_called_with(
-                            "Multiple CourseOverviews for course %s requested simultaneously; will only save one.",
-                            course.id
+                            "IntegrityError when saving CourseOverview for course %s: %s. This is likely due to "
+                            "multiple CourseOverviews being requested simultaneously; will only save one.",
+                            course.id,
+                            mock.ANY
                         )
 
     def test_course_overview_version_update(self):

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -461,7 +461,8 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
                             "IntegrityError when saving CourseOverview for course %s: %s. This is likely due to "
                             "multiple CourseOverviews being requested simultaneously; will only save one.",
                             course.id,
-                            mock.ANY
+                            mock.ANY,
+                            exc_info=True
                         )
 
     def test_course_overview_version_update(self):


### PR DESCRIPTION
We are encountering a course for which the CourseOverview refuses to save, for some reason.

Every method I can think to recreate the overview causes the "Multiple CourseOverviews for course %s requested" message to be logged, so I am assuming there is some sort of IntegrityError which is causing the CourseOverview to not save which is being suppressed by this race condition check