### PR TITLE
fix: enforce RTL in courseware chromeless iframe (AU-2863)

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -59,6 +59,36 @@ ${static.get_page_title_breadcrumbs(course_name())}
   var $$course_id = "${course.id | n, js_escaped_string}";
 </script>
 
+<style id="courseware-rtl-style">
+  html[dir="rtl"] #course-content,
+  html[dir="rtl"] #main {
+    direction: rtl !important;
+    text-align: start !important;
+  }
+
+  html[dir="rtl"] #main p,
+  html[dir="rtl"] #main div,
+  html[dir="rtl"] #main span,
+  html[dir="rtl"] #main li,
+  html[dir="rtl"] #main h1,
+  html[dir="rtl"] #main h2,
+  html[dir="rtl"] #main h3,
+  html[dir="rtl"] #main h4,
+  html[dir="rtl"] #main h5,
+  html[dir="rtl"] #main h6 {
+    direction: rtl !important;
+    text-align: start !important;
+  }
+
+  html[dir="rtl"] #main ul,
+  html[dir="rtl"] #main ol {
+    direction: rtl !important;
+    text-align: start !important;
+    padding-inline-start: 1.5em !important;
+    padding-inline-end: 0 !important;
+  }
+</style>
+
 <script type="text/javascript">
   (function () {
     // Keep LMS unit content direction aligned with learner language preference.
@@ -76,6 +106,14 @@ ${static.get_page_title_breadcrumbs(course_name())}
       return '';
     }
 
+    function normalizeLanguageCode(languageCode) {
+      if (!languageCode) {
+        return '';
+      }
+      // Normalize to BCP 47: trim whitespace and convert underscores to hyphens
+      return String(languageCode).trim().replace(/_/g, '-');
+    }
+
     function isRtlLanguage(languageCode) {
       if (!languageCode) {
         return false;
@@ -89,19 +127,23 @@ ${static.get_page_title_breadcrumbs(course_name())}
       return false;
     }
 
-    var languageCode =
+    var languageCode = normalizeLanguageCode(
       getCookieValue('openedx-language-preference') ||
       getCookieValue('django_language') ||
-      getCookieValue('prod-edx-language-preference');
+      getCookieValue('prod-edx-language-preference')
+    );
 
     if (!isRtlLanguage(languageCode)) {
       return;
     }
 
-    function applyRtlDirection() {
-      document.documentElement.setAttribute('dir', 'rtl');
-      document.documentElement.setAttribute('lang', languageCode);
+    // Apply dir/lang to documentElement immediately to prevent LTR→RTL flash
+    // This runs synchronously in the head before first paint
+    document.documentElement.setAttribute('dir', 'rtl');
+    document.documentElement.setAttribute('lang', languageCode);
 
+    function applyRtlToBody() {
+      // Apply RTL to body and content elements once they exist
       if (document.body) {
         document.body.setAttribute('dir', 'rtl');
       }
@@ -109,56 +151,19 @@ ${static.get_page_title_breadcrumbs(course_name())}
       var courseContent = document.getElementById('course-content');
       if (courseContent) {
         courseContent.setAttribute('dir', 'rtl');
-        courseContent.style.direction = 'rtl';
-        courseContent.style.textAlign = 'right';
       }
 
       var mainContent = document.getElementById('main');
       if (mainContent) {
         mainContent.setAttribute('dir', 'rtl');
         mainContent.setAttribute('lang', languageCode);
-        mainContent.style.direction = 'rtl';
-        mainContent.style.textAlign = 'right';
-      }
-
-      var rtlStyle = document.getElementById('courseware-rtl-style');
-      if (!rtlStyle) {
-        rtlStyle = document.createElement('style');
-        rtlStyle.id = 'courseware-rtl-style';
-        rtlStyle.textContent = ''
-          + 'html[dir="rtl"] #course-content,'
-          + 'html[dir="rtl"] #main {'
-          + 'direction: rtl !important;'
-          + 'text-align: right !important;'
-          + '}'
-          + 'html[dir="rtl"] #main p,'
-          + 'html[dir="rtl"] #main div,'
-          + 'html[dir="rtl"] #main span,'
-          + 'html[dir="rtl"] #main li,'
-          + 'html[dir="rtl"] #main h1,'
-          + 'html[dir="rtl"] #main h2,'
-          + 'html[dir="rtl"] #main h3,'
-          + 'html[dir="rtl"] #main h4,'
-          + 'html[dir="rtl"] #main h5,'
-          + 'html[dir="rtl"] #main h6 {'
-          + 'direction: rtl !important;'
-          + 'text-align: right !important;'
-          + '}'
-          + 'html[dir="rtl"] #main ul,'
-          + 'html[dir="rtl"] #main ol {'
-          + 'direction: rtl !important;'
-          + 'text-align: right !important;'
-          + 'padding-right: 1.5em !important;'
-          + 'padding-left: 0 !important;'
-          + '}';
-        document.head.appendChild(rtlStyle);
       }
     }
 
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', applyRtlDirection);
+      document.addEventListener('DOMContentLoaded', applyRtlToBody);
     } else {
-      applyRtlDirection();
+      applyRtlToBody();
     }
   }());
 </script>

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -59,6 +59,110 @@ ${static.get_page_title_breadcrumbs(course_name())}
   var $$course_id = "${course.id | n, js_escaped_string}";
 </script>
 
+<script type="text/javascript">
+  (function () {
+    // Keep LMS unit content direction aligned with learner language preference.
+    var rtlPrefixes = ['ar', 'fa', 'he', 'ur'];
+
+    function getCookieValue(name) {
+      var cookieString = document.cookie || '';
+      var cookies = cookieString ? cookieString.split(';') : [];
+      for (var i = 0; i < cookies.length; i++) {
+        var cookie = cookies[i].trim();
+        if (cookie.indexOf(name + '=') === 0) {
+          return decodeURIComponent(cookie.slice(name.length + 1));
+        }
+      }
+      return '';
+    }
+
+    function isRtlLanguage(languageCode) {
+      if (!languageCode) {
+        return false;
+      }
+      var normalized = String(languageCode).toLowerCase();
+      for (var i = 0; i < rtlPrefixes.length; i++) {
+        if (normalized.indexOf(rtlPrefixes[i]) === 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    var languageCode =
+      getCookieValue('openedx-language-preference') ||
+      getCookieValue('django_language') ||
+      getCookieValue('prod-edx-language-preference');
+
+    if (!isRtlLanguage(languageCode)) {
+      return;
+    }
+
+    function applyRtlDirection() {
+      document.documentElement.setAttribute('dir', 'rtl');
+      document.documentElement.setAttribute('lang', languageCode);
+
+      if (document.body) {
+        document.body.setAttribute('dir', 'rtl');
+      }
+
+      var courseContent = document.getElementById('course-content');
+      if (courseContent) {
+        courseContent.setAttribute('dir', 'rtl');
+        courseContent.style.direction = 'rtl';
+        courseContent.style.textAlign = 'right';
+      }
+
+      var mainContent = document.getElementById('main');
+      if (mainContent) {
+        mainContent.setAttribute('dir', 'rtl');
+        mainContent.setAttribute('lang', languageCode);
+        mainContent.style.direction = 'rtl';
+        mainContent.style.textAlign = 'right';
+      }
+
+      var rtlStyle = document.getElementById('courseware-rtl-style');
+      if (!rtlStyle) {
+        rtlStyle = document.createElement('style');
+        rtlStyle.id = 'courseware-rtl-style';
+        rtlStyle.textContent = ''
+          + 'html[dir="rtl"] #course-content,'
+          + 'html[dir="rtl"] #main {'
+          + 'direction: rtl !important;'
+          + 'text-align: right !important;'
+          + '}'
+          + 'html[dir="rtl"] #main p,'
+          + 'html[dir="rtl"] #main div,'
+          + 'html[dir="rtl"] #main span,'
+          + 'html[dir="rtl"] #main li,'
+          + 'html[dir="rtl"] #main h1,'
+          + 'html[dir="rtl"] #main h2,'
+          + 'html[dir="rtl"] #main h3,'
+          + 'html[dir="rtl"] #main h4,'
+          + 'html[dir="rtl"] #main h5,'
+          + 'html[dir="rtl"] #main h6 {'
+          + 'direction: rtl !important;'
+          + 'text-align: right !important;'
+          + '}'
+          + 'html[dir="rtl"] #main ul,'
+          + 'html[dir="rtl"] #main ol {'
+          + 'direction: rtl !important;'
+          + 'text-align: right !important;'
+          + 'padding-right: 1.5em !important;'
+          + 'padding-left: 0 !important;'
+          + '}';
+        document.head.appendChild(rtlStyle);
+      }
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', applyRtlDirection);
+    } else {
+      applyRtlDirection();
+    }
+  }());
+</script>
+
 </%block>
 
 <%block name="js_extra">

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -63,7 +63,7 @@ ${static.get_page_title_breadcrumbs(course_name())}
   html[dir="rtl"] #course-content,
   html[dir="rtl"] #main {
     direction: rtl !important;
-    text-align: start !important;
+    text-align: right !important;
   }
 
   html[dir="rtl"] #main p,
@@ -77,13 +77,13 @@ ${static.get_page_title_breadcrumbs(course_name())}
   html[dir="rtl"] #main h5,
   html[dir="rtl"] #main h6 {
     direction: rtl !important;
-    text-align: start !important;
+    text-align: right !important;
   }
 
   html[dir="rtl"] #main ul,
   html[dir="rtl"] #main ol {
     direction: rtl !important;
-    text-align: start !important;
+    text-align: right !important;
     padding-inline-start: 1.5em !important;
     padding-inline-end: 0 !important;
   }


### PR DESCRIPTION
## Summary
Fixes AU-2863 by enforcing RTL direction in LMS courseware chromeless content when learner language is RTL (for example Arabic).

## Problem
In LMS courseware (chromeless iframe context), Arabic content could render left-to-right even when learner language preference is RTL.

## Root Cause
The chromeless courseware iframe is a separate document context and did not consistently apply RTL direction from learner language cookies.

## What Changed
Updated `lms/templates/courseware/courseware-chromeless.html` to add an RTL bootstrap script that:

- Reads learner language from cookies:
  - `openedx-language-preference`
  - `django_language`
  - `prod-edx-language-preference`
- Detects RTL locales by prefix (`ar`, `fa`, `he`, `ur`)
- Applies RTL attributes/styles to iframe document/content containers:
  - `html` (`dir`, `lang`)
  - `body` (`dir`)
  - `#course-content` (`dir`, `direction`, `text-align`)
  - `#main` (`dir`, `lang`, `direction`, `text-align`)
- Injects scoped CSS for content elements in RTL mode (paragraphs/headings/lists)
- Runs on `DOMContentLoaded` (or immediately if DOM already loaded)

## Scope
- Only `courseware-chromeless.html` is changed.
- No API/database changes.
- No impact on non-RTL languages.

## Validation
- Verified locally with Arabic learner preference:
  - Course unit content renders RTL in LMS iframe
  - Text alignment and list layout are corrected for RTL content

## Ticket
- AU-2863