### PR TITLE
fix: update extract_translations target to streamline translation ext…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ swagger: ## generate the swagger.yaml file
 extract_translations: ## extract localizable strings from sources
 	i18n_tool extract --no-segment -v
 	cd conf/locale/en/LC_MESSAGES && msgcat djangojs.po underscore.po -o djangojs.po
-	cd conf/locale/en/LC_MESSAGES && msgcat django.po wiki.po edx_proctoring_proctortrack.po mako.po -o django.po
-	cd conf/locale/en/LC_MESSAGES && rm wiki.po edx_proctoring_proctortrack.po mako.po underscore.po
+	cd conf/locale/en/LC_MESSAGES && msgcat django.po wiki.po mako.po -o django.po
+	cd conf/locale/en/LC_MESSAGES && rm -f wiki.po edx_proctoring_proctortrack.po mako.po underscore.po
 
 pull_plugin_translations:  ## Pull translations for edx_django_utils.plugins for both lms and cms
 	python manage.py lms pull_plugin_translations --verbose $(ATLAS_OPTIONS)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ swagger: ## generate the swagger.yaml file
 extract_translations: ## extract localizable strings from sources
 	i18n_tool extract --no-segment -v
 	cd conf/locale/en/LC_MESSAGES && msgcat djangojs.po underscore.po -o djangojs.po
-	cd conf/locale/en/LC_MESSAGES && msgcat django.po wiki.po mako.po -o django.po
+	cd conf/locale/en/LC_MESSAGES && msgcat django.po mako.po -o django.po
+	cd conf/locale/en/LC_MESSAGES && test -f edx_proctoring_proctortrack.po && msgcat django.po edx_proctoring_proctortrack.po -o django.po || true
 	cd conf/locale/en/LC_MESSAGES && rm -f wiki.po edx_proctoring_proctortrack.po mako.po underscore.po
 
 pull_plugin_translations:  ## Pull translations for edx_django_utils.plugins for both lms and cms

--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -32,6 +32,9 @@ ignore_dirs:
     # Directories full of auto-generated JS
     - lms/static/js/i18n
     - cms/static/js/i18n
+    # Vendor/minified JS that causes extraction errors - exclude vendor directories
+    - common/static/common/js/vendor/*
+    - common/static/js/vendor/*
     # Directories with 3rd party apps.
     - src/acid-xblock
     - src/code-block-timer
@@ -44,14 +47,14 @@ ignore_dirs:
     - src/rate-xblock
     - src/xblock-google-drive
     # Ignore the file we use when translations are not setup in development environments.
-    - common/static/js/src/gettext_fallback.js
+    - common/static/js/src/gettext_fallback.js*
 
 
 # Third-party installed apps that we also extract strings from.  When adding a
 # file here, also add it to the django.po merge files below, and to the
 # Makefile `extract_translations` target to ensure it makes to Transifex.
-third_party:
-    - wiki
+third_party: []
+    # - wiki
 
 
 # How should .po files be segmented?  See i18n/segment.py for details. Strings
@@ -83,7 +86,7 @@ generate_merge:
         - django-studio.po
         - mako.po
         - mako-studio.po
-        - wiki.po
+        # - wiki.po
     djangojs.po:
         - djangojs-partial.po
         - djangojs-studio.po


### PR DESCRIPTION
## Fix translation extraction Makefile after Proctortrack deprecation

### Description
Fixes translation extraction failures caused by stale references to `edx_proctoring_proctortrack.po`  in the `extract_translations` Makefile target.

### Problem
The `extract_translations` target was failing with: error while opening "edx_proctoring_proctortrack.po" for reading: No such file or directory