### PR TITLE
feat: add phase 1 Datadog instrumentation for thread creation

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -21,7 +21,7 @@ from django.db.models import Q
 from django.http import Http404
 from django.urls import reverse
 from django.utils.html import strip_tags
-from edx_django_utils.monitoring import function_trace
+from edx_django_utils.monitoring import function_trace, set_custom_attribute
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseKey
 from pytz import UTC
@@ -1905,6 +1905,7 @@ def create_thread(request, thread_data):
         )
     serializer.save()
     cc_thread = serializer.instance
+    set_custom_attribute("forum.entity_id", str(cc_thread.id))
     # Use send_signal_after_commit() to ensure the signal is sent only after the transaction commits.
     send_signal_after_commit(
         lambda: thread_created.send(sender=None, user=user, post=cc_thread, notify_all_learners=notify_all_learners)

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -11,6 +11,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import BadRequest, ValidationError
 from django.shortcuts import get_object_or_404
 from drf_yasg import openapi
+from edx_django_utils.monitoring import set_custom_attribute
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import (
     SessionAuthenticationAllowInactiveUser,
@@ -118,6 +119,22 @@ from .utils import (
 log = logging.getLogger(__name__)
 
 User = get_user_model()
+
+def _discussion_error_type(exc):
+    """Map common discussion exceptions to a stable Datadog error type."""
+    if isinstance(exc, PermissionError):
+        return "permission_denied"
+    if isinstance(exc, PermissionDenied):
+        return "permission_denied"
+    if isinstance(exc, InvalidKeyError):
+        return "validation_error"
+    if isinstance(exc, ValidationError):
+        return "validation_error"
+    if isinstance(exc, ParseError):
+        return "validation_error"
+    if isinstance(exc, UnsupportedMediaType):
+        return "validation_error"
+    return "backend_error"
 
 
 @view_auth_classes()
@@ -713,12 +730,30 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
         Implements the POST method for the list endpoint as described in the
         class docstring.
         """
+        set_custom_attribute("forum.operation", "thread.create")
+        set_custom_attribute("forum.course_id", request.data.get("course_id", ""))
+        set_custom_attribute("forum.entity_type", "thread")
+        set_custom_attribute("forum.actor_id", str(getattr(request.user, "id", "")))
+
+        if request.data.get("type"):
+            set_custom_attribute("forum.thread_type", request.data.get("type"))
+        if request.data.get("topic_id"):
+            set_custom_attribute("forum.commentable_id", request.data.get("topic_id"))
+        if request.data.get("group_id") is not None:
+            set_custom_attribute("forum.group_id", str(request.data.get("group_id")))
+
+        try:
         if not request.data.get("course_id"):
             raise ValidationError({"course_id": ["This field is required."]})
         course_key_str = request.data.get("course_id")
         course_key = CourseKey.from_string(course_key_str)
 
         if is_content_creation_rate_limited(request, course_key=course_key):
+            set_custom_attribute("forum.result", "error")
+            set_custom_attribute(
+                    "forum.http_status", str(status.HTTP_429_TOO_MANY_REQUESTS)
+            )
+            set_custom_attribute("forum.error_type", "rate_limited")
             return Response(
                 "Too many requests", status=status.HTTP_429_TOO_MANY_REQUESTS
             )
@@ -729,7 +764,15 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
                 raise ValidationError({"captcha_token": "This field is required."})
 
             if not verify_recaptcha_token(captcha_token):
-                return Response({"error": "CAPTCHA verification failed."}, status=400)
+                set_custom_attribute("forum.result", "error")
+                set_custom_attribute(
+                    "forum.http_status", str(status.HTTP_400_BAD_REQUEST)
+                )
+                set_custom_attribute("forum.error_type", "validation_error")
+                return Response(
+                    {"error": "CAPTCHA verification failed."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         if (
             ONLY_VERIFIED_USERS_CAN_POST.is_enabled(course_key)
@@ -741,7 +784,15 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
 
         data = request.data.copy()
         data.pop("captcha_token", None)
-        return Response(create_thread(request, data))
+        response = Response(create_thread(request, data))
+        set_custom_attribute("forum.result", "success")
+        set_custom_attribute("forum.http_status", str(response.status_code))
+        return response
+    except Exception as exc:
+        set_custom_attribute("forum.result", "error")
+        set_custom_attribute("forum.http_status", str(status.HTTP_400_BAD_REQUEST))
+        set_custom_attribute("forum.error_type", _discussion_error_type(exc))
+        raise
 
     def partial_update(self, request, thread_id):
         """

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -19,7 +19,11 @@ from edx_rest_framework_extensions.auth.session.authentication import (
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions, status
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.exceptions import ParseError, UnsupportedMediaType
+from rest_framework.exceptions import (
+    ParseError,
+    PermissionDenied,
+    UnsupportedMediaType,
+)
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -743,56 +743,58 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
             set_custom_attribute("forum.group_id", str(request.data.get("group_id")))
 
         try:
-        if not request.data.get("course_id"):
-            raise ValidationError({"course_id": ["This field is required."]})
-        course_key_str = request.data.get("course_id")
-        course_key = CourseKey.from_string(course_key_str)
+            if not request.data.get("course_id"):
+                raise ValidationError({"course_id": ["This field is required."]})
+            course_key_str = request.data.get("course_id")
+            course_key = CourseKey.from_string(course_key_str)
 
-        if is_content_creation_rate_limited(request, course_key=course_key):
-            set_custom_attribute("forum.result", "error")
-            set_custom_attribute(
-                    "forum.http_status", str(status.HTTP_429_TOO_MANY_REQUESTS)
-            )
-            set_custom_attribute("forum.error_type", "rate_limited")
-            return Response(
-                "Too many requests", status=status.HTTP_429_TOO_MANY_REQUESTS
-            )
-
-        if is_captcha_enabled(course_key) and is_only_student(course_key, request.user):
-            captcha_token = request.data.get("captcha_token")
-            if not captcha_token:
-                raise ValidationError({"captcha_token": "This field is required."})
-
-            if not verify_recaptcha_token(captcha_token):
+            if is_content_creation_rate_limited(request, course_key=course_key):
                 set_custom_attribute("forum.result", "error")
                 set_custom_attribute(
-                    "forum.http_status", str(status.HTTP_400_BAD_REQUEST)
+                    "forum.http_status", str(status.HTTP_429_TOO_MANY_REQUESTS)
                 )
-                set_custom_attribute("forum.error_type", "validation_error")
+                set_custom_attribute("forum.error_type", "rate_limited")
                 return Response(
-                    {"error": "CAPTCHA verification failed."},
-                    status=status.HTTP_400_BAD_REQUEST,
+                    "Too many requests", status=status.HTTP_429_TOO_MANY_REQUESTS
                 )
 
-        if (
-            ONLY_VERIFIED_USERS_CAN_POST.is_enabled(course_key)
-            and not request.user.is_active
-        ):
-            raise ValidationError(
-                {"detail": "Only verified users can post in discussions."}
-            )
+            if is_captcha_enabled(course_key) and is_only_student(
+                course_key, request.user
+            ):
+                captcha_token = request.data.get("captcha_token")
+                if not captcha_token:
+                    raise ValidationError({"captcha_token": "This field is required."})
 
-        data = request.data.copy()
-        data.pop("captcha_token", None)
-        response = Response(create_thread(request, data))
-        set_custom_attribute("forum.result", "success")
-        set_custom_attribute("forum.http_status", str(response.status_code))
-        return response
-    except Exception as exc:
-        set_custom_attribute("forum.result", "error")
-        set_custom_attribute("forum.http_status", str(status.HTTP_400_BAD_REQUEST))
-        set_custom_attribute("forum.error_type", _discussion_error_type(exc))
-        raise
+                if not verify_recaptcha_token(captcha_token):
+                    set_custom_attribute("forum.result", "error")
+                    set_custom_attribute(
+                        "forum.http_status", str(status.HTTP_400_BAD_REQUEST)
+                    )
+                    set_custom_attribute("forum.error_type", "validation_error")
+                    return Response(
+                        {"error": "CAPTCHA verification failed."},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+            if (
+                ONLY_VERIFIED_USERS_CAN_POST.is_enabled(course_key)
+                and not request.user.is_active
+            ):
+                raise ValidationError(
+                    {"detail": "Only verified users can post in discussions."}
+                )
+
+            data = request.data.copy()
+            data.pop("captcha_token", None)
+            response = Response(create_thread(request, data))
+            set_custom_attribute("forum.result", "success")
+            set_custom_attribute("forum.http_status", str(response.status_code))
+            return response
+        except Exception as exc:
+            set_custom_attribute("forum.result", "error")
+            set_custom_attribute("forum.http_status", str(status.HTTP_400_BAD_REQUEST))
+            set_custom_attribute("forum.error_type", _discussion_error_type(exc))
+            raise
 
     def partial_update(self, request, thread_id):
         """

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -120,6 +120,7 @@ log = logging.getLogger(__name__)
 
 User = get_user_model()
 
+
 def _discussion_error_type(exc):
     """Map common discussion exceptions to a stable Datadog error type."""
     if isinstance(exc, PermissionError):


### PR DESCRIPTION
## Summary

This PR adds Phase 1 Datadog instrumentation for the thread creation flow in LMS discussion APIs.

The goal of this phase is to validate one clean end-to-end vertical slice before expanding instrumentation to other discussion APIs.

## What Changed

- added request-level telemetry for `POST /api/discussion/v1/threads`
- emits canonical attributes for the thread creation flow:
  - `forum.operation`
  - `forum.course_id`
  - `forum.entity_type`
  - `forum.actor_id`
  - `forum.result`
  - `forum.http_status`
- emits contextual attributes when present:
  - `forum.thread_type`
  - `forum.commentable_id`
  - `forum.group_id`
- emits `forum.entity_id` after thread creation succeeds
- added simple error classification for discussion request failures

## Why

For the current discussion flow, the request starts in `edx-platform`, so request-level instrumentation needs to be emitted here.

## Scope

This PR is intentionally limited to Phase 1 only.

Covered in this phase:
- thread creation flow

## Validation

This change is expected to be validated in stage together with the paired `forum` and `edx-internal` updates.

Expected Datadog outcomes:
- `@forum.operation:thread.create`
- `forum.result` on success and error paths
- `forum.entity_id` on successful thread creation

## Related

- Ticket: `COSMO2-853`
