### PR TITLE
fix: centralize authn MFE branding and remove duplicate context

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/utils.py
+++ b/openedx/core/djangoapps/user_authn/views/utils.py
@@ -114,32 +114,21 @@ def third_party_auth_context(request, redirect_to, tpa_hint=None):
 
 
 def get_mfe_context(request, redirect_to, tpa_hint=None):
-    """
-    Returns Authn MFE context.
-    """
+    """Return Authn MFE context including enterprise branding and country code."""
     # Import enterprise functions INSIDE the function to avoid circular import
     from openedx.features.enterprise_support.api import enterprise_customer_for_request
-    from openedx.features.enterprise_support.utils import get_enterprise_sidebar_context
+    from openedx.features.enterprise_support.utils import build_enterprise_branding_for_authn_mfe
 
     ip_address = get_client_ip(request)[0]
     country_code = country_code_from_ip(ip_address)
     context = third_party_auth_context(request, redirect_to, tpa_hint)
-    # Add enterprise branding if enterprise customer is detected
+
     enterprise_customer = enterprise_customer_for_request(request)
-    enterprise_branding = None
-    if enterprise_customer:
-        sidebar_context = get_enterprise_sidebar_context(enterprise_customer, is_proxy_login=False)
-        if sidebar_context:
-            enterprise_branding = {
-                'enterpriseName': sidebar_context.get('enterprise_name'),
-                'enterpriseLogoUrl': sidebar_context.get('enterprise_logo_url'),
-                'enterpriseBrandedWelcomeString': str(sidebar_context.get('enterprise_branded_welcome_string', '')),
-                'platformWelcomeString': str(sidebar_context.get('platform_welcome_string', '')),
-                'enterpriseSlug': sidebar_context.get('enterprise_slug') or enterprise_customer.get('slug'),
-            }
+    enterprise_branding = build_enterprise_branding_for_authn_mfe(enterprise_customer)
+
     context.update({
         'countryCode': country_code,
-        'enterpriseBranding': enterprise_branding,  # Add enterprise branding to context
+        'enterpriseBranding': enterprise_branding,
     })
     return context
 

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -30,6 +30,7 @@ from openedx.features.enterprise_support.tests.factories import (
 from openedx.features.enterprise_support.utils import (
     ENTERPRISE_HEADER_LINKS,
     _user_has_social_auth_record,
+    build_enterprise_branding_for_authn_mfe,
     clear_data_consent_share_cache,
     enterprise_fields_only,
     fetch_enterprise_customer_by_id,
@@ -169,6 +170,52 @@ class TestEnterpriseUtils(TestCase):
         expected_logo_url = branding_configuration.get('logo', '')
         assert expected_logo_url == actual_result['enterprise_logo_url']
         assert 'pied-piper' in str(actual_result['enterprise_branded_welcome_string'])
+
+    def test_build_enterprise_branding_for_authn_mfe_without_customer(self):
+        assert build_enterprise_branding_for_authn_mfe(None) is None
+
+    @mock.patch('openedx.features.enterprise_support.utils.get_enterprise_sidebar_context')
+    def test_build_enterprise_branding_for_authn_mfe(self, mock_sidebar_context):
+        enterprise_customer = {
+            'name': 'pied-piper',
+            'slug': 'pied-piper-slug',
+        }
+        mock_sidebar_context.return_value = {
+            'enterprise_name': 'pied-piper',
+            'enterprise_logo_url': 'https://example.com/logo.png',
+            'enterprise_branded_welcome_string': 'Welcome to Pied Piper',
+            'platform_welcome_string': 'Welcome to Open edX',
+            'enterprise_slug': 'sidebar-slug',
+        }
+
+        actual_result = build_enterprise_branding_for_authn_mfe(enterprise_customer)
+
+        assert actual_result == {
+            'enterpriseName': 'pied-piper',
+            'enterpriseLogoUrl': 'https://example.com/logo.png',
+            'enterpriseBrandedWelcomeString': 'Welcome to Pied Piper',
+            'platformWelcomeString': 'Welcome to Open edX',
+            'enterpriseSlug': 'sidebar-slug',
+        }
+        mock_sidebar_context.assert_called_once_with(enterprise_customer, is_proxy_login=False)
+
+    @mock.patch('openedx.features.enterprise_support.utils.get_enterprise_sidebar_context')
+    def test_build_enterprise_branding_for_authn_mfe_falls_back_to_customer_slug(self, mock_sidebar_context):
+        enterprise_customer = {
+            'name': 'pied-piper',
+            'slug': 'customer-slug',
+        }
+        mock_sidebar_context.return_value = {
+            'enterprise_name': 'pied-piper',
+            'enterprise_logo_url': '',
+            'enterprise_branded_welcome_string': 'Welcome to Pied Piper',
+            'platform_welcome_string': 'Welcome to Open edX',
+            'enterprise_slug': None,
+        }
+
+        actual_result = build_enterprise_branding_for_authn_mfe(enterprise_customer)
+
+        assert actual_result['enterpriseSlug'] == 'customer-slug'
 
     @ddt.data(
         ('notfoundpage', 0),

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -25,7 +25,6 @@ from openedx.core.djangoapps.geoinfo.api import country_code_from_ip
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.core.djangoapps.user_authn.views.utils import third_party_auth_context
 from ipware import get_client_ip
 
 ENTERPRISE_HEADER_LINKS = WaffleFlag('enterprise.enterprise_header_links', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
@@ -149,6 +148,39 @@ def get_enterprise_sidebar_context(enterprise_customer, is_proxy_login):
         'enterprise_branded_welcome_string': branded_welcome_string,
         'enterprise_slug': enterprise_customer.get('slug'),
         'platform_welcome_string': platform_welcome_string,
+    }
+
+
+def build_enterprise_branding_for_authn_mfe(enterprise_customer):
+    """Build the enterpriseBranding payload for Authn MFE context.
+
+    Args:
+        enterprise_customer (dict): Serialized enterprise customer for the request.
+
+    Returns:
+        dict or None: Branding fields for the MFE, or None if there is no
+        customer or no sidebar context to expose.
+    """
+    if not enterprise_customer:
+        return None
+
+    sidebar_context = get_enterprise_sidebar_context(
+        enterprise_customer,
+        is_proxy_login=False,
+    )
+    if not sidebar_context:
+        return None
+
+    return {
+        'enterpriseName': sidebar_context.get('enterprise_name'),
+        'enterpriseLogoUrl': sidebar_context.get('enterprise_logo_url'),
+        'enterpriseBrandedWelcomeString': str(
+            sidebar_context.get('enterprise_branded_welcome_string', '')
+        ),
+        'platformWelcomeString': str(
+            sidebar_context.get('platform_welcome_string', '')
+        ),
+        'enterpriseSlug': sidebar_context.get('enterprise_slug') or enterprise_customer.get('slug'),
     }
 
 
@@ -500,42 +532,3 @@ def get_enterprise_dashboard_url(request, enterprise_customer):
     """
     base_url = settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
     return f"{base_url}/{enterprise_customer['slug']}"
-
-
-def get_mfe_context(request, redirect_to, tpa_hint=None):
-    """
-    Returns Authn MFE context.
-    """
-    # Import enterprise functions INSIDE the function to avoid circular import
-    from openedx.features.enterprise_support.api import enterprise_customer_for_request
-
-    ip_address = get_client_ip(request)[0]
-    country_code = country_code_from_ip(ip_address)
-    context = third_party_auth_context(request, redirect_to, tpa_hint)
-
-    enterprise_customer = enterprise_customer_for_request(request)
-    enterprise_branding = None
-
-    if enterprise_customer:
-        sidebar_context = get_enterprise_sidebar_context(
-            enterprise_customer,
-            is_proxy_login=False
-        )
-        if sidebar_context:
-            enterprise_branding = {
-                'enterpriseName': sidebar_context.get('enterprise_name'),
-                'enterpriseLogoUrl': sidebar_context.get('enterprise_logo_url'),
-                'enterpriseBrandedWelcomeString': str(
-                    sidebar_context.get('enterprise_branded_welcome_string', '')
-                ),
-                'platformWelcomeString': str(
-                    sidebar_context.get('platform_welcome_string', '')
-                ),
-            }
-
-    context.update({
-        'countryCode': country_code,
-        'enterpriseBranding': enterprise_branding,
-    })
-
-    return context

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -21,11 +21,9 @@ from social_django.models import UserSocialAuth
 from common.djangoapps import third_party_auth
 from common.djangoapps.student.helpers import get_next_url_for_login_page
 from lms.djangoapps.branding.api import get_privacy_url
-from openedx.core.djangoapps.geoinfo.api import country_code_from_ip
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
 from openedx.core.djangolib.markup import HTML, Text
-from ipware import get_client_ip
 
 ENTERPRISE_HEADER_LINKS = WaffleFlag('enterprise.enterprise_header_links', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
@@ -159,7 +157,7 @@ def build_enterprise_branding_for_authn_mfe(enterprise_customer):
 
     Returns:
         dict or None: Branding fields for the MFE, or None if there is no
-        customer or no sidebar context to expose.
+        customer.
     """
     if not enterprise_customer:
         return None
@@ -168,8 +166,6 @@ def build_enterprise_branding_for_authn_mfe(enterprise_customer):
         enterprise_customer,
         is_proxy_login=False,
     )
-    if not sidebar_context:
-        return None
 
     return {
         'enterpriseName': sidebar_context.get('enterprise_name'),


### PR DESCRIPTION
## PR Description

This PR fixes the circular import risk affecting enterprise SSO/Authn MFE context generation by removing duplicate MFE context logic and centralizing enterprise branding assembly.

## Problem

The enterprise and authn utility modules had overlapping responsibility for building Authn MFE context. That duplication created a fragile import relationship between:

- utils.py
- utils.py

In some load paths, that increased the risk of circular imports and partial module initialization, which could affect enterprise SSO/org-name resolution.

## Fix

- Removed the duplicate `get_mfe_context` implementation from utils.py
- Kept a single canonical `get_mfe_context` in utils.py
- Added a focused helper in enterprise support utils to build the `enterpriseBranding` payload
- Updated the authn `get_mfe_context` to call that helper via a function-scoped import

## Why This Is Safe

- No change to the Authn MFE response contract
- No change to provider selection or auth flow behavior
- Enterprise branding fields are still populated from the same sidebar context
- `enterpriseSlug` is still included in `enterpriseBranding`
- This change reduces duplication and removes the circular-import entrypoint

## Validation

Verified that:
- only one `get_mfe_context` remains in the codebase
- the Authn MFE API still uses the canonical authn implementation
- enterprise branding data is still present when an enterprise customer is resolved

##Testing

- Enterprise login page load with org flow
- TPA hinted login flow
- Non-enterprise login flow
- Authn MFE context endpoint response shape unchanged

## JIRA

https://2u-internal.atlassian.net/browse/AUT-112