### PR TITLE
fix: Pinned post icon missing in "My Posts" tab

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -146,7 +146,6 @@ from .utils import (
     get_usernames_from_search_string,
     is_captcha_enabled,
     send_signal_after_commit,
-    set_attribute,
     is_posting_allowed,
 )
 
@@ -1449,7 +1448,6 @@ def get_learner_active_thread_list(request, course_key, query_params):
 
     try:
         threads, page, num_pages = comment_client_user.active_threads(query_params)
-        threads = set_attribute(threads, "pinned", False)
 
         if include_muted:
             filtered_threads = threads


### PR DESCRIPTION
## Description

This PR fixes an issue where the Pinned post icon” is missing in the My Posts tab of frontend-app-discussion causing the confusion for the users with respect to All post tab.

### Root Cause

The icons rendering logic is gated by a flag called "pinned" coming from `/api/discussion/v1/courses/COURSE_ID/learner/` endpoint, where the endpoint is returning pinned as False regardless if thread is pinned or not. By removing this logic backend is now able to return correct value to the frontend. 

### Ticket

[COSMO2-894](https://2u-internal.atlassian.net/browse/COSMO2-894)