### PR TITLE
fix: sort archived topics alphabetically in discussion topics tab

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -87,22 +87,22 @@ class DiscussionAPIUtilsTestCase(ModuleStoreTestCase):
         # Define some example inputs
         filtered_topic_ids = ['t1', 't2', 't3', 't4']
         topics = [
-            {'id': 't1', 'usage_key': 'u1', 'title': 'Topic 1'},
-            {'id': 't2', 'usage_key': None, 'title': 'Topic 2'},
-            {'id': 't3', 'usage_key': 'u3', 'title': 'Topic 3'},
-            {'id': 't4', 'usage_key': 'u4', 'title': 'Topic 4'},
-            {'id': 't5', 'usage_key': None, 'title': 'Topic 5'},
+            {'id': 't1', 'usage_key': 'u1', 'name': 'Topic 1'},
+            {'id': 't2', 'usage_key': None, 'name': 'Topic 2'},
+            {'id': 't3', 'usage_key': 'u3', 'name': 'Topic 3'},
+            {'id': 't4', 'usage_key': 'u4', 'name': 'Topic 4'},
+            {'id': 't5', 'usage_key': None, 'name': 'Topic 5'},
         ]
         expected_output = [
-            {'id': 't1', 'usage_key': 'u1', 'title': 'Topic 1'},
-            {'id': 't3', 'usage_key': 'u3', 'title': 'Topic 3'},
-            {'id': 't4', 'usage_key': 'u4', 'title': 'Topic 4'},
+            {'id': 't1', 'usage_key': 'u1', 'name': 'Topic 1'},
+            {'id': 't3', 'usage_key': 'u3', 'name': 'Topic 3'},
+            {'id': 't4', 'usage_key': 'u4', 'name': 'Topic 4'},
         ]
 
         # Call the function with the example inputs
         output = get_archived_topics(filtered_topic_ids, topics)
 
-        # Assert that the output matches the expected output
+        # Assert that the output matches the expected output (sorted alphabetically by name)
         assert output == expected_output
 
     @ddt.data(

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -365,13 +365,15 @@ def get_archived_topics(filtered_topic_ids: List[str], topics: List[Dict[str, st
     - Each dictionary should have a 'id' and a 'usage_key' field.
 
     Returns:
-    - A list of archived topic dictionaries, with the same format as the input topics.
+    - A list of archived topic dictionaries, sorted alphabetically by name, with the same format as the input topics.
     """
     archived_topics = []
     for topic_id in filtered_topic_ids:
         for topic in topics:
             if topic['id'] == topic_id and topic['usage_key'] is not None:
                 archived_topics.append(topic)
+    # Sort archived topics alphabetically by name (case-insensitive)
+    archived_topics.sort(key=lambda topic: topic.get('name', '').lower())
     return archived_topics
 
 


### PR DESCRIPTION
### Description
This PR fixes the sorting issue for archived topics in the Discussion Topics tab.
Previously, archived topics were displayed in an inconsistent order and were not sorted alphabetically. With this fix, archived topics are now sorted in ascending alphabetical order (A → Z) based on the full topic path.

### Changes Made
- Added alphabetical sorting for archived topics
- Updated sorting logic to use the complete topic path
- Ensured consistent ordering in the Archived Topics section

### Expected Result
Archived topics should appear in proper alphabetical order.

### Ticket
[Cosmo2-890](https://2u-internal.atlassian.net/browse/COSMO2-890)