### PR TITLE
feat: hand OPEN_EDX_FILTERS_CONFIG enterpise injection ownership to enterprise/consent plugin

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3773,23 +3773,6 @@ RECAPTCHA_SITE_KEYS = {
 #     The project ID should be obtained from the Google Cloud Console when creating a reCAPTCHA
 RECAPTCHA_PROJECT_ID = None
 
-# .. setting_name: OPEN_EDX_FILTERS_CONFIG
-# .. setting_default: {}
-# .. setting_description: Configuration dict for openedx-filters pipeline steps.
-#    Keys are filter type strings; values are dicts with 'fail_silently' (bool) and
-#    'pipeline' (list of dotted-path strings to PipelineStep subclasses).
-OPEN_EDX_FILTERS_CONFIG = {
-    "org.openedx.learning.account.settings.read_only_fields.requested.v1": {
-        "fail_silently": False,
-        "pipeline": ["enterprise.filters.accounts.AccountSettingsEnterpriseReadOnlyFieldsStep"],
-    },
-    "org.openedx.learning.dashboard.render.started.v1": {
-        "fail_silently": False,
-        "pipeline": ["enterprise.filters.dashboard.DashboardContextEnricher"],
-    },
-}
-
-
 ############################## Miscellaneous ###############################
 
 # To limit the number of courses displayed on learner dashboard

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -84,7 +84,6 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
             'EVENT_BUS_PRODUCER_CONFIG',
             'DEFAULT_FILE_STORAGE',
             'STATICFILES_STORAGE',
-            'OPEN_EDX_FILTERS_CONFIG',
         ]
     })
 
@@ -281,19 +280,6 @@ EVENT_TRACKING_BACKENDS['tracking_logs']['OPTIONS']['backends'].update(
 EVENT_TRACKING_BACKENDS['segmentio']['OPTIONS']['processors'][0]['OPTIONS']['whitelist'].extend(
     EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST
 )
-
-# Merge OPEN_EDX_FILTERS_CONFIG from YAML into the default defined in common.py.
-# Pipeline steps from YAML are appended after steps defined in common.py.
-# The fail_silently value from YAML takes precedence over the one in common.py.
-for _filter_type, _filter_config in _YAML_TOKENS.get('OPEN_EDX_FILTERS_CONFIG', {}).items():
-    if _filter_type in OPEN_EDX_FILTERS_CONFIG:  # noqa: F405
-        OPEN_EDX_FILTERS_CONFIG[_filter_type]['pipeline'].extend(  # noqa: F405
-            _filter_config.get('pipeline', [])
-        )
-        if 'fail_silently' in _filter_config:
-            OPEN_EDX_FILTERS_CONFIG[_filter_type]['fail_silently'] = _filter_config['fail_silently']  # noqa: F405
-    else:
-        OPEN_EDX_FILTERS_CONFIG[_filter_type] = _filter_config  # noqa: F405
 
 if ENABLE_THIRD_PARTY_AUTH:
     AUTHENTICATION_BACKENDS = _YAML_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -42,7 +42,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==8.0.12
+edx-enterprise==8.0.14
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -473,7 +473,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.0.12
+edx-enterprise==8.0.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.0.12
+edx-enterprise==8.0.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -557,7 +557,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.0.12
+edx-enterprise==8.0.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -578,7 +578,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.0.12
+edx-enterprise==8.0.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
The goal of this migrated logic is to be able to inject enterprise-specific pipeline steps while preserving any operator-defined keys and pipeline steps.

It is being migrated into the enterprise/consent plugins to better compartmentalize enterprise-specific logic and keep enterprise code paths outside of the platform.

ENT-11830

---

* Depends on: https://github.com/openedx/edx-enterprise/pull/2617
* Sibling to: https://github.com/openedx/openedx-platform/pull/38634