### PR TITLE
fix: discussions unmute API returning 400 for moderators

### DIFF
--- a/lms/djangoapps/discussion/rest_api/forum_mute_views.py
+++ b/lms/djangoapps/discussion/rest_api/forum_mute_views.py
@@ -113,14 +113,16 @@ class ForumMuteUserView(DeveloperErrorViewMixin, APIView):
             raise ValidationError(serializer.errors)
 
         course_key = CourseKey.from_string(course_id)
+        scope = data.get('scope', 'personal')
 
-        # Check self-mute and permissions
-        if request.user.id == target_user.id:
-            raise ValidationError("Users cannot mute themselves")
-
-        # For course-wide actions, user must have permissions to mute at course level
-        if not CanMuteUsers.can_mute(request.user, target_user, course_key, data.get('scope', 'personal')):
+        # Check permissions (includes self-mute validation)
+        if not CanMuteUsers.can_mute(request.user, target_user, course_key, scope):
             raise PermissionDenied("Permission denied")
+
+        # Determine privilege level for forum backend
+        # If scope is 'course', user must be privileged (verified by can_mute)
+        # If scope is 'personal', check if user has moderation privileges
+        requester_is_privileged = (scope == 'course') or _is_privileged_user(request.user, course_key)
 
         # Call forum API
         try:
@@ -128,9 +130,9 @@ class ForumMuteUserView(DeveloperErrorViewMixin, APIView):
                 muted_user_id=str(target_user.id),
                 muter_id=str(request.user.id),
                 course_id=str(course_key),
-                scope=data.get('scope', 'personal'),
+                scope=scope,
                 reason=data.get('reason', ''),
-                requester_is_privileged=_is_privileged_user(request.user, course_key)
+                requester_is_privileged=requester_is_privileged
             )
             return Response(result, status=status.HTTP_201_CREATED)
         except Exception as e:  # pylint: disable=broad-exception-caught
@@ -174,10 +176,13 @@ class ForumUnmuteUserView(DeveloperErrorViewMixin, APIView):
         if not CanMuteUsers.can_unmute(request.user, target_user, course_key, scope):
             raise PermissionDenied("Permission denied")
 
+        # Determine privilege level for forum backend
+        # If scope is 'course', user must be privileged (verified by can_unmute)
+        # If scope is 'personal', check if user has moderation privileges
+        requester_is_privileged = (scope == 'course') or _is_privileged_user(request.user, course_key)
+
         # Handle muter_id for personal unmutes
-        muter_id = None
-        if scope == 'personal':
-            muter_id = request.user.id
+        muter_id = str(request.user.id) if scope == 'personal' else None
 
         # Call forum API
         try:
@@ -186,7 +191,8 @@ class ForumUnmuteUserView(DeveloperErrorViewMixin, APIView):
                 unmuted_by_id=str(request.user.id),
                 course_id=str(course_key),
                 scope=scope,
-                muter_id=str(muter_id) if muter_id else None
+                muter_id=muter_id,
+                requester_is_privileged=requester_is_privileged
             )
             return Response(result)
         except Exception as e:  # pylint: disable=broad-exception-caught
@@ -262,13 +268,16 @@ class ForumMuteAndReportView(DeveloperErrorViewMixin, APIView):
         if not serializer.is_valid():
             raise ValidationError(serializer.errors)
 
-        # Check self-mute and permissions
-        if request.user.id == target_user.id:
-            raise ValidationError("Users cannot mute themselves")
+        scope = data.get('scope', 'personal')
 
-        # For course-wide actions, user must have permissions to mute at course level
-        if not CanMuteUsers.can_mute(request.user, target_user, course_key, data.get('scope', 'personal')):
+        # Check permissions (includes self-mute validation)
+        if not CanMuteUsers.can_mute(request.user, target_user, course_key, scope):
             raise PermissionDenied("Permission denied")
+
+        # Determine privilege level for forum backend
+        # If scope is 'course', user must be privileged (verified by can_mute)
+        # If scope is 'personal', check if user has moderation privileges
+        requester_is_privileged = (scope == 'course') or _is_privileged_user(request.user, course_key)
 
         # Call forum API
         try:
@@ -276,12 +285,12 @@ class ForumMuteAndReportView(DeveloperErrorViewMixin, APIView):
                 muted_user_id=str(target_user.id),
                 muter_id=str(request.user.id),
                 course_id=str(course_key),
-                scope=data.get('scope', 'personal'),
+                scope=scope,
                 reason=data.get('reason', ''),
                 thread_id=data.get('thread_id', ''),
                 comment_id=data.get('comment_id', ''),
                 request=request,
-                requester_is_privileged=_is_privileged_user(request.user, course_key)
+                requester_is_privileged=requester_is_privileged
             )
             return Response(result, status=status.HTTP_201_CREATED)
         except Exception as e:  # pylint: disable=broad-exception-caught

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -265,6 +265,39 @@ class CanMuteUsers(permissions.BasePermission):
             GlobalStaff().has_user(user)
         )
 
+    @staticmethod
+    def has_course_wide_privilege(user, course_id):
+        """
+        Check if user has privileges for course-wide mute/unmute operations.
+
+        Only these roles can perform course-wide operations:
+        - Global Staff
+        - Discussion Admin (FORUM_ROLE_ADMINISTRATOR)
+        - Discussion Moderator (FORUM_ROLE_MODERATOR)
+
+        Explicitly EXCLUDES:
+        - Course Admin
+        - Course Staff
+        - Group Community TA (FORUM_ROLE_GROUP_MODERATOR)
+        - Community TA (FORUM_ROLE_COMMUNITY_TA)
+
+        Args:
+            user: User to check
+            course_id: Course context
+
+        Returns:
+            bool: True if user has course-wide privileges
+        """
+        # Check for allowed roles
+        return (
+            GlobalStaff().has_user(user) or
+            Role.objects.filter(
+                users=user,
+                course_id=course_id,
+                name__in=[FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR]
+            ).exists()
+        )
+
     def has_permission(self, request, view):
         """
         Check if user has permission to access mute/unmute endpoints.
@@ -306,22 +339,39 @@ class CanMuteUsers(permissions.BasePermission):
         if requesting_user.id == target_user.id:
             return False
 
-        # Check if target user has discussion privileges
+        # Check if target user has discussion privileges (any role)
         target_is_privileged = CanMuteUsers._is_privileged_user(target_user, course_id)
 
-        # Check if requesting user has discussion privileges
-        requesting_is_privileged = CanMuteUsers._is_privileged_user(requesting_user, course_id)
+        # For course-wide muting, check specific roles
+        if scope == 'course':
+            if not CanMuteUsers.has_course_wide_privilege(
+                requesting_user, course_id
+            ):
+                return False
+
+            # Learners cannot mute privileged users even course-wide
+            if target_is_privileged and not CanMuteUsers._is_privileged_user(requesting_user, course_id):
+                return False
+            return True
+
+        # For personal muting
+        # Check if user is Course Staff (allowed for personal mutes)
+        is_course_staff = CourseStaffRole(course_id).has_user(requesting_user)
 
         # Learners cannot mute discussion-privileged users
-        if target_is_privileged and not requesting_is_privileged:
+        if (
+            target_is_privileged and
+            not CanMuteUsers._is_privileged_user(requesting_user, course_id) and
+            not is_course_staff
+        ):
             return False
 
-        # For course-wide muting, user must have discussion privileges
-        if scope == 'course' and not requesting_is_privileged:
-            return False
+        # Course Staff can always do personal mutes
+        if is_course_staff:
+            return True
 
         # Non-privileged users must be enrolled in the course
-        if not requesting_is_privileged:
+        if not CanMuteUsers._is_privileged_user(requesting_user, course_id):
             try:
                 CourseEnrollment.objects.get(
                     user=requesting_user,
@@ -340,9 +390,8 @@ class CanMuteUsers(permissions.BasePermission):
 
         Rules:
         - Users cannot unmute themselves
-        - Staff (instructors, TAs, global staff) can unmute anyone at any scope
-        - Course-wide unmute is restricted to staff
-        - Personal unmute requires enrollment
+        - For course-wide unmute: Only Global Staff, Discussion Admin, Discussion Moderator
+        - For personal unmute: Enrolled users, Course Staff, and privileged users
 
         Args:
             requesting_user: User attempting to unmute
@@ -357,16 +406,16 @@ class CanMuteUsers(permissions.BasePermission):
         if requesting_user.id == target_user.id:
             return False
 
-        # Check if requesting user is staff or has discussion privileges (includes CTAs)
-        requesting_is_privileged = CanMuteUsers._is_privileged_user(requesting_user, course_id)
+        # For course-wide unmuting, only specific roles are allowed
+        if scope == 'course':
+            return CanMuteUsers.has_course_wide_privilege(
+                requesting_user, course_id
+            )
 
-        # Privileged users (staff, instructors, CTAs, moderators) can unmute anyone
-        if requesting_is_privileged:
+        # For personal unmuting
+        # Course Staff can always do personal unmutes
+        if CourseStaffRole(course_id).has_user(requesting_user):
             return True
-
-        # For course-wide unmuting, only privileged users are allowed
-        if scope == 'course' and not requesting_is_privileged:
-            return False
 
         # For personal unmuting, verify the user is enrolled in the course
         try:
@@ -377,7 +426,7 @@ class CanMuteUsers(permissions.BasePermission):
             )
             return True
         except CourseEnrollment.DoesNotExist:
-            return False
+            return CanMuteUsers._is_privileged_user(requesting_user, course_id)
 
 
 class IsAllowedToRestore(permissions.BasePermission):


### PR DESCRIPTION
### Description
Fixes an issue in the Discussions → Learners tab where the Unmute (course-wide) action fails with a 400 Bad Request error in the Stage environment.
This issue prevented Discussion Moderators from unmuting users at the course-wide level, even though they were able to mute users successfully. As a result, once a learner was muted, only Global Staff could unmute them.

### Root Cause
The issue was caused by incorrect permission handling:
- Discussion Moderators had permission to mute users at course-wide scope
- But they lacked permission to unmute users at the same scope
- Due to this mismatch, the backend API rejected the unmute request with a 400 Bad Request

### Fix Implemented
Aligned permission logic to ensure:
- Users who can mute (course-wide) can also unmute (course-wide)
- Updated permission checks in the discussions moderation API
- Ensured consistent behavior across mute/unmute actions
- 
### Issue Screenshot (Before Fix)

<img width="1894" height="1075" alt="image" src="https://github.com/user-attachments/assets/594e1b12-c816-46d2-a6dc-1de9962c6215" />

### After Fix Screenshot

<img width="1919" height="530" alt="image" src="https://github.com/user-attachments/assets/709871f3-8c77-4b19-8124-65af573bc6f2" />

### Ticket
[Cosmo2-918](https://2u-internal.atlassian.net/jira/software/c/projects/COSMO2/boards/6540?assignee=712020%3A4d94e8bc-90e9-4568-98db-439c22aa6ab0&selectedIssue=COSMO2-918)

