### PR TITLE
feat: replace enterprise_support with AccountSettingsReadOnlyFields

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3779,6 +3779,10 @@ RECAPTCHA_PROJECT_ID = None
 #    Keys are filter type strings; values are dicts with 'fail_silently' (bool) and
 #    'pipeline' (list of dotted-path strings to PipelineStep subclasses).
 OPEN_EDX_FILTERS_CONFIG = {
+    "org.openedx.learning.account.settings.read_only_fields.requested.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.accounts.AccountSettingsEnterpriseReadOnlyFieldsStep"],
+    },
     "org.openedx.learning.dashboard.render.started.v1": {
         "fail_silently": False,
         "pipeline": ["enterprise.filters.dashboard.DashboardContextEnricher"],

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -84,6 +84,7 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
             'EVENT_BUS_PRODUCER_CONFIG',
             'DEFAULT_FILE_STORAGE',
             'STATICFILES_STORAGE',
+            'OPEN_EDX_FILTERS_CONFIG',
         ]
     })
 
@@ -280,6 +281,19 @@ EVENT_TRACKING_BACKENDS['tracking_logs']['OPTIONS']['backends'].update(
 EVENT_TRACKING_BACKENDS['segmentio']['OPTIONS']['processors'][0]['OPTIONS']['whitelist'].extend(
     EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST
 )
+
+# Merge OPEN_EDX_FILTERS_CONFIG from YAML into the default defined in common.py.
+# Pipeline steps from YAML are appended after steps defined in common.py.
+# The fail_silently value from YAML takes precedence over the one in common.py.
+for _filter_type, _filter_config in _YAML_TOKENS.get('OPEN_EDX_FILTERS_CONFIG', {}).items():
+    if _filter_type in OPEN_EDX_FILTERS_CONFIG:  # noqa: F405
+        OPEN_EDX_FILTERS_CONFIG[_filter_type]['pipeline'].extend(  # noqa: F405
+            _filter_config.get('pipeline', [])
+        )
+        if 'fail_silently' in _filter_config:
+            OPEN_EDX_FILTERS_CONFIG[_filter_type]['fail_silently'] = _filter_config['fail_silently']  # noqa: F405
+    else:
+        OPEN_EDX_FILTERS_CONFIG[_filter_type] = _filter_config  # noqa: F405
 
 if ENABLE_THIRD_PARTY_AUTH:
     AUTHENTICATION_BACKENDS = _YAML_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -12,6 +12,7 @@ from django.core.validators import ValidationError, validate_email
 from django.utils.translation import gettext as _
 from django.utils.translation import override as override_language
 from eventtracking import tracker
+from openedx_filters.learning.filters import AccountSettingsReadOnlyFieldsRequested
 from pytz import UTC
 
 from common.djangoapps.student import views as student_views
@@ -39,7 +40,6 @@ from openedx.core.djangoapps.user_authn.utils import check_pwned_password
 from openedx.core.djangoapps.user_authn.views.registration_form import validate_name, validate_username
 from openedx.core.lib.api.view_utils import add_serializer_errors
 from common.djangoapps.third_party_auth.utils import get_saml_provider_for_user
-from openedx.features.enterprise_support.utils import get_enterprise_readonly_account_fields
 from openedx.features.name_affirmation_api.utils import is_name_affirmation_installed
 
 from .serializers import AccountLegacyProfileSerializer, AccountUserSerializer, UserReadOnlySerializer, _visible_fields
@@ -194,11 +194,17 @@ def update_account_settings(requesting_user, update, username=None):
 
 def _validate_read_only_fields(user, data, field_errors):
     # Check for fields that are not editable. Marking them read-only causes them to be ignored, but we wish to 400.
+    plugin_readonly_fields, __ = AccountSettingsReadOnlyFieldsRequested.run_filter(
+        readonly_fields=set(),
+        user=user,
+    )
+    plugin_readonly_fields = plugin_readonly_fields or set()
+
     read_only_fields = set(data.keys()).intersection(
         # Remove email since it is handled separately below when checking for changing_email.
         (set(AccountUserSerializer.get_read_only_fields()) - {"email"}) |
         set(AccountLegacyProfileSerializer.get_read_only_fields() or set()) |
-        get_enterprise_readonly_account_fields(user)
+        plugin_readonly_fields
     )
 
     for read_only_field in read_only_fields:

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -4,7 +4,6 @@ Most of the functionality is covered in test_views.py.
 """
 
 import datetime
-import itertools
 import unicodedata
 from unittest.mock import Mock, patch
 
@@ -104,10 +103,12 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         self.staff_user = UserFactory(is_staff=True, password=self.password)
         self.reset_tracker()
 
-        enterprise_patcher = patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-        enterprise_learner_patcher = enterprise_patcher.start()
-        enterprise_learner_patcher.return_value = {}
-        self.addCleanup(enterprise_learner_patcher.stop)
+        filter_patcher = patch(
+            'openedx.core.djangoapps.user_api.accounts.api.AccountSettingsReadOnlyFieldsRequested.run_filter',
+            return_value=(set(), None),
+        )
+        filter_patcher.start()
+        self.addCleanup(filter_patcher.stop)
 
     def test_get_username_provided(self):
         """Test the difference in behavior when a username is supplied to get_account_settings."""
@@ -248,73 +249,19 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         account_settings = get_account_settings(self.default_request)[0]
         assert level_of_education == account_settings['level_of_education']
 
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    @patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')
-    @ddt.data(
-        *itertools.product(
-            # field_name_value values
-            (("email", "new_email@example.com"), ("name", "new name"), ("country", "IN")),
-            # is_enterprise_user
-            (True, False),
-            # is_synch_learner_profile_data
-            (True, False),
-            # has `UserSocialAuth` record
-            (True, False),
-        )
+    @patch(
+        'openedx.core.djangoapps.user_api.accounts.api.AccountSettingsReadOnlyFieldsRequested.run_filter',
+        return_value=({'country'}, None),
     )
-    @ddt.unpack
-    def test_update_validation_error_for_enterprise(
-        self,
-        field_name_value,
-        is_enterprise_user,
-        is_synch_learner_profile_data,
-        has_user_social_auth_record,
-        mock_auth_provider,
-        mock_customer,
-    ):
-        idp_backend_name = 'tpa-saml'
-        mock_customer.return_value = {}
-        if is_enterprise_user:
-            mock_customer.return_value.update({
-                'uuid': 'real-ent-uuid',
-                'name': 'Dummy Enterprise',
-                'identity_provider': 'saml-ubc',
-                'identity_providers': [
-                    {
-                        "provider_id": "saml-ubc",
-                    }
-                ],
-            })
-        mock_auth_provider.return_value.sync_learner_profile_data = is_synch_learner_profile_data
-        mock_auth_provider.return_value.backend_name = idp_backend_name
-
-        update_data = {field_name_value[0]: field_name_value[1]}
-
-        user_fullname_editable = False
-        if has_user_social_auth_record:
-            UserSocialAuth.objects.create(
-                provider=idp_backend_name,
-                user=self.user
-            )
-        else:
-            UserSocialAuth.objects.all().delete()
-            # user's fullname is editable if no `UserSocialAuth` record exists
-            user_fullname_editable = field_name_value[0] == 'name'
-
-        # prevent actual email change requests
-        with patch('openedx.core.djangoapps.user_api.accounts.api.student_views.do_email_change_request'):
-            # expect field un-editability only when all of the following conditions are met
-            if is_enterprise_user and is_synch_learner_profile_data and not user_fullname_editable:
-                with pytest.raises(AccountValidationError) as validation_error:
-                    update_account_settings(self.user, update_data)
-                    field_errors = validation_error.value.field_errors
-                    assert 'This field is not editable via this API' == \
-                           field_errors[field_name_value[0]]['developer_message']
-            else:
-                update_account_settings(self.user, update_data)
-                account_settings = get_account_settings(self.default_request)[0]
-                if field_name_value[0] != "email":
-                    assert field_name_value[1] == account_settings[field_name_value[0]]
+    def test_readonly_field_from_filter_is_rejected(self, mock_run_filter):  # pylint: disable=unused-argument
+        """
+        When AccountSettingsReadOnlyFieldsRequested.run_filter returns a field as read-only,
+        update_account_settings should raise AccountValidationError for that field.
+        """
+        with pytest.raises(AccountValidationError) as exc_info:
+            update_account_settings(self.user, {"country": "IN"})
+        field_errors = exc_info.value.field_errors
+        assert 'This field is not editable via this API' == field_errors['country']['developer_message']
 
     def test_update_error_validating(self):
         """Test that AccountValidationError is thrown if incorrect values are supplied."""

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -831,7 +831,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==2.1.0
+openedx-filters==3.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1380,7 +1380,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==2.1.0
+openedx-filters==3.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1005,7 +1005,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==2.1.0
+openedx-filters==3.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1050,7 +1050,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==2.1.0
+openedx-filters==3.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Removes the direct import of get_enterprise_readonly_account_fields from openedx.features.enterprise_support.utils in accounts/api.py and replaces it with a call to the AccountSettingsReadOnlyFieldsRequested openedx-filter. Adds the filter to OPEN_EDX_FILTERS_CONFIG. Updates tests to mock the filter instead of the old enterprise_support imports.

## Supporting information
[ENT-11510](https://2u-internal.atlassian.net/browse/ENT-11510)

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
