### PR TITLE
feat: replace enterprise_support with DashboardRenderStarted filter

### DIFF
--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -59,6 +59,20 @@ class TestDashboardRenderPipelineStep(PipelineStep):
         }
 
 
+class TestEnterpriseContextEnricherStep(PipelineStep):
+    """
+    Utility pipeline step that simulates enterprise context enrichment via DashboardContextEnricher.
+    Verifies that 'request' is present in context and injects a sentinel enterprise key.
+    """
+
+    def run_filter(self, context, template_name):  # pylint: disable=arguments-differ
+        """Inject a sentinel enterprise key to prove the pipeline ran."""
+        assert 'request' in context, "'request' must be in dashboard context for enterprise enrichment"
+        context['enterprise_message'] = 'test-enterprise-message'
+        context['is_enterprise_user'] = True
+        return {"context": context, "template_name": template_name}
+
+
 class TestRenderInvalidDashboard(PipelineStep):
     """
     Utility class used when getting steps for pipeline.
@@ -464,3 +478,27 @@ class StudentDashboardFiltersTest(ModuleStoreTestCase):
 
         self.assertContains(response, self.first_course.id)
         self.assertContains(response, self.second_course.id)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.dashboard.render.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestEnterpriseContextEnricherStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_dashboard_context_enricher_receives_request(self):
+        """
+        Test that the context passed to DashboardRenderStarted includes 'request', allowing
+        pipeline steps like DashboardContextEnricher to access it for enterprise enrichment.
+
+        Expected result:
+            - DashboardRenderStarted is triggered and executes TestEnterpriseContextEnricherStep.
+            - The step finds 'request' in context and injects enterprise sentinel values.
+            - The dashboard renders successfully (HTTP 200).
+        """
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual(response.status_code, 200)

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -48,11 +48,6 @@ from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_bann
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_duration_limits.access import get_user_course_duration, get_user_course_expiration_date
-from openedx.features.enterprise_support.api import (
-    get_dashboard_consent_notification,
-    get_enterprise_learner_portal_context,
-)
-from openedx.features.enterprise_support.utils import is_enterprise_learner
 
 from common.djangoapps.student.api import COURSE_DASHBOARD_PLUGIN_VIEW_NAME
 from common.djangoapps.student.helpers import cert_info, check_verify_status_by_course, get_resume_urls_for_enrollments
@@ -617,8 +612,6 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
             link_end=HTML("</a>"),
         )
 
-    enterprise_message = get_dashboard_consent_notification(request, user, course_enrollments)
-
     recovery_email_message = recovery_email_activation_message = None
     if is_secondary_email_feature_enabled():
         try:
@@ -799,7 +792,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     context = {
         'urls': urls,
         'programs_data': programs_data,
-        'enterprise_message': enterprise_message,
+        'request': request,
         'consent_required_courses': consent_required_courses,
         'enrollment_message': enrollment_message,
         'redirect_message': Text(redirect_message),
@@ -850,13 +843,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
         'course_info': get_dashboard_course_info(user, course_enrollments),
         # TODO START: clean up as part of REVEM-199 (END)
         'disable_unenrollment': disable_unenrollment,
-        # TODO: clean when experiment(Merchandise 2U LOBs - Dashboard) would be stop. [VAN-1097]
-        'is_enterprise_user': is_enterprise_learner(user),
     }
-
-    # Include enterprise learner portal metadata and messaging
-    enterprise_learner_portal_context = get_enterprise_learner_portal_context(request)
-    context.update(enterprise_learner_portal_context)
 
     context_from_plugins = get_plugins_view_context(
         ProjectType.LMS,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3717,3 +3717,15 @@ SSL_AUTH_EMAIL_DOMAIN = "MIT.EDU"
 SSL_AUTH_DN_FORMAT_STRING = (
     "/C=US/ST=Massachusetts/O=Massachusetts Institute of Technology/OU=Client CA v1/CN={0}/emailAddress={1}"
 )
+
+# .. setting_name: OPEN_EDX_FILTERS_CONFIG
+# .. setting_default: {}
+# .. setting_description: Configuration dict for openedx-filters pipeline steps.
+#    Keys are filter type strings; values are dicts with 'fail_silently' (bool) and
+#    'pipeline' (list of dotted-path strings to PipelineStep subclasses).
+OPEN_EDX_FILTERS_CONFIG = {
+    "org.openedx.learning.dashboard.render.started.v1": {
+        "fail_silently": True,
+        "pipeline": [],
+    },
+}

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -519,6 +519,19 @@ EVENT_BUS_PRODUCER_CONFIG = merge_producer_configs(
     _YAML_TOKENS.get('EVENT_BUS_PRODUCER_CONFIG', {})
 )
 
+# Merge OPEN_EDX_FILTERS_CONFIG from YAML into the default defined in common.py.
+# Pipeline steps from YAML are appended after steps defined in common.py.
+# The fail_silently value from YAML takes precedence over the one in common.py.
+for _filter_type, _filter_config in _YAML_TOKENS.get('OPEN_EDX_FILTERS_CONFIG', {}).items():
+    if _filter_type in OPEN_EDX_FILTERS_CONFIG:
+        OPEN_EDX_FILTERS_CONFIG[_filter_type]['pipeline'].extend(
+            _filter_config.get('pipeline', [])
+        )
+        if 'fail_silently' in _filter_config:
+            OPEN_EDX_FILTERS_CONFIG[_filter_type]['fail_silently'] = _filter_config['fail_silently']
+    else:
+        OPEN_EDX_FILTERS_CONFIG[_filter_type] = _filter_config
+
 #######################################################################################################################
 # HEY! Don't add anything to the end of this file.
 # Add your defaults to common.py instead!

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -831,7 +831,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==2.1.0
+openedx-filters==3.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1380,7 +1380,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==2.1.0
+openedx-filters==3.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1005,7 +1005,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==2.1.0
+openedx-filters==3.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1050,7 +1050,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==2.1.0
+openedx-filters==3.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Removes the direct imports of get_dashboard_consent_notification, get_enterprise_learner_portal_context, and is_enterprise_learner from the student dashboard view and lets the DashboardRenderStarted filter pipeline handle enterprise context enrichment instead. Adds 'request' to the context dict so pipeline steps (e.g. DashboardContextEnricher in edx-enterprise) can access it.

## Supporting information

[ENT-11569
](https://2u-internal.atlassian.net/browse/ENT-11563)
[Related openedx-platform PR ](https://github.com/openedx/openedx-platform/pull/38097)

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
