### PR TITLE
feat: implement bulk delete for MySQL database

### DIFF
--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1664,7 +1664,7 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
     def post(self, request, course_id):
         """
         Implements the delete user posts endpoint.
-        TODO: Add support for MySQLBackend as well
+        Supports both MongoDB and MySQL backends via forum API.
         """
         username = request.GET.get("username", None)
         execute_task = request.GET.get("execute", "false").lower() == "true"

--- a/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring,protected-access
 import logging
-import time
 
 from bs4 import BeautifulSoup
 
@@ -169,50 +168,24 @@ class Comment(models.Model):
     def get_user_comment_count(cls, user_id, course_ids):
         """
         Returns comments and responses count of user in the given course_ids.
-        TODO: Add support for MySQL backend as well
+        Uses forum_api to support both MongoDB and MySQL backends.
         """
-        query_params = {
-            "course_id": {"$in": course_ids},
-            "author_id": str(user_id),
-            "is_deleted": {"$ne": True},
-            "_type": "Comment",
-        }
-        return ForumComment()._collection.count_documents(
-            query_params
-        )  # pylint: disable=protected-access
+        return forum_api.get_user_comment_count(
+            user_id=str(user_id),
+            course_ids=course_ids
+        )
 
     @classmethod
     def delete_user_comments(cls, user_id, course_ids, deleted_by=None):
         """
         Deletes comments and responses of user in the given course_ids.
-        TODO: Add support for MySQL backend as well
+        Uses forum_api to support both MongoDB and MySQL backends.
         """
-        start_time = time.time()
-        query_params = {
-            "course_id": {"$in": course_ids},
-            "author_id": str(user_id),
-            "is_deleted": {"$ne": True},
-        }
-        comments_deleted = 0
-        comments = ForumComment().get_list(**query_params)
-        log.info(
-            f"<<Bulk Delete>> Fetched comments for user {user_id} in {time.time() - start_time} seconds"
+        return forum_api.delete_user_comments(
+            user_id=str(user_id),
+            course_ids=course_ids,
+            deleted_by=deleted_by
         )
-        for comment in comments:
-            start_time = time.time()
-            comment_id = comment.get("_id")
-            course_id = comment.get("course_id")
-            if comment_id:
-                # Use forum_api.delete_comment which supports deleted_by parameter
-                forum_api.delete_comment(  # pylint: disable=unexpected-keyword-arg
-                    comment_id, course_id=course_id, deleted_by=deleted_by
-                )
-                comments_deleted += 1
-            log.info(
-                f"<<Bulk Delete>> Deleted comment {comment_id} in {time.time() - start_time} seconds."
-                f" Comment Found: {comment_id is not None}"
-            )
-        return comments_deleted
 
     @classmethod
     def get_user_deleted_comment_count(cls, user_id, course_ids):

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -276,15 +276,12 @@ class Thread(models.Model):
     def get_user_threads_count(cls, user_id, course_ids):
         """
         Returns threads count of user in the given course_ids.
-        TODO: Add support for MySQL backend as well
+        Uses forum_api to support both MongoDB and MySQL backends.
         """
-        query_params = {
-            "course_id": {"$in": course_ids},
-            "author_id": str(user_id),
-            "is_deleted": {"$ne": True},
-            "_type": "CommentThread",
-        }
-        return ForumThread()._collection.count_documents(query_params)
+        return forum_api.get_user_threads_count(
+            user_id=str(user_id),
+            course_ids=course_ids
+        )
 
     @classmethod
     def _delete_thread(cls, thread_id, course_id=None, deleted_by=None):
@@ -353,31 +350,13 @@ class Thread(models.Model):
     def delete_user_threads(cls, user_id, course_ids, deleted_by=None):
         """
         Deletes threads of user in the given course_ids.
-        TODO: Add support for MySQL backend as well
+        Uses forum_api to support both MongoDB and MySQL backends.
         """
-        start_time = time.time()
-        query_params = {
-            "course_id": {"$in": course_ids},
-            "author_id": str(user_id),
-            "is_deleted": {"$ne": True},
-        }
-        threads_deleted = 0
-        threads = ForumThread().get_list(**query_params)
-        log.info(f"<<Bulk Delete>> Fetched threads for user {user_id} in {time.time() - start_time} seconds")
-        for thread in threads:
-            start_time = time.time()
-            thread_id = thread.get("_id")
-            course_id = thread.get("course_id")
-            if thread_id:
-                cls._delete_thread(
-                    thread_id, course_id=course_id, deleted_by=deleted_by
-                )
-                threads_deleted += 1
-            log.info(
-                f"<<Bulk Delete>> Deleted thread {thread_id} in {time.time() - start_time} seconds."
-                f" Thread Found: {thread_id is not None}"
-            )
-        return threads_deleted
+        return forum_api.delete_user_threads(
+            user_id=str(user_id),
+            course_ids=course_ids,
+            deleted_by=deleted_by
+        )
 
     @classmethod
     def get_user_deleted_threads_count(cls, user_id, course_ids):


### PR DESCRIPTION
### **Description**
Bulk delete functionality is currently implemented only for the MongoDB backend, while the corresponding implementation for the MySQL backend is still pending. As part of the migration from MongoDB to MySQL, it is essential to implement bulk delete support in the MySQL backend to ensure feature parity and consistent behavior across both systems.

**Ticket:**
[COSMO2-885](https://2u-internal.atlassian.net/browse/COSMO2-885)

**Related PR**
https://github.com/edx/forum/pull/23