### PR TITLE
fix: cast grading policy corretly as numbers

### DIFF
--- a/lms/djangoapps/course_home_api/progress/api.py
+++ b/lms/djangoapps/course_home_api/progress/api.py
@@ -129,10 +129,10 @@ class _AssignmentTypeGradeAggregator:
         policy_map = {}
         for policy in self.grading_policy.get('GRADER', []):
             policy_map[policy.get('type')] = {
-                'weight': policy.get('weight', 0.0),
+                'weight': float(policy.get('weight', 0.0) or 0.0),
                 'short_label': policy.get('short_label', ''),
-                'num_droppable': policy.get('drop_count', 0),
-                'num_total': policy.get('min_count', 0),
+                'num_droppable': int(policy.get('drop_count', 0) or 0),
+                'num_total': int(policy.get('min_count', 0) or 0),
             }
         return policy_map
 

--- a/lms/djangoapps/course_home_api/progress/tests/test_api.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_api.py
@@ -188,4 +188,4 @@ class ProgressApiTests(TestCase):
                 assert row['average_grade'] == expected['avg']
                 assert row['weighted_grade'] == expected['weighted']
                 assert row['has_hidden_contribution'] == expected['hidden']
-                assert row['num_droppable'] == policy['drop_count']
+                assert row['num_droppable'] == int(policy['drop_count'])

--- a/lms/djangoapps/course_home_api/progress/tests/test_api.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_api.py
@@ -79,6 +79,15 @@ _AGGREGATION_SCENARIOS = [
         ],
         {'avg': 1.0, 'weighted': 1.0, 'hidden': 'none', 'final': 1.0},
     ),
+    (
+        'string_typed_policy_counts',
+        {'type': 'Homework', 'weight': '1.0', 'drop_count': '1', 'min_count': '2', 'short_label': 'HW'},
+        [
+            _make_subsection('Homework', 1, 1, ShowCorrectness.ALWAYS),
+            _make_subsection('Homework', 0, 1, ShowCorrectness.ALWAYS),
+        ],
+        {'avg': 1.0, 'weighted': 1.0, 'hidden': 'none', 'final': 1.0},
+    ),
 ]
 
 


### PR DESCRIPTION
## Description

Fixes a typing issue in grading policies causing breakages on the progress page.

Jira - https://2u-internal.atlassian.net/browse/CR-8030

## Supporting information

Some courses were running into the error below which was a result of a grading policy using strings instead of numbers for their values.

```
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/course_home_api/progress/api.py", line 56, in with_placeholders
    scores=[0] * num_total,
           ~~~~^~~~~~~~~~~
TypeError: can't multiply sequence by non-int of type 'str'
```

This correctly casts numeric values in grading policies to numbers, allowing those mathematical operations to succeed, rather than fail.

## Testing instructions

1. Import a course with grading policies represented with strings rather than numbers.
2. Load the progress page, verify breakage.
3. Load new changes.
4. Reload progress page, verify working.

Unit tests also updated.

## Deadline

ASAP - fix for a C2 bug