### PR TITLE
fix: update role-based ban and unban permissions for discussion roles

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_moderation_permissions.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_moderation_permissions.py
@@ -1,7 +1,7 @@
 """
 Tests for discussion moderation permissions.
 """
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from rest_framework.test import APIRequestFactory
 
@@ -205,3 +205,393 @@ class IsAllowedToBulkDeleteTest(ModuleStoreTestCase):
         view = self._create_view_with_kwargs()
 
         self.assertFalse(self.permission.has_permission(request, view))
+
+
+class RoleBasedBanPermissionsTest(ModuleStoreTestCase):
+    """Tests for role-based ban/unban permissions in DiscussionModerationViewSet."""
+
+    # pylint: disable=protected-access
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(org='TestX', number='CS101', run='2024')
+        self.course_key = self.course.id
+
+        # Create users with different roles
+        self.global_staff_user = UserFactory.create(username='global_staff')
+        GlobalStaff().add_users(self.global_staff_user)
+
+        self.admin_user = UserFactory.create(username='admin_user')
+        admin_role = Role.objects.create(name='Administrator', course_id=self.course_key)
+        admin_role.users.add(self.admin_user)
+
+        self.moderator_user = UserFactory.create(username='moderator_user')
+        moderator_role = Role.objects.create(name='Moderator', course_id=self.course_key)
+        moderator_role.users.add(self.moderator_user)
+
+        self.global_staff_admin_user = UserFactory.create(username='global_staff_admin')
+        GlobalStaff().add_users(self.global_staff_admin_user)
+        admin_role.users.add(self.global_staff_admin_user)
+
+        self.global_staff_moderator_user = UserFactory.create(username='global_staff_moderator')
+        GlobalStaff().add_users(self.global_staff_moderator_user)
+        moderator_role.users.add(self.global_staff_moderator_user)
+
+        self.regular_user = UserFactory.create(username='regular_user')
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_global_staff_without_discussion_role_cannot_ban_moderator(self, mock_flag):
+        """Global Staff without discussion role cannot ban Discussion Moderator."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+        from rest_framework.response import Response
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.global_staff_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.moderator_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return error response
+        self.assertIsInstance(result, Response)
+        self.assertEqual(result.status_code, 403)
+        self.assertIn('Global Staff cannot ban discussion privileged users', result.data['error'])
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_global_staff_without_discussion_role_cannot_ban_admin(self, mock_flag):
+        """Global Staff without discussion role cannot ban Discussion Admin."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+        from rest_framework.response import Response
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.global_staff_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.admin_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return error response
+        self.assertIsInstance(result, Response)
+        self.assertEqual(result.status_code, 403)
+        self.assertIn('Global Staff cannot ban discussion privileged users', result.data['error'])
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_moderator_cannot_ban_admin(self, mock_flag):
+        """Discussion Moderator should NOT be able to ban Discussion Admin."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+        from rest_framework.response import Response
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.moderator_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.admin_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return error response
+        self.assertIsInstance(result, Response)
+        self.assertEqual(result.status_code, 403)
+        self.assertIn('Discussion Moderators cannot ban Discussion Admins', result.data['error'])
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_moderator_can_ban_global_staff(self, mock_flag):
+        """Discussion Moderator should be able to ban Global Staff users."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.moderator_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.global_staff_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return tuple (user, course_key, ban_scope, reason)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result[0], self.global_staff_user)
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_admin_can_ban_moderator(self, mock_flag):
+        """Discussion Admin should be able to ban Discussion Moderator."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.admin_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.moderator_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return tuple
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], self.moderator_user)
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_admin_can_ban_global_staff(self, mock_flag):
+        """Discussion Admin should be able to ban Global Staff users."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.admin_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.global_staff_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return tuple
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], self.global_staff_user)
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_global_staff_without_discussion_role_cannot_ban_global_staff(self, mock_flag):
+        """Global Staff without Discussion role cannot ban another Global Staff."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+        from rest_framework.response import Response
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.global_staff_user
+
+        # Create another global staff user
+        another_global_staff = UserFactory.create(username='another_global_staff')
+        GlobalStaff().add_users(another_global_staff)
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': another_global_staff.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return error response
+        self.assertIsInstance(result, Response)
+        self.assertEqual(result.status_code, 403)
+        self.assertIn('Global Staff cannot ban another Global Staff', result.data['error'])
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_global_staff_with_admin_role_can_ban_moderator(self, mock_flag):
+        """Global Staff with Discussion Admin role can ban Discussion Moderators."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.global_staff_admin_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.moderator_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return tuple
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], self.moderator_user)
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_global_staff_with_admin_role_cannot_ban_admin(self, mock_flag):
+        """Global Staff with Admin role cannot ban other Discussion Admins (Rule 2)."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+        from rest_framework.response import Response
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.global_staff_admin_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.admin_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return error response - Rule 2 (Admins cannot ban other Admins)
+        self.assertIsInstance(result, Response)
+        self.assertEqual(result.status_code, 403)
+        self.assertIn('Discussion Admins cannot ban other Discussion Admins', result.data['error'])
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_global_staff_with_admin_role_cannot_ban_global_staff_without_moderator_role(self, mock_flag):
+        """Global Staff with Admin role (but not Moderator) cannot ban Global Staff without Moderator role."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+        from rest_framework.response import Response
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.global_staff_admin_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.global_staff_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return error response - Rule 4 (Global Staff+Admin can only ban Moderators)
+        self.assertIsInstance(result, Response)
+        self.assertEqual(result.status_code, 403)
+        self.assertIn(
+            'Global Staff with Discussion Admin role can only ban Discussion Moderators',
+            result.data['error']
+        )
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_global_staff_with_moderator_role_can_ban_global_staff(self, mock_flag):
+        """Global Staff with Moderator role can ban other Global Staff."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.global_staff_moderator_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.global_staff_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return tuple
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], self.global_staff_user)
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_moderator_can_ban_regular_user(self, mock_flag):
+        """Discussion Moderator can ban regular users."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.moderator_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.regular_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return tuple
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], self.regular_user)
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_admin_can_ban_regular_user(self, mock_flag):
+        """Discussion Admin can ban regular users."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.admin_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.regular_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return tuple
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], self.regular_user)
+
+    @patch('lms.djangoapps.discussion.toggles.ENABLE_DISCUSSION_BAN.is_enabled')
+    def test_global_staff_with_admin_role_can_ban_regular_user(self, mock_flag):
+        """Global Staff with Admin role can ban regular users."""
+        from lms.djangoapps.discussion.rest_api.views import DiscussionModerationViewSet
+
+        mock_flag.return_value = True
+        viewset = DiscussionModerationViewSet()
+        request = Mock()
+        request.user = self.global_staff_admin_user
+
+        result = viewset._validate_ban_request_and_get_user(
+            request,
+            {
+                'lookup_username': self.regular_user.username,
+                'course_id': str(self.course_key),
+                'scope': 'course',
+            },
+            check_privileged=False
+        )
+
+        # Should return tuple (user, course_key, ban_scope, reason)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result[0], self.regular_user)

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -36,6 +36,7 @@ from lms.djangoapps.course_goals.models import UserActivity
 from lms.djangoapps.discussion.django_comment_client import settings as cc_settings
 from lms.djangoapps.discussion.django_comment_client.utils import (
     get_group_id_for_comments_service,
+    get_user_role_names,
 )
 from lms.djangoapps.discussion.rate_limit import is_content_creation_rate_limited
 from lms.djangoapps.discussion.rest_api.permissions import (
@@ -119,6 +120,7 @@ from ..rest_api.serializers import (
 from common.djangoapps.student.roles import GlobalStaff
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
+    FORUM_ROLE_MODERATOR,
 )
 from .utils import (
     create_blocks_params,
@@ -2454,17 +2456,96 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
                 status=status.HTTP_404_NOT_FOUND
             )
 
-        # Allow discussion admins, moderators, and global staff to ban/unban each other.
-        if check_privileged and _is_privileged_user(user, course_key):
+        # Check role-based ban permissions based on hierarchy
+        moderator_roles = get_user_role_names(request.user, course_key)
+        target_roles = get_user_role_names(user, course_key)
+
+        # simplified: inline set conversion with membership checks for O(1) lookups
+        moderator_is_global_staff = GlobalStaff().has_user(request.user)
+        moderator_is_admin = FORUM_ROLE_ADMINISTRATOR in set(moderator_roles)
+        moderator_is_moderator = FORUM_ROLE_MODERATOR in set(moderator_roles)
+        target_is_global_staff = GlobalStaff().has_user(user)
+        target_is_admin = FORUM_ROLE_ADMINISTRATOR in set(target_roles)
+        target_is_moderator = FORUM_ROLE_MODERATOR in set(target_roles)
+
+        # Rule 0: Global Staff without discussion roles cannot ban Discussion Admins or Moderators
+        # simplified: inline compound conditions directly in if statement
+        if (moderator_is_global_staff and not (moderator_is_admin or moderator_is_moderator)
+                and (target_is_admin or target_is_moderator)):
+            return Response(
+                {
+                    # simplified: broke long line to fit 120 char limit
+                    'error': (
+                        f'Global Staff cannot ban discussion privileged users unless they have '
+                        f'Discussion Admin or Moderator permissions. '
+                        f'User {user.username} has discussion privileges.'
+                    )
+                },
+                status=status.HTTP_403_FORBIDDEN
+            )
+
+        # Rule 1: Moderator cannot ban Discussion Admin or other Moderators
+        # simplified: inline moderator-only check
+        if moderator_is_moderator and not moderator_is_admin:
+            if target_is_admin:
+                return Response(
+                    {
+                        'error': (
+                            f'Discussion Moderators cannot ban Discussion Admins. '
+                            f'User {user.username} is a Discussion Admin.'
+                        )
+                    },
+                    status=status.HTTP_403_FORBIDDEN
+                )
+            if target_is_moderator:
+                return Response(
+                    {
+                        'error': (
+                            f'Discussion Moderators cannot ban other Discussion Moderators. '
+                            f'User {user.username} is a Discussion Moderator.'
+                        )
+                    },
+                    status=status.HTTP_403_FORBIDDEN
+                )
+
+        # Rule 2: Discussion Admins cannot ban other Discussion Admins
+        if moderator_is_admin and target_is_admin:
             return Response(
                 {
                     'error': (
-                        f'Cannot ban staff or privileged users. User {user.username} '
-                        f'has elevated permissions in this course.'
+                        f'Discussion Admins cannot ban other Discussion Admins. '
+                        f'User {user.username} is a Discussion Admin.'
                     )
                 },
-                status=status.HTTP_400_BAD_REQUEST
+                status=status.HTTP_403_FORBIDDEN
             )
+
+        # Rule 3: Global Staff without discussion roles cannot ban another Global Staff
+        if (moderator_is_global_staff and not (moderator_is_admin or moderator_is_moderator)
+                and target_is_global_staff):
+            return Response(
+                {
+                    'error': (
+                        f'Global Staff cannot ban another Global Staff unless they have '
+                        f'Discussion Admin or Moderator permissions. '
+                        f'User {user.username} is Global Staff.'
+                    )
+                },
+                status=status.HTTP_403_FORBIDDEN
+            )
+
+        # Rule 4: Global Staff with Admin role (but not Moderator) cannot ban Global Staff (unless Moderator)
+        if moderator_is_global_staff and moderator_is_admin and not moderator_is_moderator:
+            if target_is_global_staff and not target_is_moderator:
+                return Response(
+                    {
+                        'error': (
+                            f'Global Staff with Discussion Admin role can only ban Discussion Moderators. '
+                            f'User {user.username} is Global Staff without Moderator role.'
+                        )
+                    },
+                    status=status.HTTP_403_FORBIDDEN
+                )
 
         return user, course_key, ban_scope, reason
 
@@ -3047,6 +3128,97 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
                     {'error': 'Discussion ban feature is not enabled for this course'},
                     status=status.HTTP_403_FORBIDDEN
                 )
+
+            # Check role-based ban permissions
+            moderator_roles = get_user_role_names(request.user, course_key)
+            target_roles = get_user_role_names(target_user, course_key)
+
+            # simplified: inline set conversion with membership checks for O(1) lookups
+            moderator_is_global_staff = GlobalStaff().has_user(request.user)
+            moderator_is_admin = FORUM_ROLE_ADMINISTRATOR in set(moderator_roles)
+            moderator_is_moderator = FORUM_ROLE_MODERATOR in set(moderator_roles)
+            target_is_global_staff = GlobalStaff().has_user(target_user)
+            target_is_admin = FORUM_ROLE_ADMINISTRATOR in set(target_roles)
+            target_is_moderator = FORUM_ROLE_MODERATOR in set(target_roles)
+
+            # Rule 0: Global Staff without discussion roles cannot ban Discussion Admins or Moderators
+            # simplified: inline compound conditions directly in if statement
+            if (moderator_is_global_staff and not (moderator_is_admin or moderator_is_moderator)
+                    and (target_is_admin or target_is_moderator)):
+                return Response(
+                    {
+                        # simplified: broke long line to fit 120 char limit
+                        'error': (
+                            f'Global Staff cannot ban discussion privileged users unless they have '
+                            f'Discussion Admin or Moderator permissions. '
+                            f'User {target_user.username} has discussion privileges.'
+                        )
+                    },
+                    status=status.HTTP_403_FORBIDDEN
+                )
+
+            # Rule 1: Moderator cannot ban Discussion Admin or other Moderators
+            # simplified: inline moderator-only check
+            if moderator_is_moderator and not moderator_is_admin:
+                if target_is_admin:
+                    return Response(
+                        {
+                            'error': (
+                                f'Discussion Moderators cannot ban Discussion Admins. '
+                                f'User {target_user.username} is a Discussion Admin.'
+                            )
+                        },
+                        status=status.HTTP_403_FORBIDDEN
+                    )
+                if target_is_moderator:
+                    return Response(
+                        {
+                            'error': (
+                                f'Discussion Moderators cannot ban other Discussion Moderators. '
+                                f'User {target_user.username} is a Discussion Moderator.'
+                            )
+                        },
+                        status=status.HTTP_403_FORBIDDEN
+                    )
+
+            # Rule 2: Discussion Admins cannot ban other Discussion Admins
+            if moderator_is_admin and target_is_admin:
+                return Response(
+                    {
+                        'error': (
+                            f'Discussion Admins cannot ban other Discussion Admins. '
+                            f'User {target_user.username} is a Discussion Admin.'
+                        )
+                    },
+                    status=status.HTTP_403_FORBIDDEN
+                )
+
+            # Rule 3: Global Staff without discussion roles cannot ban another Global Staff
+            if (moderator_is_global_staff and not (moderator_is_admin or moderator_is_moderator)
+                    and target_is_global_staff):
+                return Response(
+                    {
+                        'error': (
+                            f'Global Staff cannot ban another Global Staff unless they have '
+                            f'Discussion Admin or Moderator permissions. '
+                            f'User {target_user.username} is Global Staff.'
+                        )
+                    },
+                    status=status.HTTP_403_FORBIDDEN
+                )
+
+            # Rule 4: Global Staff with Admin role (but not Moderator) cannot ban Global Staff (unless Moderator)
+            if moderator_is_global_staff and moderator_is_admin and not moderator_is_moderator:
+                if target_is_global_staff and not target_is_moderator:
+                    return Response(
+                        {
+                            'error': (
+                                f'Global Staff with Discussion Admin role can only ban Discussion Moderators. '
+                                f'User {target_user.username} is Global Staff without Moderator role.'
+                            )
+                        },
+                        status=status.HTTP_403_FORBIDDEN
+                    )
 
         # Enqueue Celery task (backward compatible with new parameters)
         task = delete_course_post_for_user.apply_async(


### PR DESCRIPTION
### Description
The current banning and unbanning behavior does not fully align with the expected role-based permission hierarchy for Global Staff, Discussion Admins, and Discussion Moderators.

This update introduces role-based permission handling for both ban and unban actions to ensure moderation behavior matches the expected access rules and prevents unauthorized actions.

### Expected Permission Rules
#### Global Staff
  - Can be banned by users with discussion permissions
  - Cannot ban another Global Staff user unless they also have Discussion Admin or Discussion Moderator permissions
  - If assigned Discussion Admin permissions, they can only ban Discussion Moderators
#### Discussion Admin
  - Can ban and unban Discussion Moderators
  - Can ban and unban Global Staff users
  - Cannot be banned or unbanned by Discussion Moderators
#### Discussion Moderator
  - Can ban and unban Global Staff users
  - Cannot ban or unban Discussion Admins
  
 ### Ticket
[ Cosmo2-963](https://2u-internal.atlassian.net/browse/COSMO2-963)