### PR TITLE
fix: resolve read/unread state persistence issue

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -48,7 +48,6 @@ from openedx.core.djangoapps.discussions.models import (
     Provider,
 )
 from openedx.core.djangoapps.discussions.utils import get_accessible_discussion_xblocks
-from openedx.core.djangoapps.django_comment_common import comment_client
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.course import (
     get_course_commentable_counts,
@@ -1411,7 +1410,6 @@ def get_learner_active_thread_list(request, course_key, query_params):
     course = _get_course(course_key, request.user)
     context = get_context(course, request)
 
-    group_id = query_params.get("group_id", None)
     user_id = query_params.get("user_id", None)
     count_flagged = query_params.get("count_flagged", None)
     show_deleted = query_params.get("show_deleted", False)
@@ -1437,17 +1435,28 @@ def get_learner_active_thread_list(request, course_key, query_params):
             "show_deleted can only be set by users with moderation roles."
         )
 
-    if group_id is None:
-        comment_client_user = comment_client.User(id=user_id, course_id=course_key)
-    else:
-        comment_client_user = comment_client.User(
-            id=user_id, course_id=course_key, group_id=group_id
-        )
-
     include_muted = query_params.pop('include_muted', False)
 
     try:
-        threads, page, num_pages = comment_client_user.active_threads(query_params)
+        # Use forum v2 API for MySQL backend support
+        # Extract author_id (stored as user_id in query_params)
+        author_id = str(query_params.pop('user_id'))
+        course_id_str = str(course_key)
+
+        # Remove course_id if present since we pass it explicitly
+        query_params.pop('course_id', None)
+
+        response = forum_api.get_user_threads(
+            course_id=course_id_str,
+            author_id=author_id,
+            user_id=str(request.user.id),  # Current user viewing the threads (for read state)
+            context="course",
+            **query_params
+        )
+
+        threads = response.get("collection", [])
+        page = response.get("page", 1)
+        num_pages = response.get("num_pages", 1)
 
         if include_muted:
             filtered_threads = threads
@@ -1458,28 +1467,15 @@ def get_learner_active_thread_list(request, course_key, query_params):
                 threads
             )
 
-        # This portion below is temporary until we migrate to forum v2
+        # Filter by deletion status
         filtered_threads_with_deletion_status = []
         for thread in filtered_threads:
-            try:
-                forum_thread = forum_api.get_thread(
-                    thread.get("id"), course_id=str(course_key)
-                )
-                is_deleted = forum_thread.get("is_deleted", False)
+            is_deleted = thread.get("is_deleted", False)
 
-                if show_deleted and is_deleted:
-                    thread["is_deleted"] = True
-                    thread["deleted_at"] = forum_thread.get("deleted_at")
-                    thread["deleted_by"] = forum_thread.get("deleted_by")
-                    filtered_threads_with_deletion_status.append(thread)
-                elif not show_deleted and not is_deleted:
-                    filtered_threads_with_deletion_status.append(thread)
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                log.warning(
-                    "Failed to check thread %s deletion status: %s", thread.get("id"), e
-                )
-                if not show_deleted:  # Fail safe: include thread for regular users
-                    filtered_threads_with_deletion_status.append(thread)
+            if show_deleted and is_deleted:
+                filtered_threads_with_deletion_status.append(thread)
+            elif not show_deleted and not is_deleted:
+                filtered_threads_with_deletion_status.append(thread)
 
         results = _serialize_discussion_entities(
             request,

--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -1552,6 +1552,17 @@ class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         Sets up the test case
         """
         super().setUp()
+        # Patch forum_api in api module to use the same mock as the mixin
+        self.api_patcher = mock.patch(
+            'lms.djangoapps.discussion.rest_api.api.forum_api',
+            self.mock_forum_api
+        )
+        self.api_patcher.start()
+        self.addCleanup(self.api_patcher.stop)
+
+        # Set up default mock return values for muted users
+        self.set_mock_return_value("get_all_muted_users_for_course", {"muted_users": []})
+
         self.author = self.user
         self.remove_keys = [
             "abuse_flaggers",
@@ -1740,17 +1751,20 @@ class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
         assert response.status_code == 200
         params = {
-            "user_id": str(self.user.id),
             "course_id": str(self.course.id),
+            "author_id": str(self.user.id),
+            "user_id": str(self.user.id),
+            "context": "course",
             "page": 1,
             "per_page": 10,
+            "group_id": None,
+            "count_flagged": False,
             "thread_type": thread_type,
             "sort_key": 'activity',
-            "count_flagged": False,
             "show_deleted": False,
         }
 
-        self.check_mock_called_with("get_user_active_threads", -1, **params)
+        self.check_mock_called_with("get_user_threads", -1, **params)
 
     @ddt.data(
         ("last_activity_at", "activity"),
@@ -1797,15 +1811,19 @@ class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
         assert response.status_code == 200
         params = {
-            "user_id": str(self.user.id),
             "course_id": str(self.course.id),
+            "author_id": str(self.user.id),
+            "user_id": str(self.user.id),
+            "context": "course",
             "page": 1,
             "per_page": 10,
-            "sort_key": cc_query,
+            "group_id": None,
             "count_flagged": False,
+            "thread_type": None,
+            "sort_key": cc_query,
             "show_deleted": False,
         }
-        self.check_mock_called_with("get_user_active_threads", -1, **params)
+        self.check_mock_called_with("get_user_threads", -1, **params)
 
     @ddt.data("flagged", "unanswered", "unread", "unresponded")
     def test_status_by(self, post_status):
@@ -1850,16 +1868,20 @@ class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         else:
             assert response.status_code == 200
             params = {
-                "user_id": str(self.user.id),
                 "course_id": str(self.course.id),
+                "author_id": str(self.user.id),
+                "user_id": str(self.user.id),
+                "context": "course",
                 "page": 1,
                 "per_page": 10,
+                "group_id": None,
+                "count_flagged": False,
+                "thread_type": None,
                 post_status: True,
                 "sort_key": 'activity',
-                "count_flagged": False,
                 "show_deleted": False,
             }
-            self.check_mock_called_with("get_user_active_threads", -1, **params)
+            self.check_mock_called_with("get_user_threads", -1, **params)
 
 
 @ddt.ddt

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -778,7 +778,7 @@ class ForumMockUtilsMixin(MockForumApiMixin):
         self.set_mock_return_value("delete_comment", {})
 
     def register_user_active_threads(self, user_id, response):
-        self.set_mock_return_value("get_user_active_threads", response)
+        self.set_mock_return_value("get_user_threads", response)
 
     def register_get_subscriptions(self, thread_id, response):
         self.set_mock_return_value("get_thread_subscriptions", response)


### PR DESCRIPTION
## Description

This PR fixes an issue where discussion forum threads marked as read were incorrectly showing as unread after a page reload or tab switch.
### Cause

Thread read state was being overwritten by requests that did not contain valid user context, causing already-read threads to appear unread.

### Ticket

[COSMO2-904](https://2u-internal.atlassian.net/browse/COSMO2-904)

### Related PR

https://github.com/edx/forum/pull/48
https://github.com/edx/forum/pull/49