### PR TITLE
fix: remove edx_proctoring_proctortrack.po from translation extractio…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ swagger: ## generate the swagger.yaml file
 extract_translations: ## extract localizable strings from sources
 	i18n_tool extract --no-segment -v
 	cd conf/locale/en/LC_MESSAGES && msgcat djangojs.po underscore.po -o djangojs.po
-	cd conf/locale/en/LC_MESSAGES && msgcat django.po wiki.po edx_proctoring_proctortrack.po mako.po -o django.po
-	cd conf/locale/en/LC_MESSAGES && rm wiki.po edx_proctoring_proctortrack.po mako.po underscore.po
+	cd conf/locale/en/LC_MESSAGES && msgcat django.po wiki.po mako.po -o django.po
+	cd conf/locale/en/LC_MESSAGES && rm wiki.po mako.po underscore.po
 
 pull_plugin_translations:  ## Pull translations for edx_django_utils.plugins for both lms and cms
 	python manage.py lms pull_plugin_translations --verbose $(ATLAS_OPTIONS)


### PR DESCRIPTION
## Description

This PR removes `edx_proctoring_proctortrack.po` from the `extract_translations` Make target because the file is currently missing and is causing extraction issues.

The goal of this change is to align our `extract_translations` Make target with what currently exists on the `master` branch of edx-platform. This approach helps unblock the translation extraction work without getting delayed by the existing Proctortrack PO file issue.

A follow-up ticket has been created to investigate why the `edx_proctoring_proctortrack.po` file is missing and determine the appropriate long-term fix.: https://2u-internal.atlassian.net/browse/AU-2967

jira link : https://2u-internal.atlassian.net/browse/AU-2810
