### PR TITLE
fix: resolved “Load more comments” button not rendering issue

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -2234,11 +2234,14 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
             DiscussionEntity.comment,
         )
 
-        comments_count = len(paged_response_comments)
+        total_comments_count = len(response_comments)
         num_pages = (
-            (comments_count + page_size - 1) // page_size if comments_count else 1
+            (total_comments_count + page_size - 1) // page_size
+            if total_comments_count else 1
         )
-        paginator = DiscussionAPIPagination(request, page, num_pages, comments_count)
+        paginator = DiscussionAPIPagination(
+            request, page, num_pages, total_comments_count
+        )
         return paginator.get_paginated_response(results)
     except CommentClientRequestError as err:
         raise CommentNotFoundError("Comment not found") from err


### PR DESCRIPTION
## Description

This PR fixes an issue where the “Load more comments” button was not rendering in discussion threads, preventing users from viewing additional comments beyond the initial set.

### Root Cause

The rendering logic for the pagination control was not being triggered correctly, causing the “Load more comments” button to not appear even when more comments were available

### Ticket

[COSMO2-889](https://2u-internal.atlassian.net/browse/COSMO2-889)