### PR TITLE
SSO/logistration: lazy‑load third_party_auth_context to break import cycle

### DIFF
--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -25,7 +25,6 @@ from openedx.core.djangoapps.geoinfo.api import country_code_from_ip
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.core.djangoapps.user_authn.views.utils import third_party_auth_context
 from ipware import get_client_ip
 
 ENTERPRISE_HEADER_LINKS = WaffleFlag('enterprise.enterprise_header_links', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
@@ -508,6 +507,9 @@ def get_mfe_context(request, redirect_to, tpa_hint=None):
     """
     # Import enterprise functions INSIDE the function to avoid circular import
     from openedx.features.enterprise_support.api import enterprise_customer_for_request
+    # Importing third_party_auth_context here to avoid circular import since it imports get_mfe_context
+    from openedx.core.djangoapps.user_authn.views.utils import third_party_auth_context
+
 
     ip_address = get_client_ip(request)[0]
     country_code = country_code_from_ip(ip_address)

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -510,7 +510,6 @@ def get_mfe_context(request, redirect_to, tpa_hint=None):
     # Importing third_party_auth_context here to avoid circular import since it imports get_mfe_context
     from openedx.core.djangoapps.user_authn.views.utils import third_party_auth_context
 
-
     ip_address = get_client_ip(request)[0]
     country_code = country_code_from_ip(ip_address)
     context = third_party_auth_context(request, redirect_to, tpa_hint)


### PR DESCRIPTION
**PR Description**
This PR fixes a circular import issue affecting enterprise SSO/authn context generation.

**Problem**

- openedx/features/enterprise_support/utils.py imported third_party_auth_context at module load time from openedx/core/djangoapps/user_authn/views/utils.py.
- That authn utils module also depends on enterprise utilities, creating a circular import path in certain load orders.
- 

**Root Cause**
A top-level cross-module import between enterprise_support.utils and user_authn.views.utils caused Python to initialize partially loaded modules, which can break org-name/SSO context resolution flows.

**Fix**
- Removed the top-level import of third_party_auth_context from enterprise_support.utils.
- Added a function-scoped import inside get_mfe_context():
- from openedx.core.djangoapps.user_authn.views.utils import third_party_auth_context
- This preserves existing behavior while deferring the import until runtime, avoiding circular module initialization.
- 

**Why this is safe**
- No functional logic changes to auth flow, provider selection, or enterprise branding payload.
- Same helper is used with the same arguments; only import timing changed.
- Pattern is consistent with existing lazy imports in enterprise/authn code for circular dependency prevention.

**Impact**
- Prevents circular import failures in enterprise-authn context assembly.
- Reduces risk of intermittent SSO login context issues related to module import order.
- No API contract changes.

**Testing / Validation**
- Verified get_mfe_context() still builds:
- third_party_auth_context
- countryCode
- enterpriseBranding (when enterprise customer is present)

**Suggested regression checks:**
- Enterprise login page load with org flow
- TPA hinted login (tpa_hint) flow
- Non-enterprise login flow
- Authn MFE context endpoint response shape unchanged

**JIRA**
https://2u-internal.atlassian.net/browse/AUT-112