### PR TITLE
fix: handle Elasticsearch failures in teams module

### DIFF
--- a/lms/djangoapps/teams/search_indexes.py
+++ b/lms/djangoapps/teams/search_indexes.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils import translation
-from elasticsearch.exceptions import ConnectionError  # lint-amnesty, pylint: disable=redefined-builtin
+from elasticsearch.exceptions import ConnectionError, TransportError  # lint-amnesty, pylint: disable=redefined-builtin
 from search.search_engine_base import SearchEngine
 
 from lms.djangoapps.teams.models import CourseTeam
@@ -141,8 +141,8 @@ def course_team_post_save_callback(**kwargs):
     """
     try:
         CourseTeamIndexer.index(kwargs['instance'])
-    except ElasticSearchConnectionError:
-        pass
+    except (ElasticSearchConnectionError, TransportError):
+        logging.exception('Failed to index team %s in Elasticsearch', kwargs['instance'].team_id)
 
 
 @receiver(post_delete, sender=CourseTeam, dispatch_uid='teams.signals.course_team_post_delete_callback')
@@ -152,5 +152,5 @@ def course_team_post_delete_callback(**kwargs):
     """
     try:
         CourseTeamIndexer.remove(kwargs['instance'])
-    except ElasticSearchConnectionError:
-        pass
+    except (ElasticSearchConnectionError, TransportError):
+        logging.exception('Failed to remove team %s from Elasticsearch', kwargs['instance'].team_id)

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -18,7 +18,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models.signals import post_save
 from django.urls import reverse
 from django.utils import translation
-from elasticsearch.exceptions import ConnectionError  # lint-amnesty, pylint: disable=redefined-builtin
+from elasticsearch.exceptions import ConnectionError, TransportError  # lint-amnesty, pylint: disable=redefined-builtin
 from rest_framework.test import APIClient, APITestCase
 from search.search_engine_base import SearchEngine
 
@@ -2808,6 +2808,23 @@ class TestElasticSearchErrors(TeamAPITestCase):
             data={'description': 'new description'},
             user='staff'
         )
+
+    def test_list_teams_search_failure(self):
+        """Test that search() failures return a 503 when Elasticsearch query fails.
+
+        This test covers failures that occur during the actual search operation,
+        not just during engine initialization (which is covered by test_list_teams).
+        """
+        search_error = TransportError(500, 'internal server error', {})
+        with patch.object(SearchEngine, 'get_search_engine') as mock_get_engine:
+            mock_engine = mock_get_engine.return_value
+            mock_engine.search.side_effect = search_error
+
+            self.get_teams_list(
+                expected_status=503,
+                data={'course_id': str(self.test_course_1.id), 'text_search': 'engineering'},
+                user='staff'
+            )
 
 
 @ddt.ddt

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -17,6 +17,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_noop
 from django_countries import countries
+from elasticsearch.exceptions import TransportError
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from edx_rest_framework_extensions.paginators import DefaultPagination, paginate_search_results
 from opaque_keys import InvalidKeyError
@@ -467,21 +468,20 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
             })
 
         if text_search and CourseTeamIndexer.search_is_enabled():
+            result_filter.update({'course_id': course_id_string})
             try:
                 search_engine = CourseTeamIndexer.engine()
-            except ElasticSearchConnectionError:
+                search_results = search_engine.search(
+                    query_string=text_search,
+                    field_dictionary=result_filter,
+                    size=MAXIMUM_SEARCH_SIZE,
+                )
+            except (ElasticSearchConnectionError, TransportError):
+                log.exception('Elasticsearch error for team search in course %s', course_id_string)
                 return Response(
                     build_api_error(gettext_noop('Error connecting to elasticsearch')),
                     status=status.HTTP_503_SERVICE_UNAVAILABLE
                 )
-
-            result_filter.update({'course_id': course_id_string})
-
-            search_results = search_engine.search(
-                query_string=text_search,
-                field_dictionary=result_filter,
-                size=MAXIMUM_SEARCH_SIZE,
-            )
 
             # We need to manually exclude some potential private_managed teams from results, because
             # it doesn't appear that the search supports "field__in" style lookups


### PR DESCRIPTION
### Description

Handles Elasticsearch failures gracefully in the teams module to prevent 500 errors.
Returns a safe response when search operations fail due to ES issues.
Improves logging to help debug production errors.
