### PR TITLE
fix: Optimized goal_reminder_email query

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -223,7 +223,7 @@ class Command(BaseCommand):
         sent_count = 0
         filtered_count = 0
         course_goals = course_goals.exclude(course_key__in=courses_to_exclude).select_related('user').order_by('user')
-        total_goals = len(course_goals)
+        total_goals = course_goals.count()
         tracker.emit(
             'edx.course.goal.email.session_started',
             {
@@ -237,7 +237,7 @@ class Command(BaseCommand):
             datetime.now(),
             session_id
         ))
-        for goal in course_goals:
+        for goal in course_goals.iterator(chunk_size=500):
             # emulate a request for waffle's benefit
             with emulate_http_request(site=Site.objects.get_current(), user=goal.user):
                 if self.handle_goal(goal, today, sunday_date, monday_date, session_id):


### PR DESCRIPTION
## Description
Optimised the goal_reminder_email management command to reduce memory usage and improve query efficiency.
 - Replaced len(course_goals) with course_goals.count() to avoid materialising the full queryset into memory
 - Added .iterator(chunk_size=500) to the for-loop to stream goals in batches instead of loading all records at once

## Root Cause
The command was calling len() on an unevaluated Django queryset with select_related('user'), which forced the entire result set — potentially millions of CourseGoal and related User objects — to be loaded into memory at once. This caused 50+ GB memory usage and 9+ hour runtimes.

## Ticket
[COSMO2-937](https://2u-internal.atlassian.net/browse/COSMO2-937)
