### PR TITLE
chore: add analytics_exporter configuration for management commands

### DIFF
--- a/cms/envs/analytics_exporter.py
+++ b/cms/envs/analytics_exporter.py
@@ -1,0 +1,14 @@
+"""
+Settings for running management commands for the Analytics Exporter.
+
+The Analytics Exporter jobs run edxapp management commands using production
+settings and configuration, however they currently DO NOT use edxapp production
+environments (such as edxapp Amazon AMIs or Docker images) where theme files
+get installed.  As a result we must disable comprehensive theming or else
+startup checks from the theming app will throw an error due to missing themes.
+"""
+
+from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+ENABLE_COMPREHENSIVE_THEMING = False
+

--- a/cms/envs/analytics_exporter.py
+++ b/cms/envs/analytics_exporter.py
@@ -11,4 +11,3 @@ startup checks from the theming app will throw an error due to missing themes.
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 ENABLE_COMPREHENSIVE_THEMING = False
-

--- a/lms/envs/analytics_exporter.py
+++ b/lms/envs/analytics_exporter.py
@@ -1,0 +1,14 @@
+"""
+Settings for running management commands for the Analytics Exporter.
+
+The Analytics Exporter jobs run edxapp management commands using production
+settings and configuration, however they currently DO NOT use edxapp production
+environments (such as edxapp Amazon AMIs or Docker images) where theme files
+get installed.  As a result we must disable comprehensive theming or else
+startup checks from the theming app will throw an error due to missing themes.
+"""
+
+from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+ENABLE_COMPREHENSIVE_THEMING = False
+

--- a/lms/envs/analytics_exporter.py
+++ b/lms/envs/analytics_exporter.py
@@ -11,4 +11,3 @@ startup checks from the theming app will throw an error due to missing themes.
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 ENABLE_COMPREHENSIVE_THEMING = False
-


### PR DESCRIPTION
This pull request introduces environment configuration files for the Analytics Exporter in both the `cms` and `lms` services. The main goal is to ensure that management commands for the Analytics Exporter can run without errors.

Environment configuration for Analytics Exporter:

* Added `analytics_exporter.py` settings files to both `cms/envs/` and `lms/envs/` that:
  
  **JIRA**: https://2u-internal.atlassian.net/browse/COSMO2-911