### PR TITLE
feat(studio): add inline title edit button and unit page styles to container view

### DIFF
--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -445,6 +445,100 @@
   }
 }
 
+.view-container.is-unit-page {
+  .wrapper-xblock {
+    .xblock-header-primary {
+      .header-details {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+
+        .xblock-display-title {
+          min-width: 0;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+      }
+
+      .title-edit-button.unit-rename-button {
+        @include transition(opacity $tmg-f3 linear 0s);
+
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        margin-left: ($baseline/4);
+        padding: ($baseline/4);
+        border: none;
+        background: transparent;
+        color: $ui-link-color;
+        opacity: 0;
+
+        .icon {
+          font-style: normal;
+        }
+
+        &:hover {
+          color: $uxpl-blue-hover-active;
+        }
+
+        &:focus {
+          opacity: 1;
+          outline: none;
+          box-shadow: 0 0 0 2px rgba($ui-link-color, 0.4);
+        }
+      }
+
+      &:hover .title-edit-button.unit-rename-button {
+        opacity: 1;
+      }
+    }
+
+    .header-actions .action-edit .edit-button.action-button {
+      @include transition(all $tmg-f3 linear 0s);
+
+      display: inline-flex;
+      align-items: center;
+      height: ($baseline*1.75);
+      border: 1px solid $ui-link-color;
+      border-radius: 4px;
+      background: transparent;
+      color: $ui-link-color;
+      padding: ($baseline/4) ($baseline/2);
+
+      .fa-pencil {
+        display: none;
+      }
+
+      .action-button-text {
+        padding: 0;
+        line-height: 1.4;
+        text-transform: none;
+      }
+
+      &:hover {
+        background-color: $ui-link-color;
+        color: $white;
+      }
+
+      &:focus {
+        outline: none;
+        box-shadow: inset 0 0 0 2px $ui-link-color;
+      }
+    }
+
+    .header-actions .show-actions-menu-button.action-button {
+      border-radius: 4px;
+    }
+  }
+
+  input.xblock-inline-title-editor {
+    padding-top: 0;
+    padding-bottom: 0;
+    font-weight: font-weight(semi-bold);
+  }
+}
 
 .move-xblock-modal {
   button {

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -22,7 +22,7 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%block name="title">${xblock.display_name_with_default} ${xblock_type_display_name(xblock)}</%block>
-<%block name="bodyclass">is-signedin course container view-container</%block>
+<%block name="bodyclass">is-signedin course container view-container${' is-unit-page' if is_unit_page else ''}</%block>
 
 <%namespace name='static' file='static_content.html'/>
 

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -137,6 +137,12 @@ can_unlink = upstream_info.upstream_ref and not upstream_info.has_top_level_pare
                 <p class="xblock-group-visibility-label">${selected_groups_label}</p>
                 % endif
             </div>
+            % if can_edit and not is_root and not selectable:
+            <button type="button" data-tooltip="${_('Edit Title')}" class="btn-default title-edit-button unit-rename-button">
+                <span class="icon fa fa-pencil" aria-hidden="true"></span>
+                <span class="sr">${_("Edit Title")}</span>
+            </button>
+            % endif
         </div>
         <div class="header-actions">
             <ul class="actions-list nav-dd ui-right">


### PR DESCRIPTION
- Introduced new styles for the unit page container, enhancing the header layout and actions.
- Added an edit title button for non-root xblocks, improving user interaction for title modifications.
- Updated the body class in the container template to conditionally include 'is-unit-page' based on the context.

--- 
## Description
Enhances the Studio container view (unit page) with improved header styling and an inline title
edit affordance for non-root xblocks, giving Course Authors a more intuitive way to rename
components without leaving the page.

**User roles impacted:** Course Author

## Changes
- **Styles**: Introduced new CSS for the unit page container, improving the header layout and
  action area spacing/alignment.
- **Edit Title Button**: Added an edit title button in the container view, rendered only for
  non-root xblocks — root xblocks (units themselves) are unaffected.
- **Template**: Updated the container template to conditionally apply the `is-unit-page` body
  class, scoping the new styles correctly to the unit page context.

## Screen recording:
https://github.com/user-attachments/assets/68b67d32-7bbc-47e2-8abf-151436e725fa

## Supporting Information
Jira ticket: TNL2-619  
Related frontend PR: edx/frontend-app-authoring#101

## Testing Instructions
1. Open Studio and navigate to a course unit page.
2. Verify the header layout and action area reflect the updated styles.
3. Open the container view for a **non-root xblock** — confirm the edit title button is visible.
4. Open the container view for a **root xblock (unit)** — confirm the edit title button is
   **not** shown.
5. Verify that the `is-unit-page` class is applied to `<body>` on unit pages and absent on
   other container views (e.g., split tests, content groups).

## Other Information
- This is the backend/template counterpart to the frontend rename changes in
  `edx/frontend-app-authoring#101` (same ticket, `feat/TNL2-619`).
- No database migrations involved.
- No deprecations or breaking changes expected.
 