### PR TITLE
fix: more robust casting of int / float in grading policy

### DIFF
--- a/lms/djangoapps/course_home_api/progress/api.py
+++ b/lms/djangoapps/course_home_api/progress/api.py
@@ -17,6 +17,7 @@ User = get_user_model()
 
 
 def _to_float(value, default=0.0) -> float:
+    """Parse a grading policy value as a float, returning default for any unparseable input."""
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -24,6 +25,13 @@ def _to_float(value, default=0.0) -> float:
 
 
 def _to_int(value, default=0) -> int:
+    """
+    Parse a grading policy value as an int, returning default for non-integer or unparseable input.
+
+    Accepts string representations of both integers ('2') and whole-number floats ('2.0').
+    Returns default for non-finite values (nan/inf), fractional floats ('2.9'), and
+    anything that cannot be parsed as a number.
+    """
     try:
         parsed = float(value)
     except (TypeError, ValueError):

--- a/lms/djangoapps/course_home_api/progress/api.py
+++ b/lms/djangoapps/course_home_api/progress/api.py
@@ -20,11 +20,20 @@ def _to_float(value, default=0.0) -> float:
     try:
         return float(value)
     except (TypeError, ValueError):
-        return default
+        return float(default)
 
 
 def _to_int(value, default=0) -> int:
-    return int(_to_float(value, default))
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not parsed.is_integer():
+        return default
+    try:
+        return int(parsed)
+    except (OverflowError, ValueError):
+        return default
 
 
 @dataclass

--- a/lms/djangoapps/course_home_api/progress/api.py
+++ b/lms/djangoapps/course_home_api/progress/api.py
@@ -16,6 +16,17 @@ from dataclasses import dataclass, field
 User = get_user_model()
 
 
+def _to_float(value, default=0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_int(value, default=0) -> int:
+    return int(_to_float(value, default))
+
+
 @dataclass
 class _AssignmentBucket:
     """Holds scores and visibility info for one assignment type.
@@ -129,10 +140,10 @@ class _AssignmentTypeGradeAggregator:
         policy_map = {}
         for policy in self.grading_policy.get('GRADER', []):
             policy_map[policy.get('type')] = {
-                'weight': float(policy.get('weight', 0.0) or 0.0),
+                'weight': _to_float(policy.get('weight')),
                 'short_label': policy.get('short_label', ''),
-                'num_droppable': int(policy.get('drop_count', 0) or 0),
-                'num_total': int(policy.get('min_count', 0) or 0),
+                'num_droppable': _to_int(policy.get('drop_count')),
+                'num_total': _to_int(policy.get('min_count')),
             }
         return policy_map
 

--- a/lms/djangoapps/course_home_api/progress/tests/test_api.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_api.py
@@ -197,4 +197,4 @@ class ProgressApiTests(TestCase):
                 assert row['average_grade'] == expected['avg']
                 assert row['weighted_grade'] == expected['weighted']
                 assert row['has_hidden_contribution'] == expected['hidden']
-                assert row['num_droppable'] == int(policy['drop_count'])
+                assert row['num_droppable'] == int(float(policy['drop_count']))

--- a/lms/djangoapps/course_home_api/progress/tests/test_api.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_api.py
@@ -80,8 +80,17 @@ _AGGREGATION_SCENARIOS = [
         {'avg': 1.0, 'weighted': 1.0, 'hidden': 'none', 'final': 1.0},
     ),
     (
-        'string_typed_policy_counts',
+        'string_int_typed_policy_counts',
         {'type': 'Homework', 'weight': '1.0', 'drop_count': '1', 'min_count': '2', 'short_label': 'HW'},
+        [
+            _make_subsection('Homework', 1, 1, ShowCorrectness.ALWAYS),
+            _make_subsection('Homework', 0, 1, ShowCorrectness.ALWAYS),
+        ],
+        {'avg': 1.0, 'weighted': 1.0, 'hidden': 'none', 'final': 1.0},
+    ),
+    (
+        'string_float_typed_policy_counts',
+        {'type': 'Homework', 'weight': '1.0', 'drop_count': '1.0', 'min_count': '2.0', 'short_label': 'HW'},
         [
             _make_subsection('Homework', 1, 1, ShowCorrectness.ALWAYS),
             _make_subsection('Homework', 0, 1, ShowCorrectness.ALWAYS),


### PR DESCRIPTION
## Description

Better handles mistyped values in Grading Policies, as below:

```json
{
    "str_of_float_which_should_be_int": "2.0",
    "str_of_float_which_should_be_float": "1.234",
    "str_of_int_which_should_be_int": "2",
    "float_which_should_be_int": 2.0,
    "int_which_should_be_int": 2,
    "float_which_should_be_float": 1.234
}
```

Previously, string representations of numbers would cause breakages. Blind casting to `float` or `int` caused issues where an `int` represented as a `str` formatted as a `float` would cause further casting issues.

## Supporting information

Jira - https://2u-internal.atlassian.net/browse/AU-2934

Builds off of #273 , which added `int` casting of `str`, this further adds conversion of `float` represented as `str` (e.g. `2.0`) for a value that should be an `int`.

## Testing instructions

Load currently breaking progress page, verify fix causes page to work correctly.

## Deadline

ASAP - Currently causing C2 learner issue.