### PR TITLE
fix: update anonymous author labeling for moderator and global staff

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -279,16 +279,21 @@ class _ContentSerializer(serializers.Serializer):
 
         # For anonymous_to_peers posts
         if obj.get("anonymous_to_peers", False):
-            # Authors should always see their own posts as anonymous
-            if obj.get("user_id") and int(obj["user_id"]) == user_id:
-                return True
-
-            # Only moderators and global staff can see the author (not CTAs)
             is_privileged_staff = (
                 user_id in self.context["moderator_user_ids"]
                 or self.context.get("is_global_staff", False)
             )
-            return not is_privileged_staff
+
+            if is_privileged_staff:
+                # Privileged users can see all author names, including their own
+                return False
+
+            # Non-privileged authors should see their own posts as anonymous
+            if obj.get("user_id") and int(obj["user_id"]) == user_id:
+                return True
+
+            # Everyone else sees anonymous
+            return True
 
         return False
 

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -272,26 +272,39 @@ class _ContentSerializer(serializers.Serializer):
         the requester.
         """
         user_id = self.context["request"].user.id
-        is_user_staff = (
-            user_id in self.context["moderator_user_ids"]
-            or user_id in self.context["ta_user_ids"]
-            or self.context.get("is_global_staff", False)
-        )
 
-        return obj["anonymous"] or obj["anonymous_to_peers"] and not is_user_staff
+        # Fully anonymous posts are always anonymous to everyone
+        if obj.get("anonymous", False):
+            return True
+
+        # For anonymous_to_peers posts
+        if obj.get("anonymous_to_peers", False):
+            # Authors should always see their own posts as anonymous
+            if obj.get("user_id") and int(obj["user_id"]) == user_id:
+                return True
+
+            # Only moderators and global staff can see the author (not CTAs)
+            is_privileged_staff = (
+                user_id in self.context["moderator_user_ids"]
+                or self.context.get("is_global_staff", False)
+            )
+            return not is_privileged_staff
+
+        return False
 
     def get_author(self, obj):
         """
-        Returns the author's username, or None if the content is anonymous.
-        Always returns None for anonymous posts to preserve anonymity.
+        Returns the author's username, or None if the content is anonymous to the viewer.
+        For anonymous_to_peers posts, staff/moderators/admins can see the author.
         """
-        return None if self._is_content_anonymous(obj) else obj["username"]
+        return None if self._is_anonymous(obj) else obj["username"]
 
     def get_author_id(self, obj):
         """
         Returns the author's user ID.
         - For non-anonymous posts: available to everyone
-        - For anonymous posts: always null to preserve anonymity
+        - For anonymous posts: null to preserve anonymity
+        - For anonymous_to_peers posts: available to staff/moderators/admins
 
         Note: The backend still has access to the actual author_id through the
         raw content object (obj["user_id"]) for permission checks like can_delete,
@@ -301,9 +314,8 @@ class _ContentSerializer(serializers.Serializer):
         if user_id is None:
             return None
 
-        # For anonymous posts, always hide the author_id to preserve anonymity
-        # Use _is_content_anonymous to check raw flags, not viewer-dependent _is_anonymous
-        if self._is_content_anonymous(obj):
+        # For posts anonymous to the viewer, hide the author_id
+        if self._is_anonymous(obj):
             return None
 
         return str(user_id)
@@ -343,9 +355,10 @@ class _ContentSerializer(serializers.Serializer):
     def get_author_label(self, obj):
         """
         Returns the role label for the content author.
-        Always returns None for anonymous posts to preserve anonymity.
+        Returns None for posts that are anonymous to the viewer.
+        For anonymous_to_peers posts, staff/moderators/admins can see the label.
         """
-        if self._is_content_anonymous(obj) or obj["user_id"] is None:
+        if self._is_anonymous(obj) or obj["user_id"] is None:
             return None
         else:
             user_id = int(obj["user_id"])

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
@@ -583,9 +583,9 @@ class SerializerTestMixin(UrlResetMixin, ForumMockUtilsMixin):
 
     @ddt.data(
         (FORUM_ROLE_ADMINISTRATOR, True, False, True),
-        (FORUM_ROLE_ADMINISTRATOR, False, True, True),
+        (FORUM_ROLE_ADMINISTRATOR, False, True, False),
         (FORUM_ROLE_MODERATOR, True, False, True),
-        (FORUM_ROLE_MODERATOR, False, True, True),
+        (FORUM_ROLE_MODERATOR, False, True, False),
         (FORUM_ROLE_COMMUNITY_TA, True, False, True),
         (FORUM_ROLE_COMMUNITY_TA, False, True, True),
         (FORUM_ROLE_STUDENT, True, False, True),
@@ -596,8 +596,9 @@ class SerializerTestMixin(UrlResetMixin, ForumMockUtilsMixin):
         """
         Test that content is properly made anonymous.
 
-        Content is always anonymous if the anonymous field is true or the
-        anonymous_to_peers field is true, regardless of viewer privileges.
+        Content is always anonymous if the anonymous field is true, regardless of viewer privileges.
+        For anonymous_to_peers posts, privileged users (administrators and moderators) can see the author,
+        but other users (community TAs and students) see it as anonymous.
 
         role_name is the name of the requester's role.
         anonymous is the value of the anonymous field in the content.
@@ -605,7 +606,7 @@ class SerializerTestMixin(UrlResetMixin, ForumMockUtilsMixin):
           content.
         expected_serialized_anonymous is whether the content should actually be
           anonymous in the API output when requested by a user with the given
-          role (now always True when anonymous or anonymous_to_peers is True).
+          role.
         """
         self.register_get_user_response(self.user)
         self.create_role(role_name, [self.user])


### PR DESCRIPTION
###  Description 
This PR updates discussion REST API serialization to refine when a post’s author identity (username/id/role label) is revealed, especially for anonymous_to_peers content, based on requester role (moderator vs. discussion admin vs. global staff).

### Changes:

Reworked _is_anonymous to treat anonymous as always anonymous, and anonymous_to_peers as viewer-dependent.
Updated author, author_id, and author_label to use the viewer-dependent anonymity logic (so moderators/global staff can see author identity for anonymous_to_peers).
Adjusted inline documentation to describe the new behavior (though wording still needs alignment with implementation).