### PR TITLE
Replace audit expiry site-config targeting with course waffle flag

### DIFF
--- a/lms/djangoapps/experiments/audit_expiry_urgency.py
+++ b/lms/djangoapps/experiments/audit_expiry_urgency.py
@@ -7,7 +7,7 @@ Design constraints (from ticket):
 * Experiment key: audit_expiry_urgency_v1
 * Variants: control_5_7_weeks, expiry_7_days
 * Assignment unit: user_id
-* Stickiness: across sessions/devices and across the configured target courses
+* Stickiness: across sessions/devices and targeted courses
 * Failure behavior: default to control
 """
 
@@ -21,16 +21,11 @@ from django.utils import timezone
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollmentAttribute
 from lms.djangoapps.utils import OptimizelyClient
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.course_duration_limits.access import get_user_course_duration
 
-from .flags import AUDIT_EXPIRY_URGENCY_V1_ENABLED
+from .flags import audit_expiry_urgency_v1_enabled_for_course
 
 log = logging.getLogger(__name__)
-
-# Avoid emitting a warning on every enrollment save if the allowlist is missing.
-_WARNED_NO_TARGET_COURSES = False
-
 
 EXPERIMENT_KEY = 'audit_expiry_urgency_v1'
 
@@ -46,38 +41,10 @@ ATTRIBUTE_NAME_ASSIGNED_AT = 'assigned_at'
 ATTRIBUTE_NAME_DECISION_SOURCE = 'decision_source'
 ATTRIBUTE_NAME_AUDIT_EXPIRY_AT = 'audit_expiry_at'
 
-SITE_CONFIG_KEY_TARGET_COURSES = 'AUDIT_EXPIRY_EXPERIMENT_COURSES'
-
 # TEMP: Local testing fallback.
 # When set (e.g. in devstack), this forces a specific variant and skips the
 # Optimizely lookup entirely.
 FORCE_VARIANT_SETTING = 'AUDIT_EXPIRY_FORCE_VARIANT'
-
-
-def _get_configured_target_course_id_strings():
-    """Return configured target course run IDs as a list of strings."""
-    default_from_settings = getattr(settings, SITE_CONFIG_KEY_TARGET_COURSES, [])
-    configured = configuration_helpers.get_value(SITE_CONFIG_KEY_TARGET_COURSES, default=default_from_settings)
-
-    if configured is None:
-        configured = []
-    if isinstance(configured, str):
-        configured = [configured]
-    if not isinstance(configured, list):
-        configured = []
-
-    course_ids = [str(item) for item in configured if item]
-    if not course_ids:
-        global _WARNED_NO_TARGET_COURSES  # pylint: disable=global-statement
-        if not _WARNED_NO_TARGET_COURSES:
-            log.warning('Audit expiry urgency: no target courses configured (key=%s)', SITE_CONFIG_KEY_TARGET_COURSES)
-            _WARNED_NO_TARGET_COURSES = True
-    return course_ids
-
-
-def is_target_course(course_key):
-    """Return True if course_key is one of the configured target course runs."""
-    return str(course_key) in set(_get_configured_target_course_id_strings())
 
 
 def _get_attribute(enrollment, name):
@@ -154,25 +121,20 @@ def _set_attribute(enrollment, name, value):
             )
 
 
-def _find_existing_variant_for_user(user, target_course_id_strings):
+def _find_existing_variant_for_user(user):
     """Reuse learner-level assignment by looking for an existing stored variant."""
-    if not target_course_id_strings:
-        return None
-
     # Note: do NOT filter on enrollment.is_active; we want reenrollments to retain assignment.
-    existing_variant = (
+    return (
         CourseEnrollmentAttribute.objects.filter(
             enrollment__user=user,
-            enrollment__course_id__in=target_course_id_strings,
             namespace=ATTRIBUTE_NAMESPACE,
             name=ATTRIBUTE_NAME_VARIANT,
+            value__in=VALID_VARIANTS,
         )
         .order_by('-id')
         .values_list('value', flat=True)
         .first()
     )
-
-    return existing_variant if existing_variant in VALID_VARIANTS else None
 
 
 def _forced_variant_from_settings():
@@ -208,13 +170,13 @@ def _activate_optimizely_variant(user):
         return None
 
 
-def choose_variant(user, target_course_id_strings):
+def choose_variant(user):
     """Choose (or reuse) a learner-level variant and decision source."""
     forced_variant = _forced_variant_from_settings()
     if forced_variant:
         return forced_variant, 'force_variant'
 
-    existing_variant = _find_existing_variant_for_user(user, target_course_id_strings)
+    existing_variant = _find_existing_variant_for_user(user)
     if existing_variant:
         return existing_variant, 'existing'
 
@@ -271,9 +233,6 @@ def maybe_persist_audit_expiry_urgency_attributes(enrollment):
 
     Safe + idempotent: if audit_expiry_at already exists, this is a no-op.
     """
-    if not AUDIT_EXPIRY_URGENCY_V1_ENABLED.is_enabled():
-        return
-
     if not enrollment or not getattr(enrollment, 'user_id', None):
         log.warning('Audit expiry urgency: skipped (missing enrollment or user)')
         return
@@ -285,7 +244,7 @@ def maybe_persist_audit_expiry_urgency_attributes(enrollment):
     if any((
         not enrollment.is_active,
         enrollment.mode != CourseMode.AUDIT,
-        not is_target_course(enrollment.course_id),
+        not audit_expiry_urgency_v1_enabled_for_course(enrollment.course_id),
     )):
         return
 
@@ -298,8 +257,7 @@ def maybe_persist_audit_expiry_urgency_attributes(enrollment):
         # Only apply if Course Duration Limits would normally apply.
         return
 
-    target_course_ids = _get_configured_target_course_id_strings()
-    variant, decision_source = choose_variant(enrollment.user, target_course_ids)
+    variant, decision_source = choose_variant(enrollment.user)
 
     audit_expiry_at, expiry_days = compute_audit_expiry_at(enrollment, variant, access_duration)
     if timezone.is_naive(audit_expiry_at):

--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -31,6 +31,33 @@ AUDIT_EXPIRY_URGENCY_V1_ENABLED = WaffleFlag(
     __name__,
 )
 
+# .. toggle_name: experiments.audit_expiry_urgency_v1.course_enabled
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Course/org targeting flag for the Audit Expiry Urgency (v1) backend experiment.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-06-01
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: Audit Expiry Urgency Experiment
+# .. toggle_warning: This temporary feature toggle does not have a target removal date.
+AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED = CourseWaffleFlag(
+    'experiments.audit_expiry_urgency_v1.course_enabled',
+    __name__,
+)
+
+
+def audit_expiry_urgency_v1_enabled_for_course(course_key):
+    """
+    Return whether the audit expiry urgency experiment is enabled for a course.
+
+    The global waffle flag remains the kill switch. The course waffle flag only
+    controls course/org targeting once that kill switch is enabled.
+    """
+    return (
+        AUDIT_EXPIRY_URGENCY_V1_ENABLED.is_enabled()
+        and AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED.is_enabled(course_key)
+    )
+
 
 class ExperimentWaffleFlag(CourseWaffleFlag):
     """

--- a/lms/djangoapps/experiments/signals.py
+++ b/lms/djangoapps/experiments/signals.py
@@ -14,10 +14,9 @@ from .audit_expiry_urgency import (
     EXPERIMENT_KEY,
     get_persisted_expiry_days,
     get_persisted_variant,
-    is_target_course,
     maybe_persist_audit_expiry_urgency_attributes,
 )
-from .flags import AUDIT_EXPIRY_URGENCY_V1_ENABLED
+from .flags import audit_expiry_urgency_v1_enabled_for_course
 
 log = logging.getLogger(__name__)
 
@@ -52,10 +51,7 @@ def track_audit_expiry_urgency_conversion(sender, user, course_key, mode, **kwar
         if mode != CourseMode.VERIFIED:
             return
 
-        if not AUDIT_EXPIRY_URGENCY_V1_ENABLED.is_enabled():
-            return
-
-        if not is_target_course(course_key):
+        if not audit_expiry_urgency_v1_enabled_for_course(course_key):
             return
 
         enrollment = CourseEnrollment.get_enrollment(user, course_key)

--- a/lms/djangoapps/experiments/tests/test_audit_expiry_urgency.py
+++ b/lms/djangoapps/experiments/tests/test_audit_expiry_urgency.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from django.test.utils import override_settings
 from django.utils import timezone
+from edx_django_utils.cache import RequestCache
 from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
@@ -14,9 +15,16 @@ from common.djangoapps.student.models import CourseEnrollmentAttribute
 from common.djangoapps.student.signals import ENROLLMENT_TRACK_UPDATED
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangoapps.waffle_utils.models import (
+    WaffleFlagCourseOverrideModel,
+    WaffleFlagOrgOverrideModel,
+)
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 
-from lms.djangoapps.experiments.flags import AUDIT_EXPIRY_URGENCY_V1_ENABLED
+from lms.djangoapps.experiments.flags import (
+    AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED,
+    AUDIT_EXPIRY_URGENCY_V1_ENABLED,
+)
 
 
 class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
@@ -24,6 +32,7 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
 
     def setUp(self):
         super().setUp()  # lint-amnesty, pylint: disable=super-with-arguments
+        RequestCache.clear_all_namespaces()
         self.now = timezone.now().replace(microsecond=0)
         self.course_1 = CourseOverviewFactory.create(start=self.now - timedelta(days=1), self_paced=True)
         self.course_2 = CourseOverviewFactory.create(start=self.now - timedelta(days=1), self_paced=True)
@@ -38,10 +47,72 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
             enabled=True,
             enabled_as_of=self.now - timedelta(days=365),
         )
+        self.addCleanup(RequestCache.clear_all_namespaces)
 
-    @override_settings(AUDIT_EXPIRY_EXPERIMENT_COURSES=[])
-    def test_noop_when_not_allowlisted(self):
+    def _enable_course_flag(self, course_key):
+        WaffleFlagCourseOverrideModel.objects.create(
+            waffle_flag=AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED.name,
+            course_id=course_key,
+            enabled=True,
+        )
+        RequestCache.clear_all_namespaces()
+
+    def _enable_org_flag(self, org):
+        WaffleFlagOrgOverrideModel.objects.create(
+            waffle_flag=AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED.name,
+            org=org,
+            enabled=True,
+        )
+        RequestCache.clear_all_namespaces()
+
+    def _disable_course_flag(self, course_key):
+        WaffleFlagCourseOverrideModel.objects.create(
+            waffle_flag=AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED.name,
+            course_id=course_key,
+            override_choice=WaffleFlagCourseOverrideModel.ALL_CHOICES.off,
+            enabled=True,
+        )
+        RequestCache.clear_all_namespaces()
+
+    def test_noop_when_course_flag_disabled(self):
         enrollment = CourseEnrollmentFactory.create(course=self.course_1, mode=CourseMode.AUDIT, is_active=True)
+
+        with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
+            enrollment.save()
+
+        assert not CourseEnrollmentAttribute.objects.filter(enrollment=enrollment).exists()
+
+    def test_noop_when_global_flag_disabled_even_if_course_flag_enabled(self):
+        enrollment = CourseEnrollmentFactory.create(course=self.course_1, mode=CourseMode.AUDIT, is_active=True)
+        self._enable_course_flag(self.course_1.id)
+
+        with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=False):
+            enrollment.save()
+
+        assert not CourseEnrollmentAttribute.objects.filter(enrollment=enrollment).exists()
+
+    def test_org_flag_enables_experiment_for_partner_courses(self):
+        enrollment = CourseEnrollmentFactory.create(course=self.course_1, mode=CourseMode.AUDIT, is_active=True)
+        self._enable_org_flag(self.course_1.id.org)
+
+        with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
+            with mock.patch(
+                'lms.djangoapps.experiments.audit_expiry_urgency.'
+                'OptimizelyClient.get_optimizely_client',
+                return_value=None,
+            ):
+                enrollment.save()
+
+        assert CourseEnrollmentAttribute.objects.filter(
+            enrollment=enrollment,
+            namespace='audit_expiry_experiment',
+            name='variant',
+        ).exists()
+
+    def test_course_flag_force_off_overrides_org_flag(self):
+        enrollment = CourseEnrollmentFactory.create(course=self.course_1, mode=CourseMode.AUDIT, is_active=True)
+        self._enable_org_flag(self.course_1.id.org)
+        self._disable_course_flag(self.course_1.id)
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
             enrollment.save()
@@ -50,15 +121,15 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
 
     def test_defaults_to_control_when_optimizely_unavailable(self):
         enrollment = CourseEnrollmentFactory.create(course=self.course_1, mode=CourseMode.AUDIT, is_active=True)
+        self._enable_course_flag(self.course_1.id)
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
-            with override_settings(AUDIT_EXPIRY_EXPERIMENT_COURSES=[str(self.course_1.id)]):
-                with mock.patch(
-                    'lms.djangoapps.experiments.audit_expiry_urgency.'
-                    'OptimizelyClient.get_optimizely_client',
-                    return_value=None,
-                ):
-                    enrollment.save()
+            with mock.patch(
+                'lms.djangoapps.experiments.audit_expiry_urgency.'
+                'OptimizelyClient.get_optimizely_client',
+                return_value=None,
+            ):
+                enrollment.save()
 
         variant = CourseEnrollmentAttribute.objects.get(
             enrollment=enrollment,
@@ -93,7 +164,7 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
         assert assigned_at
         assert decision_source == 'fallback_control'
 
-    def test_reuses_variant_across_allowlisted_courses(self):
+    def test_reuses_variant_across_targeted_courses(self):
         user = None
         enrollment_1 = CourseEnrollmentFactory.create(
             course=self.course_1,
@@ -107,27 +178,28 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
             mode=CourseMode.AUDIT,
             is_active=True,
         )
+        self._enable_course_flag(self.course_1.id)
+        self._enable_course_flag(self.course_2.id)
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
-            with override_settings(AUDIT_EXPIRY_EXPERIMENT_COURSES=[str(self.course_1.id), str(self.course_2.id)]):
-                # First enrollment activates to expiry_7_days.
-                client = mock.Mock()
-                client.activate.return_value = 'expiry_7_days'
-                with mock.patch(
-                    'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
-                    return_value=client,
-                ):
-                    enrollment_1.save()
+            # First enrollment activates to expiry_7_days.
+            client = mock.Mock()
+            client.activate.return_value = 'expiry_7_days'
+            with mock.patch(
+                'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
+                return_value=client,
+            ):
+                enrollment_1.save()
 
-                # Second enrollment should not call activate (it should reuse persisted variant)
-                client_2 = mock.Mock()
-                client_2.activate.return_value = 'control_5_7_weeks'
-                with mock.patch(
-                    'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
-                    return_value=client_2,
-                ):
-                    enrollment_2.save()
-                    assert client_2.activate.call_count == 0
+            # Second enrollment should not call activate (it should reuse persisted variant)
+            client_2 = mock.Mock()
+            client_2.activate.return_value = 'control_5_7_weeks'
+            with mock.patch(
+                'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
+                return_value=client_2,
+            ):
+                enrollment_2.save()
+                assert client_2.activate.call_count == 0
 
         v1 = CourseEnrollmentAttribute.objects.get(
             enrollment=enrollment_1,
@@ -143,6 +215,7 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
 
     def test_idempotent_does_not_overwrite_existing_audit_expiry_at(self):
         enrollment = CourseEnrollmentFactory.create(course=self.course_1, mode=CourseMode.AUDIT, is_active=True)
+        self._enable_course_flag(self.course_1.id)
 
         # Pre-seed attributes.
         existing_expiry = (timezone.now() + timedelta(days=123)).replace(microsecond=0)
@@ -154,15 +227,14 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
         )
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
-            with override_settings(AUDIT_EXPIRY_EXPERIMENT_COURSES=[str(self.course_1.id)]):
-                client = mock.Mock()
-                client.activate.return_value = 'expiry_7_days'
-                with mock.patch(
-                    'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
-                    return_value=client,
-                ):
-                    enrollment.save()
-                    assert client.activate.call_count == 0
+            client = mock.Mock()
+            client.activate.return_value = 'expiry_7_days'
+            with mock.patch(
+                'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
+                return_value=client,
+            ):
+                enrollment.save()
+                assert client.activate.call_count == 0
 
         persisted = CourseEnrollmentAttribute.objects.filter(
             enrollment=enrollment,
@@ -173,10 +245,10 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
 
     def test_force_variant_setting_skips_optimizely(self):
         enrollment = CourseEnrollmentFactory.create(course=self.course_1, mode=CourseMode.AUDIT, is_active=True)
+        self._enable_course_flag(self.course_1.id)
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
             with override_settings(
-                AUDIT_EXPIRY_EXPERIMENT_COURSES=[str(self.course_1.id)],
                 AUDIT_EXPIRY_FORCE_VARIANT='expiry_7_days',
                 DEBUG=False,
             ):
@@ -215,45 +287,46 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
             mode=CourseMode.AUDIT,
             is_active=True,
         )
+        self._enable_course_flag(self.course_1.id)
+        self._enable_course_flag(self.course_2.id)
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
-            with override_settings(AUDIT_EXPIRY_EXPERIMENT_COURSES=[str(self.course_1.id), str(self.course_2.id)]):
-                client = mock.Mock()
-                client.activate.return_value = 'expiry_7_days'
-                with mock.patch(
-                    'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
-                    return_value=client,
-                ):
-                    enrollment_1.save()
-                    enrollment_2.save()
+            client = mock.Mock()
+            client.activate.return_value = 'expiry_7_days'
+            with mock.patch(
+                'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
+                return_value=client,
+            ):
+                enrollment_1.save()
+                enrollment_2.save()
 
         assert client.track.call_count == 1
         assert client.track.call_args[0][0] == 'audit_expiry_urgency_exposed'
 
     def test_tracks_verified_conversion_for_experiment_participant(self):
         enrollment = CourseEnrollmentFactory.create(course=self.course_1, mode=CourseMode.AUDIT, is_active=True)
+        self._enable_course_flag(self.course_1.id)
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
-            with override_settings(AUDIT_EXPIRY_EXPERIMENT_COURSES=[str(self.course_1.id)]):
-                client = mock.Mock()
-                client.activate.return_value = 'expiry_7_days'
-                with mock.patch(
-                    'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
-                    return_value=client,
-                ):
-                    enrollment.save()
+            client = mock.Mock()
+            client.activate.return_value = 'expiry_7_days'
+            with mock.patch(
+                'lms.djangoapps.experiments.audit_expiry_urgency.OptimizelyClient.get_optimizely_client',
+                return_value=client,
+            ):
+                enrollment.save()
 
-                conversion_client = mock.Mock()
-                with mock.patch(
-                    'lms.djangoapps.experiments.signals.OptimizelyClient.get_optimizely_client',
-                    return_value=conversion_client,
-                ):
-                    ENROLLMENT_TRACK_UPDATED.send(
-                        sender=None,
-                        user=enrollment.user,
-                        course_key=enrollment.course_id,
-                        mode=CourseMode.VERIFIED,
-                    )
+            conversion_client = mock.Mock()
+            with mock.patch(
+                'lms.djangoapps.experiments.signals.OptimizelyClient.get_optimizely_client',
+                return_value=conversion_client,
+            ):
+                ENROLLMENT_TRACK_UPDATED.send(
+                    sender=None,
+                    user=enrollment.user,
+                    course_key=enrollment.course_id,
+                    mode=CourseMode.VERIFIED,
+                )
 
         assert conversion_client.track.call_count == 1
         assert conversion_client.track.call_args[0][0] == 'audit_expiry_urgency_upgraded_to_verified'

--- a/lms/djangoapps/experiments/tests/test_audit_expiry_urgency.py
+++ b/lms/djangoapps/experiments/tests/test_audit_expiry_urgency.py
@@ -50,6 +50,7 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
         self.addCleanup(RequestCache.clear_all_namespaces)
 
     def _enable_course_flag(self, course_key):
+        """Enable the course-level waffle override for the experiment."""
         WaffleFlagCourseOverrideModel.objects.create(
             waffle_flag=AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED.name,
             course_id=course_key,
@@ -58,6 +59,7 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
         RequestCache.clear_all_namespaces()
 
     def _enable_org_flag(self, org):
+        """Enable the org-level waffle override for the experiment."""
         WaffleFlagOrgOverrideModel.objects.create(
             waffle_flag=AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED.name,
             org=org,
@@ -66,6 +68,7 @@ class TestAuditExpiryUrgencyExperiment(SharedModuleStoreTestCase):
         RequestCache.clear_all_namespaces()
 
     def _disable_course_flag(self, course_key):
+        """Force the course-level waffle override off for the experiment."""
         WaffleFlagCourseOverrideModel.objects.create(
             waffle_flag=AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED.name,
             course_id=course_key,

--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -12,7 +12,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.models import CourseEnrollmentAttribute
 from common.djangoapps.util.date_utils import strftime_localized, strftime_localized_html
-from lms.djangoapps.experiments.flags import AUDIT_EXPIRY_URGENCY_V1_ENABLED
+from lms.djangoapps.experiments.flags import audit_expiry_urgency_v1_enabled_for_course
 from lms.djangoapps.courseware.access_response import AccessError
 from lms.djangoapps.courseware.access_utils import ACCESS_GRANTED
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
@@ -91,7 +91,7 @@ def get_user_course_expiration_date(user, course, enrollment=None):
     # it is the single source of truth for UI/API reads.
     # Kill switch behavior: when disabled, ignore any persisted experiment values
     # and fall back to the default computed CDL logic.
-    if AUDIT_EXPIRY_URGENCY_V1_ENABLED.is_enabled():
+    if audit_expiry_urgency_v1_enabled_for_course(course.id):
         persisted_expiry_attr = (
             CourseEnrollmentAttribute.objects.filter(
                 enrollment=enrollment,
@@ -162,7 +162,7 @@ def get_access_expiration_data(user, course):
     variant = None
     expiry_days = None
 
-    if AUDIT_EXPIRY_URGENCY_V1_ENABLED.is_enabled():
+    if audit_expiry_urgency_v1_enabled_for_course(course.id):
         experiment_attributes = {
             attr.name: attr.value
             for attr in enrollment.attributes.filter(namespace='audit_expiry_experiment')

--- a/openedx/features/course_duration_limits/tests/test_access.py
+++ b/openedx/features/course_duration_limits/tests/test_access.py
@@ -8,6 +8,7 @@ import ddt
 from crum import set_current_request
 from django.test import RequestFactory
 from django.utils import timezone
+from edx_django_utils.cache import RequestCache
 from pytz import UTC
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
@@ -28,7 +29,10 @@ from openedx.features.course_duration_limits.access import (
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from common.djangoapps.student.models import CourseEnrollmentAttribute
 from edx_toggles.toggles.testutils import override_waffle_flag
-from lms.djangoapps.experiments.flags import AUDIT_EXPIRY_URGENCY_V1_ENABLED
+from lms.djangoapps.experiments.flags import (
+    AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED,
+    AUDIT_EXPIRY_URGENCY_V1_ENABLED,
+)
 
 
 @ddt.ddt
@@ -36,10 +40,12 @@ class TestAccess(ModuleStoreTestCase):
     """Tests of openedx.features.course_duration_limits.access"""
     def setUp(self):
         super().setUp()  # lint-amnesty, pylint: disable=super-with-arguments
+        RequestCache.clear_all_namespaces()
 
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=UTC))
         DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
         self.course = CourseOverviewFactory.create(start=datetime(2018, 1, 1, tzinfo=UTC), self_paced=True)
+        self.addCleanup(RequestCache.clear_all_namespaces)
 
     def assertDateInMessage(self, date, message):  # lint-amnesty, pylint: disable=missing-function-docstring
         # First, check that the formatted version is in there
@@ -114,7 +120,8 @@ class TestAccess(ModuleStoreTestCase):
         )
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
-            data = get_access_expiration_data(user, overview)
+            with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED, active=True):
+                data = get_access_expiration_data(user, overview)
 
         assert data['experiment_key'] == 'audit_expiry_urgency_v1'
         assert data['variant'] == 'expiry_7_days'
@@ -227,7 +234,36 @@ class TestAccess(ModuleStoreTestCase):
         )
 
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
-            assert get_user_course_expiration_date(user, overview) == persisted
+            with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED, active=True):
+                assert get_user_course_expiration_date(user, overview) == persisted
+
+    def test_get_user_course_expiration_date_ignores_persisted_audit_expiry_at_when_course_flag_off(self):
+        enrollment = CourseEnrollmentFactory.create(course=self.course)
+        overview = enrollment.course
+        user = enrollment.user
+
+        CourseModeFactory(
+            course_id=enrollment.course.id,
+            mode_slug=CourseMode.VERIFIED,
+        )
+        CourseModeFactory(
+            course_id=enrollment.course.id,
+            mode_slug=CourseMode.AUDIT,
+        )
+
+        persisted = (timezone.now() + timedelta(days=42)).replace(microsecond=0)
+        CourseEnrollmentAttribute.objects.create(
+            enrollment=enrollment,
+            namespace='audit_expiry_experiment',
+            name='audit_expiry_at',
+            value=persisted.isoformat(),
+        )
+
+        with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=True):
+            computed = get_user_course_expiration_date(user, overview)
+
+        assert computed is not None
+        assert computed != persisted
 
     def test_get_user_course_expiration_date_ignores_persisted_audit_expiry_at_when_flag_off(self):
         enrollment = CourseEnrollmentFactory.create(course=self.course)
@@ -254,7 +290,8 @@ class TestAccess(ModuleStoreTestCase):
         # With the waffle flag off, the persisted value should be ignored
         # and the normal computed CDL logic should be used.
         with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_ENABLED, active=False):
-            computed = get_user_course_expiration_date(user, overview)
+            with override_waffle_flag(AUDIT_EXPIRY_URGENCY_V1_COURSE_ENABLED, active=True):
+                computed = get_user_course_expiration_date(user, overview)
 
         assert computed is not None
         assert computed != persisted


### PR DESCRIPTION
This updates the Audit Expiry Urgency experiment targeting from a site-config course allowlist to a course-aware waffle flag.

Keeps experiments.audit_expiry_urgency_v1.enabled as the global kill switch.
Adds experiments.audit_expiry_urgency_v1.course_enabled for course/org targeting.
Replaces AUDIT_EXPIRY_EXPERIMENT_COURSES checks in persistence, conversion tracking, and read-side expiry logic.
Preserves existing Optimizely assignment, sticky variant persistence, exposure tracking, and conversion tracking behavior.
Updates existing backend tests for course flag, org flag, global kill switch, force-off override, and persisted expiry behavior.