### PR TITLE
fix: prevent entrance exam minimum from being set to None

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -268,7 +268,7 @@ class CourseOverview(TimeStampedModel):
         # it to be a float like everything else.
         if isinstance(course.entrance_exam_minimum_score_pct, int):
             course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct / 100
-        else:
+        elif course.entrance_exam_minimum_score_pct is not None:
             course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct
 
         course_overview.force_on_flexible_peer_openassessments = course.force_on_flexible_peer_openassessments

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -6,6 +6,7 @@ import os
 from io import BytesIO
 from unittest import mock
 
+from cms.djangoapps.contentstore.views import course
 import pytest
 import datetime  # lint-amnesty, pylint: disable=wrong-import-order
 import itertools  # lint-amnesty, pylint: disable=wrong-import-order
@@ -624,6 +625,16 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
 
         CourseOverview.load_from_module_store(course_key)
         assert CourseOverview.objects.filter(id=course_key).exists()
+
+    def test_null_entrance_exam_minimum_score(self):
+        """
+        Tests that course overview can be created when entrance_exam_minimum_score is null.
+        """
+        course = CourseFactory.create()
+        course.entrance_exam_minimum_score_pct = None
+        course_overview = CourseOverview._create_or_update(course)  # pylint: disable=protected-access
+        assert course_overview.entrance_exam_minimum_score_pct == \
+            CourseOverview.entrance_exam_minimum_score_pct.field.default
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -6,7 +6,6 @@ import os
 from io import BytesIO
 from unittest import mock
 
-from cms.djangoapps.contentstore.views import course
 import pytest
 import datetime  # lint-amnesty, pylint: disable=wrong-import-order
 import itertools  # lint-amnesty, pylint: disable=wrong-import-order


### PR DESCRIPTION
A course is not loading because there is an integrityerror on saving the courseoverview.

It appears that the error is that entrance_exam_minimum_score_pct is being set to None on the model which is invalid. I'm not 100% sure why this field is being set on the course at all and I don't see any way to get it unset on the course so I'm adding in a protection here to prevent the field from being set to None at all. The field has defaults that match the xblock field defaults, so this is fine to do.