### PR TITLE
feat: add telemetry for bulk discussion user post workflows

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tasks.py
@@ -6,7 +6,7 @@ import logging
 
 from celery import shared_task
 from django.contrib.auth import get_user_model
-from edx_django_utils.monitoring import set_code_owner_attribute
+from edx_django_utils.monitoring import set_code_owner_attribute, set_custom_attribute
 from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey
 
@@ -145,6 +145,14 @@ def delete_course_post_for_user(  # pylint: disable=too-many-statements
         reason: Ban reason (NEW)
     """
     event_data = event_data or {}
+    if event_data.get("course_key"):
+        set_custom_attribute("forum.operation", "bulk_delete_user_posts.execute")
+        set_custom_attribute("forum.entity_type", "user")
+        set_custom_attribute("forum.entity_id", str(user_id or ""))
+        set_custom_attribute("forum.actor_id", str(event_data.get("triggered_by_user_id", "")))
+        set_custom_attribute("forum.course_id", str(event_data.get("course_key", "")))
+        set_custom_attribute("forum.scope", str(event_data.get("course_or_org", "")))
+        set_custom_attribute("forum.course_count", str(len(course_ids or [])))
     log.info(
         f"<<Bulk Delete>> Deleting all posts for {username} in course {course_ids}"
     )
@@ -156,6 +164,10 @@ def delete_course_post_for_user(  # pylint: disable=too-many-statements
     comments_deleted = Comment.delete_user_comments(
         user_id, course_ids, deleted_by=deleted_by_user_id
     )
+    if event_data.get("course_key"):
+        set_custom_attribute("forum.threads_deleted", str(threads_deleted))
+        set_custom_attribute("forum.comments_deleted", str(comments_deleted))
+        set_custom_attribute("forum.result", "success")
     log.info(
         f"<<Bulk Delete>> Deleted {threads_deleted} posts and {comments_deleted} comments for {username} "
         f"in course {course_ids}"
@@ -253,6 +265,14 @@ def restore_course_post_for_user(user_id, username, course_ids, event_data=None)
     Restores all soft-deleted posts for user in a course by setting is_deleted=False.
     """
     event_data = event_data or {}
+    if event_data.get("course_key"):
+        set_custom_attribute("forum.operation", "bulk_restore_user_posts.execute")
+        set_custom_attribute("forum.entity_type", "user")
+        set_custom_attribute("forum.entity_id", str(user_id or ""))
+        set_custom_attribute("forum.actor_id", str(event_data.get("triggered_by_user_id", "")))
+        set_custom_attribute("forum.course_id", str(event_data.get("course_key", "")))
+        set_custom_attribute("forum.scope", str(event_data.get("course_or_org", "")))
+        set_custom_attribute("forum.course_count", str(len(course_ids or [])))
     log.info(
         "<<Bulk Restore>> Restoring all posts for %s in course %s", username, course_ids
     )
@@ -264,6 +284,10 @@ def restore_course_post_for_user(user_id, username, course_ids, event_data=None)
     comments_restored = Comment.restore_user_deleted_comments(
         user_id, course_ids, restored_by=restored_by_user_id
     )
+    if event_data.get("course_key"):
+        set_custom_attribute("forum.threads_restored", str(threads_restored))
+        set_custom_attribute("forum.comments_restored", str(comments_restored))
+        set_custom_attribute("forum.result", "success")
     log.info(
         "<<Bulk Restore>> Restored %s posts and %s comments for %s in course %s",
         threads_restored,

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1943,15 +1943,22 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
         Implements the delete user posts endpoint.
         Supports both MongoDB and MySQL backends via forum API.
         """
+        set_custom_attribute("forum.operation", "bulk_delete_user_posts.queue")
+        set_custom_attribute("forum.entity_type", "user")
+        set_custom_attribute("forum.actor_id", str(getattr(request.user, "id", "")))
+        set_custom_attribute("forum.course_id", str(course_id or ""))
         username = request.GET.get("username", None)
         execute_task = request.GET.get("execute", "false").lower() == "true"
         if (not username) or (not course_id):
             raise BadRequest("username and course_id are required.")
         course_or_org = request.GET.get("course_or_org", "course")
+        set_custom_attribute("forum.scope", course_or_org)
+        set_custom_attribute("forum.execute", str(execute_task).lower())
         if course_or_org not in ["course", "org"]:
             raise BadRequest("course_or_org must be either 'course' or 'org'.")
 
         user = get_object_or_404(User, username=username)
+        set_custom_attribute("forum.entity_id", str(user.id))
         course_ids = [course_id]
         if course_or_org == "org":
             org_id = CourseKey.from_string(course_id).org
@@ -1967,6 +1974,9 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
 
         comment_count = Comment.get_user_comment_count(user.id, course_ids)
         thread_count = Thread.get_user_threads_count(user.id, course_ids)
+        set_custom_attribute("forum.course_count", str(len(course_ids)))
+        set_custom_attribute("forum.thread_count", str(thread_count))
+        set_custom_attribute("forum.comment_count", str(comment_count))
         log.info(
             f"<<Bulk Delete>> {username} in {course_ids} - Count thread {thread_count}, comment {comment_count}"
         )
@@ -1979,9 +1989,11 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
                 "course_or_org": course_or_org,
                 "course_key": course_id,
             }
-            delete_course_post_for_user.apply_async(
+            task = delete_course_post_for_user.apply_async(
                 args=(user.id, username, course_ids, event_data),
             )
+            set_custom_attribute("forum.task_id", str(task.id))
+        _set_trace_outcome(status.HTTP_202_ACCEPTED)
         return Response(
             {"comment_count": comment_count, "thread_count": thread_count},
             status=status.HTTP_202_ACCEPTED,
@@ -2120,15 +2132,22 @@ class BulkRestoreUserPosts(DeveloperErrorViewMixin, APIView):
         """
         Implements the restore user posts endpoint.
         """
+        set_custom_attribute("forum.operation", "bulk_restore_user_posts.queue")
+        set_custom_attribute("forum.entity_type", "user")
+        set_custom_attribute("forum.actor_id", str(getattr(request.user, "id", "")))
+        set_custom_attribute("forum.course_id", str(course_id or ""))
         username = request.GET.get("username", None)
         execute_task = request.GET.get("execute", "false").lower() == "true"
         if (not username) or (not course_id):
             raise BadRequest("username and course_id are required.")
         course_or_org = request.GET.get("course_or_org", "course")
+        set_custom_attribute("forum.scope", course_or_org)
+        set_custom_attribute("forum.execute", str(execute_task).lower())
         if course_or_org not in ["course", "org"]:
             raise BadRequest("course_or_org must be either 'course' or 'org'.")
 
         user = get_object_or_404(User, username=username)
+        set_custom_attribute("forum.entity_id", str(user.id))
         course_ids = [course_id]
         if course_or_org == "org":
             org_id = CourseKey.from_string(course_id).org
@@ -2147,6 +2166,9 @@ class BulkRestoreUserPosts(DeveloperErrorViewMixin, APIView):
         )
         comment_count = Comment.get_user_deleted_comment_count(user.id, course_ids)
         thread_count = Thread.get_user_deleted_threads_count(user.id, course_ids)
+        set_custom_attribute("forum.course_count", str(len(course_ids)))
+        set_custom_attribute("forum.thread_count", str(thread_count))
+        set_custom_attribute("forum.comment_count", str(comment_count))
         log.info(
             "<<Bulk Restore>> %s in %s - Count thread %s, comment %s",
             username,
@@ -2163,9 +2185,11 @@ class BulkRestoreUserPosts(DeveloperErrorViewMixin, APIView):
                 "course_or_org": course_or_org,
                 "course_key": course_id,
             }
-            restore_course_post_for_user.apply_async(
+            task = restore_course_post_for_user.apply_async(
                 args=(user.id, username, course_ids, event_data),
             )
+            set_custom_attribute("forum.task_id", str(task.id))
+        _set_trace_outcome(status.HTTP_202_ACCEPTED)
         return Response(
             {"comment_count": comment_count, "thread_count": thread_count},
             status=status.HTTP_202_ACCEPTED,


### PR DESCRIPTION
Adds Datadog forum telemetry for bulk discussion user-post workflows.

This covers:

- Bulk delete user posts
- Bulk restore user posts

Telemetry is added at both points in the flow:

- HTTP request layer, when the job is queued
- Celery task layer, when the delete/restore is executed

## Changes

Added request-level operations:

- `bulk_delete_user_posts.queue`
- `bulk_restore_user_posts.queue`

Added task-level operations:

- `bulk_delete_user_posts.execute`
- `bulk_restore_user_posts.execute`

Captured attributes include:

- `forum.operation`
- `forum.entity_type`
- `forum.entity_id`
- `forum.actor_id`
- `forum.course_id`
- `forum.scope`
- `forum.course_count`
- `forum.thread_count`
- `forum.comment_count`
- `forum.task_id`
- `forum.threads_deleted`
- `forum.comments_deleted`
- `forum.threads_restored`
- `forum.comments_restored`
- `forum.result`
- `forum.http_status`

## Why

Bulk delete and restore APIs return `202` after queueing background work. Request-level telemetry confirms the job was queued, while task-level telemetry confirms what was actually deleted or restored by Celery.

