### PR TITLE
fix: ban/unban inconsistencies and org-level 403 error

### DIFF
--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -2401,11 +2401,23 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
             404: 'The specified user does not exist.',
         },
     )
-    def _validate_ban_request_and_get_user(self, request, serializer_data):
+    def _validate_ban_request_and_get_user(self, request, serializer_data, check_privileged=True):
         """
-        Validate ban request and retrieve target user.
+        Validate ban/unban request and retrieve target user.
+
+        Args:
+            request: The HTTP request object
+            serializer_data: Validated serializer data
+            check_privileged: If True, prevents banning privileged users.
+                             Set to False to allow banning/unbanning of discussion staff.
+                             (Default: True for backward compatibility, but set to False
+                             to allow moderators/admins to ban each other)
 
         Returns tuple of (user, course_key, ban_scope, reason) or Response object on error.
+
+        Note:
+            As of the current implementation, check_privileged should be set to False
+            to allow discussion admins, moderators, and global staff to ban/unban each other.
         """
         from lms.djangoapps.discussion.rest_api.utils import (
             _is_privileged_user,
@@ -2442,8 +2454,8 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
                 status=status.HTTP_404_NOT_FOUND
             )
 
-        # Check if user is staff/privileged - they shouldn't be banned
-        if _is_privileged_user(user, course_key):
+        # Allow discussion admins, moderators, and global staff to ban/unban each other.
+        if check_privileged and _is_privileged_user(user, course_key):
             return Response(
                 {
                     'error': (
@@ -2620,7 +2632,9 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         # Validate and get user
-        result = self._validate_ban_request_and_get_user(request, serializer.validated_data)
+        result = self._validate_ban_request_and_get_user(
+            request, serializer.validated_data, check_privileged=False
+        )
         if isinstance(result, Response):
             error_type = "permission_denied" if result.status_code == status.HTTP_403_FORBIDDEN else "validation_error"
             _set_trace_outcome(result.status_code, error_type)
@@ -2818,7 +2832,9 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         # Validate and get user
-        result = self._validate_ban_request_and_get_user(request, serializer.validated_data)
+        result = self._validate_ban_request_and_get_user(
+            request, serializer.validated_data, check_privileged=False
+        )
         if isinstance(result, Response):
             set_custom_attribute("forum.result", "error")
             set_custom_attribute("forum.http_status", str(result.status_code))
@@ -2999,10 +3015,9 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
             * If ban_user is true, a ban record will be created after content deletion
             * Reason is required when ban_user is true
             * Email notification is sent to partner-support upon ban
-            * Staff and privileged users cannot be banned
+            * Discussion admins, moderators, and global staff can ban each other
         """
         from lms.djangoapps.discussion.rest_api.serializers import BulkDeleteBanRequestSerializer
-        from lms.djangoapps.discussion.rest_api.utils import _is_privileged_user
 
         serializer = BulkDeleteBanRequestSerializer(data=request.data, context={'request': request})
         if not serializer.is_valid():
@@ -3023,18 +3038,6 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
             return Response(
                 {'error': f'User with ID {validated_data["user_id"]} does not exist'},
                 status=status.HTTP_404_NOT_FOUND
-            )
-
-        # Check if target user is staff/privileged - they shouldn't be banned
-        if validated_data['ban_user'] and _is_privileged_user(target_user, course_key):
-            return Response(
-                {
-                    'error': (
-                        f'Cannot ban staff or privileged users. User {target_user.username} '
-                        f'has elevated permissions in this course.'
-                    )
-                },
-                status=status.HTTP_400_BAD_REQUEST
             )
 
         # Check if ban feature is enabled for this course
@@ -3146,9 +3149,8 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
             * Only returns active bans (is_active=True)
             * Course-level bans are specific to one course
             * Organization-level bans apply to all courses in the organization
-            * Shows ALL banned users including staff (so they can be unbanned if mistakenly banned)
+            * Shows ALL banned users including discussion staff (admins, moderators, global staff)
             * Deduplicates users with multiple ban records (e.g., course-level + org-level)
-            * New bans of staff are prevented by validation in ban endpoints
         """
         from forum import api as forum_api
 


### PR DESCRIPTION
## Description
Ban/unban functionality is inconsistent across different contexts in Discussions.
Org-level ban returns a 403 error
Course-level ban works correctly
Users banned from a comment/response cannot be unbanned from the same context
Unban is only possible from the parent post
### Expected
Ban/unban should work consistently across org, course, posts, and comments.
### Ticket
[COSMO2-983](https://2u-internal.atlassian.net/browse/COSMO2-893)