### PR TITLE
fix: ENT-11771 SAML login - Allow email editing if emtpy

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0015_samlproviderconfig_disable_email_editing.py
+++ b/common/djangoapps/third_party_auth/migrations/0015_samlproviderconfig_disable_email_editing.py
@@ -15,8 +15,10 @@ class Migration(migrations.Migration):
             field=models.BooleanField(
                 default=False,
                 help_text=django.utils.translation.gettext_lazy(
-                    "If enabled, the email field on the SSO registration form will be read-only and "
-                    "users will not be able to change their email address in their account settings."
+                    "If enabled, and the identity provider supplies an email address, the email field "
+                    "on the SSO registration form will be read-only and users will not be able to change "
+                    "their email address in their account settings. If the identity provider does not "
+                    "supply an email address, the field remains editable during registration."
                 ),
             ),
         ),

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -756,8 +756,10 @@ class SAMLProviderConfig(ProviderConfig):
     disable_email_editing = models.BooleanField(
         default=False,
         help_text=_(
-            "If enabled, the email field on the SSO registration form will be read-only and "
-            "users will not be able to change their email address in their account settings."
+            "If enabled, and the identity provider supplies an email address, the email field "
+            "on the SSO registration form will be read-only and users will not be able to change "
+            "their email address in their account settings. If the identity provider does not "
+            "supply an email address, the field remains editable during registration."
         ),
     )
     other_settings = models.TextField(

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -1252,7 +1252,8 @@ class RegistrationFormFactory:
 
                     if (
                         isinstance(current_provider, SAMLProviderConfig) and
-                        current_provider.disable_email_editing
+                        current_provider.disable_email_editing and
+                        field_overrides.get("email")
                     ):
                         form_desc.override_field_properties(
                             "email",

--- a/openedx/core/djangoapps/user_authn/views/tests/test_saml_disable_email_editing.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_saml_disable_email_editing.py
@@ -70,6 +70,32 @@ class SAMLDisableEmailEditingTest(TestCase):
         'openedx.core.djangoapps.user_authn.views.registration_form.third_party_auth.is_enabled',
         return_value=True,
     )
+    def test_email_editable_when_disable_email_editing_true_but_no_email(self, mock_is_enabled):
+        """Email field is not readonly when disable_email_editing=True but the pipeline provides no email."""
+        saml_config = SAMLProviderConfigFactory(disable_email_editing=True)
+
+        with simulate_running_pipeline(
+            "common.djangoapps.third_party_auth.pipeline",
+            "tpa-saml",
+            response={"idp_name": saml_config.slug},
+            fullname="Test User",
+            username="testuser",
+        ):
+            form_desc = RegistrationFormFactory().get_registration_form(self._create_request())
+
+        email_field = self._get_email_field(form_desc)
+        self.assertIsNotNone(email_field)
+        self.assertNotIn(
+            'readonly',
+            email_field.get('restrictions', {}),
+            "Email field must be editable when the pipeline provides no email address",
+        )
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={}, REGISTRATION_FIELD_ORDER=[])
+    @mock.patch(
+        'openedx.core.djangoapps.user_authn.views.registration_form.third_party_auth.is_enabled',
+        return_value=True,
+    )
     def test_email_editable_when_disable_email_editing_false(self, mock_is_enabled):
         """Email field has no readonly restriction when disable_email_editing=False."""
         saml_config = SAMLProviderConfigFactory(disable_email_editing=False)


### PR DESCRIPTION
Small follow up to make email editable if blank.
[ENT-11771](https://2u-internal.atlassian.net/browse/ENT-11771)