### PR TITLE
feat: ENT-11771 Option for disabling email during TPA

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0015_samlproviderconfig_disable_email_editing.py
+++ b/common/djangoapps/third_party_auth/migrations/0015_samlproviderconfig_disable_email_editing.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+import django.utils.translation
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0014_samlproviderconfig_optional_email_checkboxes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='disable_email_editing',
+            field=models.BooleanField(
+                default=False,
+                help_text=django.utils.translation.gettext_lazy(
+                    "If enabled, the email field on the SSO registration form will be read-only and "
+                    "users will not be able to change their email address in their account settings."
+                ),
+            ),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -753,6 +753,13 @@ class SAMLProviderConfig(ProviderConfig):
             "are skipped, their values are inferred as False (opted out)."
         ),
     )
+    disable_email_editing = models.BooleanField(
+        default=False,
+        help_text=_(
+            "If enabled, the email field on the SSO registration form will be read-only and "
+            "users will not be able to change their email address in their account settings."
+        ),
+    )
     other_settings = models.TextField(
         verbose_name="Advanced settings", blank=True,
         help_text=(

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -20,7 +20,7 @@ from common.djangoapps.student.models import (
     username_exists_or_retired
 )
 
-from common.djangoapps.third_party_auth.models import OAuth2ProviderConfig, SAMLProviderData
+from common.djangoapps.third_party_auth.models import OAuth2ProviderConfig, SAMLProviderConfig, SAMLProviderData
 from openedx.core.djangolib.markup import Text
 
 from . import provider
@@ -221,6 +221,26 @@ def create_or_update_bulk_saml_provider_data(entity_id, public_keys, sso_url, ex
             new_records_created = True
 
     return new_records_created
+
+
+def get_saml_provider_for_user(user):
+    """
+    Return the SAMLProviderConfig for a user based on their UserSocialAuth record, or None.
+
+    SAML UIDs are stored as '{slug}:{remote_id}', so the provider slug can be extracted
+    from the first segment of the UID.
+    """
+    from social_django.models import UserSocialAuth
+    social_auth = UserSocialAuth.objects.filter(user=user, provider='tpa-saml').order_by('id').first()
+    if not social_auth:
+        return None
+    slug, sep, _ = social_auth.uid.partition(':')
+    if not sep:
+        return None
+    try:
+        return SAMLProviderConfig.objects.current_set().get(slug=slug)
+    except SAMLProviderConfig.DoesNotExist:
+        return None
 
 
 def is_saml_provider(backend, kwargs):

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -38,6 +38,7 @@ from openedx.core.djangoapps.user_api.preferences.api import update_user_prefere
 from openedx.core.djangoapps.user_authn.utils import check_pwned_password
 from openedx.core.djangoapps.user_authn.views.registration_form import validate_name, validate_username
 from openedx.core.lib.api.view_utils import add_serializer_errors
+from common.djangoapps.third_party_auth.utils import get_saml_provider_for_user
 from openedx.features.enterprise_support.utils import get_enterprise_readonly_account_fields
 from openedx.features.name_affirmation_api.utils import is_name_affirmation_installed
 
@@ -212,6 +213,15 @@ def _validate_email_change(user, data, field_errors):
     # If user has requested to change email, we must call the multi-step process to handle this.
     # It is not handled by the serializer (which considers email to be read-only).
     if "email" not in data:
+        return
+
+    saml_provider = get_saml_provider_for_user(user)
+    if saml_provider and saml_provider.disable_email_editing:
+        field_errors["email"] = {
+            "developer_message": "Email address changes are disabled for this SSO provider.",
+            "user_message": _("Your email address is managed by your institution and cannot be changed here.")
+        }
+        del data["email"]
         return
 
     if not settings.FEATURES['ALLOW_EMAIL_ADDRESS_CHANGE']:

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from rest_framework import serializers
 
 
+from common.djangoapps.third_party_auth.utils import get_saml_provider_for_user
 from common.djangoapps.student.models import (
     LanguageProficiency,
     PendingNameChange,
@@ -233,10 +234,26 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
         else:
             fields = self.configuration.get('public_fields')
 
-        return self._filter_fields(
-            fields,
-            data
-        )
+        result = self._filter_fields(fields, data)
+
+        if self.custom_fields and self._is_email_change_disabled(user):
+            result["email_change_disabled"] = True
+
+        return result
+
+    def _is_email_change_disabled(self, user):
+        """
+        Return True if email editing is disabled for this user via their SAML provider.
+
+        Checks self.context["email_change_disabled_by_user_id"] first (a pre-fetched
+        {user_id: bool} mapping) to avoid an extra DB query in bulk serialization.
+        Falls back to a direct DB lookup.
+        """
+        prefetched = self.context.get("email_change_disabled_by_user_id")
+        if prefetched is not None:
+            return bool(prefetched.get(user.id, False))
+        saml_provider = get_saml_provider_for_user(user)
+        return bool(saml_provider and saml_provider.disable_email_editing)
 
     def _filter_fields(self, field_whitelist, serialized_account):
         """

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -472,6 +472,25 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         assert 'Email address changes have been disabled' in context_manager.value.developer_message
 
     @patch.dict(settings.FEATURES, dict(ALLOW_EMAIL_ADDRESS_CHANGE=True))
+    def test_email_changes_blocked_by_saml_provider(self):
+        """
+        Test that email changes are rejected when the user's SAML provider has disable_email_editing=True.
+        """
+        from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
+        saml_config = SAMLProviderConfigFactory(disable_email_editing=True)
+        UserSocialAuth.objects.create(
+            user=self.user,
+            provider='tpa-saml',
+            uid=f'{saml_config.slug}:remote-user-id',
+        )
+
+        with pytest.raises(AccountValidationError) as context_manager:
+            update_account_settings(self.user, {"email": "new@example.com"})
+        field_errors = context_manager.value.field_errors
+        assert 'email' in field_errors
+        assert 'Email address changes are disabled' in field_errors['email']['developer_message']
+
+    @patch.dict(settings.FEATURES, dict(ALLOW_EMAIL_ADDRESS_CHANGE=True))
     def test_email_changes_blocked_on_retired_email(self):
         """
         Test that email address changes are rejected when an email associated with a *partially* retired account is

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_serializers.py
@@ -7,11 +7,13 @@ import logging
 
 from django.test import TestCase
 from django.test.client import RequestFactory
+from social_django.models import UserSocialAuth
 from testfixtures import LogCapture
 
-from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer
 from common.djangoapps.student.models import UserProfile
 from common.djangoapps.student.tests.factories import UserFactory
+from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
+from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer
 
 LOGGER_NAME = "openedx.core.djangoapps.user_api.accounts.serializers"
 
@@ -52,3 +54,61 @@ class UserReadOnlySerializerTest(TestCase):  # lint-amnesty, pylint: disable=mis
 
         assert data['username'] == self.user.username
         assert data['name'] is None
+
+    def test_email_change_disabled_present_in_self_view(self):
+        """
+        email_change_disabled=True is included when custom_fields is set (self/staff view).
+        """
+        saml_config = SAMLProviderConfigFactory(disable_email_editing=True)
+        UserSocialAuth.objects.create(
+            user=self.user,
+            provider='tpa-saml',
+            uid=f'{saml_config.slug}:remote-user-id',
+        )
+        UserProfile.objects.create(user=self.user, name='Test User')
+        admin_fields = list(self.config['public_fields']) + ['email_change_disabled']
+        data = UserReadOnlySerializer(
+            self.user,
+            configuration=self.config,
+            custom_fields=admin_fields,
+            context={'request': self.request},
+        ).data
+        assert data.get('email_change_disabled') is True
+
+    def test_email_change_disabled_absent_in_public_view(self):
+        """
+        email_change_disabled is not included in public (non-custom_fields) views.
+        """
+        saml_config = SAMLProviderConfigFactory(disable_email_editing=True)
+        UserSocialAuth.objects.create(
+            user=self.user,
+            provider='tpa-saml',
+            uid=f'{saml_config.slug}:remote-user-id',
+        )
+        UserProfile.objects.create(user=self.user, name='Test User')
+        data = UserReadOnlySerializer(
+            self.user,
+            configuration=self.config,
+            context={'request': self.request},
+        ).data
+        assert 'email_change_disabled' not in data
+
+    def test_email_change_disabled_absent_when_flag_false(self):
+        """
+        email_change_disabled is not included when disable_email_editing=False.
+        """
+        saml_config = SAMLProviderConfigFactory(disable_email_editing=False)
+        UserSocialAuth.objects.create(
+            user=self.user,
+            provider='tpa-saml',
+            uid=f'{saml_config.slug}:remote-user-id',
+        )
+        UserProfile.objects.create(user=self.user, name='Test User')
+        admin_fields = list(self.config['public_fields'])
+        data = UserReadOnlySerializer(
+            self.user,
+            configuration=self.config,
+            custom_fields=admin_fields,
+            context={'request': self.request},
+        ).data
+        assert 'email_change_disabled' not in data

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -815,12 +815,12 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
             assert data['time_zone'] is None
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        verify_get_own_information(self._get_num_queries(23))
+        verify_get_own_information(self._get_num_queries(24))
 
         # Now make sure that the user can get the same information, even if not active
         self.user.is_active = False
         self.user.save()
-        verify_get_own_information(self._get_num_queries(15))
+        verify_get_own_information(self._get_num_queries(16))
 
     def test_get_account_empty_string(self):
         """
@@ -835,7 +835,7 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
         legacy_profile.save()
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        with self.assertNumQueries(self._get_num_queries(23), table_ignorelist=WAFFLE_TABLES):
+        with self.assertNumQueries(self._get_num_queries(24), table_ignorelist=WAFFLE_TABLES):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "state", "bio",):
             assert response.data[empty_field] is None

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -432,10 +432,7 @@ class RegistrationFormFactory:
 
     def _get_saml_provider_config(self):
         """
-        Get the SAML provider config for the current request's running pipeline.
-
-        Returns:
-            SAMLProviderConfig or None: The SAML provider config if found, None otherwise
+        Return the current SAMLProviderConfig for the running pipeline, or None.
         """
         if not self.request or not third_party_auth.is_enabled():
             return None
@@ -444,45 +441,19 @@ class RegistrationFormFactory:
         if not running_pipeline:
             return None
 
+        kwargs = running_pipeline.get('kwargs', {})
+        # idp_name may live in kwargs directly, in kwargs['details'], or in kwargs['response']
+        saml_provider_name = (
+            kwargs.get('idp_name') or
+            kwargs.get('details', {}).get('idp_name') or
+            kwargs.get('response', {}).get('idp_name')
+        )
+        if not saml_provider_name:
+            return None
+
         try:
-            # idp_name can be in kwargs directly, in kwargs['details'], or in kwargs['response']
-            saml_provider_name = running_pipeline.get('kwargs', {}).get('idp_name')
-            if not saml_provider_name:
-                saml_provider_name = (
-                    running_pipeline.get('kwargs', {})
-                    .get('details', {})
-                    .get('idp_name')
-                )
-            if not saml_provider_name:
-                saml_provider_name = (
-                    running_pipeline.get('kwargs', {})
-                    .get('response', {})
-                    .get('idp_name')
-                )
-
-            if not saml_provider_name:
-                return None
-
-            try:
-                # Try to find the SAML provider config
-                # First try with current_set(), then fall back to direct query
-                try:
-                    return SAMLProviderConfig.objects.current_set().get(
-                        slug=saml_provider_name
-                    )
-                except SAMLProviderConfig.DoesNotExist:
-                    # Fallback to direct query without current_set()
-                    return SAMLProviderConfig.objects.get(
-                        slug=saml_provider_name
-                    )
-            except SAMLProviderConfig.DoesNotExist:
-                log.debug(
-                    "SAML provider config not found for idp_name: %s",
-                    saml_provider_name
-                )
-                return None
-        except Exception as exc:  # pylint: disable=broad-except
-            log.debug("Error getting SAML provider config: %s", str(exc))
+            return SAMLProviderConfig.objects.current_set().get(slug=saml_provider_name)
+        except SAMLProviderConfig.DoesNotExist:
             return None
 
     def get_registration_form(self, request):
@@ -564,6 +535,7 @@ class RegistrationFormFactory:
                 if field['name'] == 'confirm_email':
                     del form_desc.fields[index]
                     break
+
         return form_desc
 
     def _get_registration_submit_url(self, request):
@@ -1250,19 +1222,14 @@ class RegistrationFormFactory:
                         if field_name not in field_overrides:
                             continue
 
-                        # Special handling for marketing_emails_opt_in:
-                        # If SAML provider config has skip_registration_optional_checkboxes=True,
-                        # don't let the provider's get_register_form_data override the default
-                        skip_override = False
-                        if field_name == 'marketing_emails_opt_in':
-                            saml_config = self._get_saml_provider_config()
-                            if saml_config and saml_config.skip_registration_optional_checkboxes:
-                                log.debug(
-                                    "Skipping provider override for marketing_emails_opt_in "
-                                    "due to SAML config for provider: %s",
-                                    saml_config.slug
-                                )
-                                skip_override = True
+                        skip_override = (
+                            # Only suppress the IdP default for this specific field
+                            field_name == 'marketing_emails_opt_in' and
+                            # OAuth2 providers don't have this flag, so guard the attribute access
+                            isinstance(current_provider, SAMLProviderConfig) and
+                            # Provider is configured to opt users out of marketing emails silently
+                            current_provider.skip_registration_optional_checkboxes
+                        )
 
                         if not skip_override:
                             form_desc.override_field_properties(
@@ -1282,6 +1249,19 @@ class RegistrationFormFactory:
                                     label="",
                                     instructions="",
                                 )
+
+                    if (
+                        isinstance(current_provider, SAMLProviderConfig) and
+                        current_provider.disable_email_editing
+                    ):
+                        form_desc.override_field_properties(
+                            "email",
+                            restrictions={
+                                "readonly": "readonly",
+                                "min_length": accounts.EMAIL_MIN_LENGTH,
+                                "max_length": accounts.EMAIL_MAX_LENGTH,
+                            },
+                        )
 
                     # Hide the confirm_email field
                     form_desc.override_field_properties(

--- a/openedx/core/djangoapps/user_authn/views/tests/test_saml_disable_email_editing.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_saml_disable_email_editing.py
@@ -1,0 +1,93 @@
+"""
+Tests for the SAMLProviderConfig.disable_email_editing option.
+"""
+
+from unittest import mock
+
+from django.test import TestCase, override_settings
+from django.test.client import RequestFactory
+
+from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
+from common.djangoapps.third_party_auth.tests.testutil import simulate_running_pipeline
+from openedx.core.djangoapps.user_authn.views.registration_form import RegistrationFormFactory
+
+
+class SAMLDisableEmailEditingTest(TestCase):
+    """
+    Tests that disable_email_editing=True makes the registration form email field
+    read-only and that disable_email_editing=False leaves it editable.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+
+    def _create_request(self):
+        """Create a test request with session support."""
+        from importlib import import_module
+        from django.conf import settings
+        request = self.factory.get('/register')
+        engine = import_module(settings.SESSION_ENGINE)
+        request.session = engine.SessionStore(None)
+        return request
+
+    def _get_email_field(self, form_desc):
+        """Return the email field dict from a form description, or None."""
+        return next((f for f in form_desc.fields if f['name'] == 'email'), None)
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={}, REGISTRATION_FIELD_ORDER=[])
+    @mock.patch(
+        'openedx.core.djangoapps.user_authn.views.registration_form.third_party_auth.is_enabled',
+        return_value=True,
+    )
+    def test_email_readonly_when_disable_email_editing_true(self, mock_is_enabled):
+        """Email field has restrictions.readonly when disable_email_editing=True."""
+        saml_config = SAMLProviderConfigFactory(disable_email_editing=True)
+
+        with simulate_running_pipeline(
+            "common.djangoapps.third_party_auth.pipeline",
+            "tpa-saml",
+            response={"idp_name": saml_config.slug},
+            email="testuser@example.com",
+            fullname="Test User",
+            username="testuser",
+        ):
+            form_desc = RegistrationFormFactory().get_registration_form(self._create_request())
+
+        email_field = self._get_email_field(form_desc)
+        self.assertIsNotNone(email_field)
+        restrictions = email_field.get('restrictions', {})
+        self.assertEqual(
+            restrictions.get('readonly'),
+            'readonly',
+            "Email field should have restrictions.readonly='readonly' when disable_email_editing=True",
+        )
+        self.assertIn('min_length', restrictions, "min_length restriction should be preserved alongside readonly")
+        self.assertIn('max_length', restrictions, "max_length restriction should be preserved alongside readonly")
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={}, REGISTRATION_FIELD_ORDER=[])
+    @mock.patch(
+        'openedx.core.djangoapps.user_authn.views.registration_form.third_party_auth.is_enabled',
+        return_value=True,
+    )
+    def test_email_editable_when_disable_email_editing_false(self, mock_is_enabled):
+        """Email field has no readonly restriction when disable_email_editing=False."""
+        saml_config = SAMLProviderConfigFactory(disable_email_editing=False)
+
+        with simulate_running_pipeline(
+            "common.djangoapps.third_party_auth.pipeline",
+            "tpa-saml",
+            response={"idp_name": saml_config.slug},
+            email="testuser@example.com",
+            fullname="Test User",
+            username="testuser",
+        ):
+            form_desc = RegistrationFormFactory().get_registration_form(self._create_request())
+
+        email_field = self._get_email_field(form_desc)
+        self.assertIsNotNone(email_field)
+        self.assertNotIn(
+            'readonly',
+            email_field.get('restrictions', {}),
+            "Email field should not have readonly restriction when disable_email_editing=False",
+        )


### PR DESCRIPTION
## Description
[ENT-11771](https://2u-internal.atlassian.net/browse/ENT-11771)

Adds a disable_email_editing flag to SAMLProviderConfig that makes the email field read-only on the SSO registration form and blocks email changes via the account settings API.

When enabled for a SAML provider, the IdP-supplied email address is locked — users cannot modify it during registration or in their profile settings.
## Testing

1. Run the migration: `manage.py migrate third_party_auth`
2. In Django admin, open a `SAMLProviderConfig` and check **Disable email editing**, save
3. Trigger a SAML SSO registration flow for that provider — the email field on the registration form should be pre-filled and non-editable
4. For an existing SSO user linked to that provider, attempt a `PATCH /api/user/v1/accounts/{username}` with a new `email` value — expect a 400 with *"Your email address is managed by your institution and cannot be changed here."*
5. The same `GET /api/user/v1/accounts/{username}` response should include `"email_change_disabled": true`

## Notes for reviewers

- **Default is `False`** — no behaviour change for existing providers unless explicitly opted in
- **MFE not covered**: `frontend-app-account` needs to read `email_change_disabled` from the account API and disable the email field in profile settings — that's a follow-up in a separate repo
