### PR TITLE
feat(lms): enable Gunicorn DogStatsD metrics via env-driven config

### DIFF
--- a/lms/docker_lms_gunicorn.py
+++ b/lms/docker_lms_gunicorn.py
@@ -1,6 +1,7 @@
 """
-gunicorn configuration file: http://docs.gunicorn.org/en/stable/configure.html
+gunicorn configuration file: https://gunicorn.org/reference/settings/
 """
+import os
 
 preload_app = False
 timeout = 300
@@ -8,6 +9,11 @@ bind = "127.0.0.1:8000"
 pythonpath = "/edx/app/edxapp/edx-platform"
 max_requests = 50
 workers = 17
+proc_name = os.getenv("GUNICORN_PROC_NAME", "edxapp-lms")
+# Metrics emission is opt-in: these remain unset unless explicitly provided.
+statsd_host = os.getenv("GUNICORN_STATSD_HOST")
+statsd_prefix = os.getenv("GUNICORN_STATSD_PREFIX")
+dogstatsd_tags = os.getenv("GUNICORN_DOGSTATSD_TAGS")
 
 
 def pre_request(worker, req):


### PR DESCRIPTION
### Summary:

- add support for GUNICORN_PROC_NAME, GUNICORN_STATSD_HOST, GUNICORN_STATSD_PREFIX, and GUNICORN_DOGSTATSD_TAGS in LMS Gunicorn config
- keep runtime settings configurable per environment without extending the Gunicorn command line
- prepare stage/prod manifests to inject tags/endpoint consistently for Datadog monitor alignment
