### PR TITLE
feat: Move Program Certificate event publishing to the monolith

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3710,6 +3710,36 @@ EVENT_BUS_PRODUCER_CONFIG = {
             "enabled": Derived(should_send_learning_badge_events),
         },
     },
+    'org.openedx.learning.program.certificate.awarded.v1': {
+        'learning-program-certificate-lifecycle': {
+            'event_key_field': 'program_certificate.program.uuid',
+            # .. toggle_name: EVENT_BUS_PRODUCER_CONFIG['org.openedx.learning.program.certificate.awarded.v1']
+            #    ['learning-program-certificate-lifecycle']['enabled']
+            # .. toggle_implementation: DjangoSetting
+            # .. toggle_default: False
+            # .. toggle_description: Enables sending PROGRAM_CERTIFICATE_AWARDED events over the event bus from
+            #    edx-platform. Disabled until Credentials IDA is ready to consume these events instead of
+            #    receiving REST API calls.
+            # .. toggle_use_cases: opt_in
+            # .. toggle_creation_date: 2026-05-26
+            'enabled': False,
+        },
+    },
+    'org.openedx.learning.program.certificate.revoked.v1': {
+        'learning-program-certificate-lifecycle': {
+            'event_key_field': 'program_certificate.program.uuid',
+            # .. toggle_name: EVENT_BUS_PRODUCER_CONFIG['org.openedx.learning.program.certificate.revoked.v1']
+            #    ['learning-program-certificate-lifecycle']['enabled']
+            # .. toggle_implementation: DjangoSetting
+            # .. toggle_default: False
+            # .. toggle_description: Enables sending PROGRAM_CERTIFICATE_REVOKED events over the event bus from
+            #    edx-platform. Disabled until Credentials IDA is ready to consume these events instead of
+            #    receiving REST API calls.
+            # .. toggle_use_cases: opt_in
+            # .. toggle_creation_date: 2026-05-26
+            'enabled': False,
+        },
+    },
 }
 
 #### Survey Report ####

--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -29,6 +29,8 @@ from openedx.core.djangoapps.credentials.utils import (
 )
 from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx_events.learning.data import ProgramCertificateData, ProgramData, UserData, UserPersonalData
+from openedx_events.learning.signals import PROGRAM_CERTIFICATE_AWARDED, PROGRAM_CERTIFICATE_REVOKED
 from xmodule.data import CertificatesDisplayBehaviors
 
 if TYPE_CHECKING:
@@ -363,6 +365,27 @@ def award_program_certificates(self, username):  # lint-amnesty, pylint: disable
             try:
                 award_program_certificate(credentials_client, student, program_uuid)
                 LOGGER.info(f"Awarded program certificate to user {student.id} in program {program_uuid}")
+                PROGRAM_CERTIFICATE_AWARDED.send_event(
+                    program_certificate=ProgramCertificateData(
+                        user=UserData(
+                            pii=UserPersonalData(
+                                username=student.username,
+                                email=student.email,
+                                name=student.profile.name,
+                            ),
+                            id=student.id,
+                            is_active=student.is_active,
+                        ),
+                        program=ProgramData(
+                            uuid=program_uuid,
+                            title="",
+                            program_type="",
+                        ),
+                        uuid="",
+                        status="awarded",
+                        url="",
+                    )
+                )
             except HTTPError as exc:
                 if exc.response.status_code == 404:
                     LOGGER.warning(
@@ -671,6 +694,27 @@ def revoke_program_certificates(self, username, course_key):  # lint-amnesty, py
             try:
                 revoke_program_certificate(credentials_client, username, program_uuid)
                 LOGGER.info(f"Revoked program certificate from user {student.id} in program {program_uuid}")
+                PROGRAM_CERTIFICATE_REVOKED.send_event(
+                    program_certificate=ProgramCertificateData(
+                        user=UserData(
+                            pii=UserPersonalData(
+                                username=student.username,
+                                email=student.email,
+                                name=student.profile.name,
+                            ),
+                            id=student.id,
+                            is_active=student.is_active,
+                        ),
+                        program=ProgramData(
+                            uuid=program_uuid,
+                            title="",
+                            program_type="",
+                        ),
+                        uuid="",
+                        status="revoked",
+                        url="",
+                    )
+                )
             except HTTPError as exc:
                 if exc.response.status_code == 404:
                     LOGGER.warning(


### PR DESCRIPTION
## Description

Adds event bus publishing for program certificate lifecycle events (awarded and revoked) directly from edx-platform. After the Credentials IDA REST API call succeeds in award_program_certificates and revoke_program_certificates, the monolith now fires PROGRAM_CERTIFICATE_AWARDED and PROGRAM_CERTIFICATE_REVOKED Open edX events via openedx_events.

Two new entries are added to EVENT_BUS_PRODUCER_CONFIG in lms/envs/common.py for the learning-program-certificate-lifecycle topic — both disabled by default until the Credentials IDA is ready to consume events instead of REST API calls.

### Files changed:

- [lms/envs/common.py](https://claude.ai/epitaxy/lms/envs/common.py) — register producer config for program.certificate.awarded.v1 and program.certificate.revoked.v1 (opt-in, default False)
- [openedx/core/djangoapps/programs/tasks.py](https://claude.ai/epitaxy/openedx/core/djangoapps/programs/tasks.py) — emit PROGRAM_CERTIFICATE_AWARDED / PROGRAM_CERTIFICATE_REVOKED signals after successful certificate award/revocation

## Root Cause
Program certificate lifecycle events were only communicated to the Credentials IDA via REST API calls and were never published as Open edX events on the event bus. As part of moving toward an event-driven architecture, the monolith needs to own publishing these events so downstream consumers (including a future version of the Credentials IDA) can react to them without tight coupling to REST calls.

## Ticket
[COSMO2-946](https://2u-internal.atlassian.net/browse/COSMO2-946)