### PR TITLE
fix: correct XML serialization of empty upstream field

### DIFF
--- a/cms/lib/xblock/upstream_sync.py
+++ b/cms/lib/xblock/upstream_sync.py
@@ -37,6 +37,13 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _UpstreamKeyString(String):
+    """
+    A String field variant that never serializes a None value as an XML child element.
+    """
+    none_to_xml = False
+
+
 class UpstreamLinkException(Exception):
     """
     Raised whenever we try to inspect, sync-from, fetch-from, or delete a block's link to upstream content.
@@ -433,7 +440,7 @@ class UpstreamSyncMixin(XBlockMixin):
     """
 
     # Upstream synchronization metadata fields
-    upstream = String(
+    upstream = _UpstreamKeyString(
         help=(
             "The usage key or container key of the source block/container (generally within a content library) "
             "which serves as a source of upstream updates for this block, or None if there is no such upstream. "


### PR DESCRIPTION
**Description:** Fixes an import/export issue where None values in the upstream field were serialized as empty XML elements.

**Change:**
- Introduced `_UpstreamKeyString` with `none_to_xml = False`
- Updated upstream field to use this custom class

**Impact:**
- Prevents invalid upstream references during import, fixing issues where XBlocks (e.g., drag-and-drop) fail to load after export/import.

**Jira:** https://2u-internal.atlassian.net/browse/TNL2-508