### PR TITLE
feat: replace enterprise_support import with GradeEventContextRequest…

### DIFF
--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -15,6 +15,7 @@ from openedx_events.learning.data import (
     UserPersonalData
 )
 from openedx_events.learning.signals import CCX_COURSE_PASSING_STATUS_UPDATED, COURSE_PASSING_STATUS_UPDATED
+from openedx_filters.learning.filters import GradeEventContextRequested
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
@@ -27,7 +28,6 @@ from common.djangoapps.track.event_transaction_utils import (
 )
 from lms.djangoapps.grades.signals.signals import SCHEDULE_FOLLOW_UP_SEGMENT_EVENT_FOR_COURSE_PASSED_FIRST_TIME
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.features.enterprise_support.context import get_enterprise_event_context
 
 log = getLogger(__name__)
 
@@ -166,10 +166,25 @@ def course_grade_passed_first_time(user_id, course_id):
     """
     event_name = COURSE_GRADE_PASSED_FIRST_TIME_EVENT_TYPE
     context = contexts.course_context_from_course_id(course_id)
-    context_enterprise = get_enterprise_event_context(user_id, course_id)
-    context.update(context_enterprise)
+    try:
+        filtered_context, _, _ = GradeEventContextRequested.run_filter(
+            context=context, user_id=user_id, course_id=course_id
+        )
+    except Exception:  # pylint: disable=broad-except
+        log.exception(
+            'GradeEventContextRequested failed for user_id=%s course_id=%s',
+            user_id,
+            course_id,
+        )
+        raise
+    log.info(
+        'GradeEventContextRequested succeeded for user_id=%s course_id=%s',
+        user_id,
+        course_id,
+    )
+
     # TODO (AN-6134): remove this context manager
-    with tracker.get_tracker().context(event_name, context):
+    with tracker.get_tracker().context(event_name, filtered_context):
         tracker.emit(
             event_name,
             {

--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -177,7 +177,7 @@ def course_grade_passed_first_time(user_id, course_id):
             course_id,
         )
         raise
-    log.info(
+    log.debug(
         'GradeEventContextRequested succeeded for user_id=%s course_id=%s',
         user_id,
         course_id,

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -3,6 +3,7 @@ Test that various events are fired for models in the grades app.
 """
 
 from unittest import mock
+from unittest.mock import patch
 
 from ccx_keys.locator import CCXLocator
 from django.utils.timezone import now
@@ -251,4 +252,101 @@ class CCXCoursePassingStatusEventsTest(
                 ),
             },
             event_receiver.call_args.kwargs,
+        )
+
+
+class GradeEventContextFilterTest(SharedModuleStoreTestCase):
+    """
+    Tests that course_grade_passed_first_time invokes the GradeEventContextRequested
+    filter instead of the old enterprise_support import.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create()
+        self.course = CourseFactory.create()
+
+    @patch('lms.djangoapps.grades.events.GradeEventContextRequested.run_filter')
+    def test_filter_called_with_context(self, mock_run_filter):
+        """
+        course_grade_passed_first_time should call GradeEventContextRequested.run_filter
+        and merge the returned context.
+        """
+        original_context = {"course_id": str(self.course.id), "base_key": "base_value"}
+        filtered_context = {"org": "test_org", "enterprise_uuid": "abc-123"}
+        expected_context = {
+            "course_id": str(self.course.id),
+            "base_key": "base_value",
+            "org": "test_org",
+            "enterprise_uuid": "abc-123",
+        }
+        mock_run_filter.return_value = (filtered_context, self.user.id, self.course.id)
+
+        from lms.djangoapps.grades.events import course_grade_passed_first_time
+        with (
+            patch(
+                'lms.djangoapps.grades.events.contexts.course_context_from_course_id',
+                return_value=original_context,
+            ),
+            patch('lms.djangoapps.grades.events.tracker') as mock_tracker,
+        ):
+            course_grade_passed_first_time(self.user.id, self.course.id)
+
+        mock_run_filter.assert_called_once()
+        call_kwargs = mock_run_filter.call_args.kwargs
+        assert call_kwargs['context'] == original_context
+        assert call_kwargs['user_id'] == self.user.id
+        assert str(call_kwargs['course_id']) == str(self.course.id)
+        mock_tracker.get_tracker.return_value.context.assert_called_once_with(
+            'edx.course.grade.passed.first_time',
+            expected_context,
+        )
+
+    @patch('lms.djangoapps.grades.events.GradeEventContextRequested.run_filter')
+    def test_filter_none_return_leaves_context_intact(self, mock_run_filter):
+        """
+        If run_filter returns None, context is not overwritten.
+        """
+        original_context = {"course_id": str(self.course.id)}
+        mock_run_filter.return_value = (None, self.user.id, self.course.id)
+
+        from lms.djangoapps.grades.events import course_grade_passed_first_time
+        with (
+            patch(
+                'lms.djangoapps.grades.events.contexts.course_context_from_course_id',
+                return_value=original_context,
+            ),
+            patch('lms.djangoapps.grades.events.tracker') as mock_tracker,
+        ):
+            course_grade_passed_first_time(self.user.id, self.course.id)
+
+        mock_tracker.get_tracker.return_value.context.assert_called_once_with(
+            'edx.course.grade.passed.first_time',
+            original_context,
+        )
+
+    @patch('lms.djangoapps.grades.events.GradeEventContextRequested.run_filter')
+    def test_filter_exception_leaves_context_intact(self, mock_run_filter):
+        """
+        If run_filter raises an exception, the original context is used and the
+        event still emits, as enterprise specific code is optional.
+        """
+        original_context = {"course_id": str(self.course.id)}
+        mock_run_filter.side_effect = Exception("boom")
+
+        from lms.djangoapps.grades.events import course_grade_passed_first_time
+        with (
+            patch(
+                'lms.djangoapps.grades.events.contexts.course_context_from_course_id',
+                return_value=original_context,
+            ),
+            patch('lms.djangoapps.grades.events.tracker') as mock_tracker,
+            patch('lms.djangoapps.grades.events.log') as mock_log,
+        ):
+            course_grade_passed_first_time(self.user.id, self.course.id)
+
+        mock_log.exception.assert_called_once()
+        mock_tracker.get_tracker.return_value.context.assert_called_once_with(
+            'edx.course.grade.passed.first_time',
+            original_context,
         )

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -258,7 +258,7 @@ class CCXCoursePassingStatusEventsTest(
 class GradeEventContextFilterTest(SharedModuleStoreTestCase):
     """
     Tests that course_grade_passed_first_time invokes the GradeEventContextRequested
-    filter instead of the old enterprise_support import.
+    filter and uses the returned context directly.
     """
 
     def setUp(self):
@@ -266,87 +266,68 @@ class GradeEventContextFilterTest(SharedModuleStoreTestCase):
         self.user = UserFactory.create()
         self.course = CourseFactory.create()
 
+    @patch('lms.djangoapps.grades.events.tracker')
+    @patch('lms.djangoapps.grades.events.contexts.course_context_from_course_id')
     @patch('lms.djangoapps.grades.events.GradeEventContextRequested.run_filter')
-    def test_filter_called_with_context(self, mock_run_filter):
+    def test_filter_called_with_context(
+        self,
+        mock_run_filter,
+        mock_course_context_from_course_id,
+        mock_tracker,
+    ):
         """
-        course_grade_passed_first_time should call GradeEventContextRequested.run_filter
-        and merge the returned context.
+        course_grade_passed_first_time should call
+        GradeEventContextRequested.run_filter and use the returned context.
         """
-        original_context = {"course_id": str(self.course.id), "base_key": "base_value"}
-        filtered_context = {"org": "test_org", "enterprise_uuid": "abc-123"}
-        expected_context = {
+        original_context = {"course_id": str(self.course.id)}
+        filtered_context = {
             "course_id": str(self.course.id),
-            "base_key": "base_value",
             "org": "test_org",
             "enterprise_uuid": "abc-123",
         }
+        mock_course_context_from_course_id.return_value = original_context
         mock_run_filter.return_value = (filtered_context, self.user.id, self.course.id)
 
         from lms.djangoapps.grades.events import course_grade_passed_first_time
-        with (
-            patch(
-                'lms.djangoapps.grades.events.contexts.course_context_from_course_id',
-                return_value=original_context,
-            ),
-            patch('lms.djangoapps.grades.events.tracker') as mock_tracker,
-        ):
-            course_grade_passed_first_time(self.user.id, self.course.id)
 
-        mock_run_filter.assert_called_once()
-        call_kwargs = mock_run_filter.call_args.kwargs
-        assert call_kwargs['context'] == original_context
-        assert call_kwargs['user_id'] == self.user.id
-        assert str(call_kwargs['course_id']) == str(self.course.id)
+        course_grade_passed_first_time(self.user.id, self.course.id)
+
+        mock_run_filter.assert_called_once_with(
+            context=original_context,
+            user_id=self.user.id,
+            course_id=self.course.id,
+        )
         mock_tracker.get_tracker.return_value.context.assert_called_once_with(
             'edx.course.grade.passed.first_time',
-            expected_context,
+            filtered_context,
         )
 
+    @patch('lms.djangoapps.grades.events.log')
+    @patch('lms.djangoapps.grades.events.tracker')
+    @patch('lms.djangoapps.grades.events.contexts.course_context_from_course_id')
     @patch('lms.djangoapps.grades.events.GradeEventContextRequested.run_filter')
-    def test_filter_none_return_leaves_context_intact(self, mock_run_filter):
+    def test_filter_exception_is_logged_and_raised(
+        self,
+        mock_run_filter,
+        mock_course_context_from_course_id,
+        mock_tracker,
+        mock_log,
+    ):
         """
-        If run_filter returns None, context is not overwritten.
+        If run_filter raises an exception, it should be logged and re-raised.
         """
         original_context = {"course_id": str(self.course.id)}
-        mock_run_filter.return_value = (None, self.user.id, self.course.id)
-
-        from lms.djangoapps.grades.events import course_grade_passed_first_time
-        with (
-            patch(
-                'lms.djangoapps.grades.events.contexts.course_context_from_course_id',
-                return_value=original_context,
-            ),
-            patch('lms.djangoapps.grades.events.tracker') as mock_tracker,
-        ):
-            course_grade_passed_first_time(self.user.id, self.course.id)
-
-        mock_tracker.get_tracker.return_value.context.assert_called_once_with(
-            'edx.course.grade.passed.first_time',
-            original_context,
-        )
-
-    @patch('lms.djangoapps.grades.events.GradeEventContextRequested.run_filter')
-    def test_filter_exception_leaves_context_intact(self, mock_run_filter):
-        """
-        If run_filter raises an exception, the original context is used and the
-        event still emits, as enterprise specific code is optional.
-        """
-        original_context = {"course_id": str(self.course.id)}
+        mock_course_context_from_course_id.return_value = original_context
         mock_run_filter.side_effect = Exception("boom")
 
         from lms.djangoapps.grades.events import course_grade_passed_first_time
-        with (
-            patch(
-                'lms.djangoapps.grades.events.contexts.course_context_from_course_id',
-                return_value=original_context,
-            ),
-            patch('lms.djangoapps.grades.events.tracker') as mock_tracker,
-            patch('lms.djangoapps.grades.events.log') as mock_log,
-        ):
+
+        with self.assertRaisesRegex(Exception, "boom"):
             course_grade_passed_first_time(self.user.id, self.course.id)
 
-        mock_log.exception.assert_called_once()
-        mock_tracker.get_tracker.return_value.context.assert_called_once_with(
-            'edx.course.grade.passed.first_time',
-            original_context,
+        mock_log.exception.assert_called_once_with(
+            'GradeEventContextRequested failed for user_id=%s course_id=%s',
+            self.user.id,
+            self.course.id,
         )
+        mock_tracker.get_tracker.return_value.context.assert_not_called()

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -42,7 +42,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==8.0.14
+edx-enterprise==8.0.15
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -473,7 +473,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.0.14
+edx-enterprise==8.0.15
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.0.14
+edx-enterprise==8.0.15
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -557,7 +557,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.0.14
+edx-enterprise==8.0.15
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -578,7 +578,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.0.14
+edx-enterprise==8.0.15
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Replaces `get_enterprise_event_context` in lms/djangoapps/grades/events.py with `GradeEventContextRequested.run_filter`.

The filter pipeline is expected to return the final event context object, so `course_grade_passed_first_time` now uses the returned context directly rather than merging enterprise-specific fields into a base context.

If the filter raises an exception, the error is logged and re-raised.

You can see it enriching the payload with the enterprise uuid correctly when fired directly 
<img width="1007" height="243" alt="Screenshot 2026-05-18 at 8 29 18 PM" src="https://github.com/user-attachments/assets/7c539256-6d5f-498c-97d0-149438119f78" />

And in the COURSE_GRADE_PASSED_FIRST_TIME event sender also has the enterprise uuid information 
<img width="1045" height="199" alt="Screenshot 2026-05-18 at 8 31 56 PM" src="https://github.com/user-attachments/assets/b42a36a9-aa91-4d7d-ac14-fc1acd67b08d" />

Also tested with a user that doesn't have any enterprise associations, just prints enterprise uuid empty 
<img width="1042" height="85" alt="Screenshot 2026-05-18 at 8 33 45 PM" src="https://github.com/user-attachments/assets/f1a9e19d-073a-4eda-9bdf-5827e21a6a81" />

## Supporting information

Jira - [ENT-11563](https://2u-internal.atlassian.net/browse/ENT-11563)

## Testing instructions

https://2u-internal.atlassian.net/wiki/spaces/SOL/pages/3710353504/Enterprise+Plugin+Ticket+Runbook
openedx-filters change is already merged into master, but make sure you have the most recent version pulled. 
edx-enterprise must be checked out on pwnage101/ENT-11563 ([PR](https://github.com/openedx/edx-enterprise/pull/2543))

Then run `docker compose exec test-shell bash -c "pytest -c pytest.local.ini tests/filters/ -v"` to validate the tests run with the edx-enterprise changes. 

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
