### PR TITLE
fix: prevent None entrance_exam_minimum_score_pct from breaking Cours…

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -501,7 +501,11 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         course = modulestore().get_course(self.course.id)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(course.entrance_exam_enabled)
-        self.assertEqual(course.entrance_exam_minimum_score_pct, None)
+        entrance_exam_minimum_score_pct = float(settings.ENTRANCE_EXAM_MIN_SCORE_PCT)
+        if entrance_exam_minimum_score_pct.is_integer():
+            entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct / 100
+
+        self.assertEqual(course.entrance_exam_minimum_score_pct, entrance_exam_minimum_score_pct)
 
         self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
                          msg='The entrance exam should not be required anymore')

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -224,7 +224,7 @@ def _delete_entrance_exam(request, course_key):
     if course.entrance_exam_id:
         metadata = {
             'entrance_exam_enabled': False,
-            'entrance_exam_minimum_score_pct': None,
+            'entrance_exam_minimum_score_pct': _get_default_entrance_exam_minimum_pct(),
             'entrance_exam_id': None,
         }
         CourseMetadata.update_from_dict(metadata, course, request.user)

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -266,10 +266,20 @@ class CourseOverview(TimeStampedModel):
         course_overview.entrance_exam_id = course.entrance_exam_id or ''
         # Despite it being a float, the course object defaults to an int. So we will detect that case and update
         # it to be a float like everything else.
-        if isinstance(course.entrance_exam_minimum_score_pct, int):
-            course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct / 100
-        elif course.entrance_exam_minimum_score_pct is not None:
-            course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct
+        # Extra handling: entrance_exam_minimum_score_pct can be None (e.g. when exams are disabled in Studio),
+        # so we fall back to settings.ENTRANCE_EXAM_MIN_SCORE_PCT to prevent CourseOverview save failures.
+        if course.entrance_exam_minimum_score_pct is None:
+            entrance_exam_minimum_score_pct = float(settings.ENTRANCE_EXAM_MIN_SCORE_PCT)
+        else:
+            entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct
+
+        if (
+            isinstance(entrance_exam_minimum_score_pct, int)
+            or (isinstance(entrance_exam_minimum_score_pct, float) and entrance_exam_minimum_score_pct.is_integer())
+        ):
+            entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct / 100
+
+        course_overview.entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct
 
         course_overview.force_on_flexible_peer_openassessments = course.force_on_flexible_peer_openassessments
 

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -625,6 +625,7 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
         CourseOverview.load_from_module_store(course_key)
         assert CourseOverview.objects.filter(id=course_key).exists()
 
+    @override_settings(ENTRANCE_EXAM_MIN_SCORE_PCT=0.5)
     def test_null_entrance_exam_minimum_score(self):
         """
         Tests that course overview can be created when entrance_exam_minimum_score is null.
@@ -632,8 +633,7 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
         course = CourseFactory.create()
         course.entrance_exam_minimum_score_pct = None
         course_overview = CourseOverview._create_or_update(course)  # pylint: disable=protected-access
-        assert course_overview.entrance_exam_minimum_score_pct == \
-            CourseOverview.entrance_exam_minimum_score_pct.field.default
+        assert course_overview.entrance_exam_minimum_score_pct == 0.5
 
 
 @ddt.ddt


### PR DESCRIPTION
I made this fix in https://github.com/edx/edx-platform/pull/219 and went to cherry pick it over to openedx just to see that they had already made this fix. I'm overwriting my change with theirs for the sake of preventing an eventual merge conflict