### PR TITLE
feat: redact PII fields before delete in user retirement flows

### DIFF
--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -1606,7 +1606,9 @@ class CourseEnrollmentAllowed(DeletableByUserValue, models.Model):
     the object is marked with the student who enrolled, to prevent students from changing e-mails and
     enrolling many accounts through the same e-mail.
 
-    .. no_pii:
+    .. pii: Contains email, redacted then deleted in AccountRetirementView
+    .. pii_types: email_address
+    .. pii_retirement: local_api
     """
     email = models.CharField(max_length=255, db_index=True)
     course_id = CourseKeyField(max_length=255, db_index=True)
@@ -1654,6 +1656,13 @@ class CourseEnrollmentAllowed(DeletableByUserValue, models.Model):
         `course_id` identifies the course for which to compute the QuerySet.
         """
         return CourseEnrollmentAllowed.objects.filter(course_id=course_id, user__isnull=True)
+
+    @classmethod
+    def redact_before_delete_fields(cls):
+        """
+        Redact email before deleting records for downstream soft-delete systems.
+        """
+        return {'email': 'redacted-before-delete@safe.com'}
 
 
 class CourseEnrollmentAttribute(models.Model):

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -904,13 +904,20 @@ class PendingEmailChange(DeletableByUserValue, models.Model):
     """
     This model keeps track of pending requested changes to a user's email address.
 
-    .. pii: Contains new_email, retired in AccountRetirementView
+    .. pii: Contains new_email, redacted then deleted in AccountRetirementView
     .. pii_types: email_address
     .. pii_retirement: local_api
     """
     user = models.OneToOneField(User, unique=True, db_index=True, on_delete=models.CASCADE)
     new_email = models.CharField(blank=True, max_length=255, db_index=True)
     activation_key = models.CharField(('activation key'), max_length=32, unique=True, db_index=True)
+
+    @classmethod
+    def redact_before_delete_fields(cls):
+        """
+        Redact PII fields before delete in downstream soft-delete systems.
+        """
+        return {'new_email': 'redacted-before-delete@safe.com'}
 
     def request_change(self, email):
         """Request a change to a user's email.

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -10,8 +10,10 @@ from crum import set_current_request
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.cache import cache
 from django.conf import settings
+from django.db import connection
 from django.db.models.functions import Lower
 from django.test import TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 from edx_toggles.toggles.testutils import override_waffle_flag
 from freezegun import freeze_time
 from opaque_keys.edx.keys import CourseKey
@@ -42,10 +44,13 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.schedules.models import Schedule
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
-from openedx.core.djangolib.testing.utils import skip_unless_lms
-from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangolib.testing.utils import assert_redact_before_delete, skip_unless_lms
+from xmodule.modulestore import ModuleStoreEnum  # pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import (  # pylint: disable=wrong-import-order
+    ModuleStoreTestCase,
+    SharedModuleStoreTestCase,
+)
+from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
 
 
 @ddt.ddt
@@ -597,6 +602,22 @@ class PendingEmailChangeTests(SharedModuleStoreTestCase):
         assert not record_was_deleted
         assert 1 == len(PendingEmailChange.objects.all())
 
+    def test_delete_by_user_value_redacts_pending_email_before_deletion(self):
+        """
+        Verify that delete_by_user_value redacts new_email before deletion.
+        """
+        table = PendingEmailChange._meta.db_table
+        with CaptureQueriesContext(connection) as ctx:
+            record_was_deleted = PendingEmailChange.delete_by_user_value(self.user, field='user')
+
+        assert_redact_before_delete(
+            [q['sql'] for q in ctx],
+            table=table,
+            expected_redacted_value_list=['redacted-before-delete@safe.com'],
+        )
+        assert record_was_deleted
+        assert not PendingEmailChange.objects.filter(user=self.user).exists()
+
 
 class TestCourseEnrollmentAllowed(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
@@ -612,11 +633,18 @@ class TestCourseEnrollmentAllowed(ModuleStoreTestCase):  # lint-amnesty, pylint:
         )
 
     def test_retiring_user_deletes_record(self):
-        is_successful = CourseEnrollmentAllowed.delete_by_user_value(
-            value=self.email,
-            field='email'
-        )
+        with CaptureQueriesContext(connection) as ctx:
+            is_successful = CourseEnrollmentAllowed.delete_by_user_value(
+                value=self.email,
+                field='email'
+            )
+
         assert is_successful
+        assert_redact_before_delete(
+            [q['sql'] for q in ctx],
+            table=CourseEnrollmentAllowed._meta.db_table,
+            expected_redacted_value_list=['redacted-before-delete@safe.com'],
+        )
         user_search_results = CourseEnrollmentAllowed.objects.filter(
             email=self.email
         )

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -935,14 +935,17 @@ def confirm_email_change(request, key):
 
         user.email = pec.new_email
         user.save()
-        pec.delete()
+
+        # Redact pending email before deletion.
+        PendingEmailChange.delete_by_user_value(user, field="user")
+
         # And send it to the new email...
-        msg.recipient = Recipient(user.id, pec.new_email)
+        msg.recipient = Recipient(user.id, user.email)
         try:
             ace.send(msg)
         except Exception:  # pylint: disable=broad-except
             log.warning('Unable to send confirmation email to new address', exc_info=True)
-            response = render_to_response("email_change_failed.html", {'email': pec.new_email})
+            response = render_to_response("email_change_failed.html", {'email': user.email})
             transaction.set_rollback(True)
             return response
 

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -306,3 +306,10 @@ class UnregisteredLearnerCohortAssignments(DeletableByUserValue, models.Model):
     course_user_group = models.ForeignKey(CourseUserGroup, on_delete=models.CASCADE)
     email = models.CharField(blank=True, max_length=255, db_index=True)
     course_id = CourseKeyField(max_length=255)
+
+    @classmethod
+    def redact_before_delete_fields(cls):
+        """
+        Redact email before deleting records for downstream soft-delete systems.
+        """
+        return {'email': 'redacted-before-delete@safe.com'}

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -6,19 +6,24 @@ Tests for cohorts
 from unittest.mock import call, patch
 import pytest
 import ddt
-from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
-from django.db import IntegrityError
+from django.contrib.auth.models import AnonymousUser, User  # pylint: disable=imported-auth-user
+from django.db import IntegrityError, connection
 from django.http import Http404
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import ToyCourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangolib.testing.utils import assert_redact_before_delete
+from xmodule.modulestore.django import modulestore  # pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import (  # pylint: disable=wrong-import-order
+    TEST_DATA_SPLIT_MODULESTORE,
+    ModuleStoreTestCase,
+)
+from xmodule.modulestore.tests.factories import ToyCourseFactory  # pylint: disable=wrong-import-order
 
 from .. import cohorts
 from ..models import CourseCohort, CourseUserGroup, CourseUserGroupPartitionGroup, UnregisteredLearnerCohortAssignments
@@ -798,12 +803,18 @@ class TestUnregisteredLearnerCohortAssignments(TestCase):
         )
 
     def test_retired_user_has_deleted_record(self):
-        was_retired = UnregisteredLearnerCohortAssignments.delete_by_user_value(
-            value='learner@example.com',
-            field='email'
-        )
+        with CaptureQueriesContext(connection) as ctx:
+            was_retired = UnregisteredLearnerCohortAssignments.delete_by_user_value(
+                value='learner@example.com',
+                field='email'
+            )
 
         assert was_retired
+        assert_redact_before_delete(
+            [q['sql'] for q in ctx],
+            table=UnregisteredLearnerCohortAssignments._meta.db_table,
+            expected_redacted_value_list=['redacted-before-delete@safe.com'],
+        )
 
         search_retired_user_results = \
             UnregisteredLearnerCohortAssignments.objects.filter(

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -59,6 +59,7 @@ from openedx.core.djangoapps.credit.models import (
 )
 from openedx.core.djangoapps.external_user_ids.models import ExternalIdType
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
+from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory, AccessTokenFactory
 from openedx.core.djangoapps.user_api.accounts.views import AccountRetirementPartnerReportView
 from openedx.core.djangoapps.user_api.models import (
     RetirementState,
@@ -66,8 +67,7 @@ from openedx.core.djangoapps.user_api.models import (
     UserRetirementPartnerReportingStatus,
     UserRetirementStatus
 )
-from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory, AccessTokenFactory
+from openedx.core.djangolib.testing.utils import assert_redact_before_delete, skip_unless_lms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -1468,7 +1468,14 @@ class TestAccountRetirementPost(RetirementTestCase):
     @mock.patch('openedx.core.djangoapps.user_api.accounts.views.remove_profile_images')
     def test_retire_user(self, mock_remove_profile_images, mock_get_profile_image_names):
         data = {'username': self.original_username}
-        self.post_and_assert_status(data)
+        with CaptureQueriesContext(connection) as ctx:
+            self.post_and_assert_status(data)
+
+        assert_redact_before_delete(
+            [q['sql'] for q in ctx],
+            table=PendingEmailChange._meta.db_table,
+            expected_redacted_value_list=['redacted-before-delete@safe.com'],
+        )
 
         self.test_user.refresh_from_db()
         self.test_user.profile.refresh_from_db()  # pylint: disable=no-member

--- a/openedx/core/djangolib/model_mixins.py
+++ b/openedx/core/djangolib/model_mixins.py
@@ -21,21 +21,39 @@ class DeletableByUserValue:
     """
 
     @classmethod
+    def redact_before_delete_fields(cls):
+        """
+        Returns dict of PII fields and their redacted values.
+
+        Always returns an empty dict unless overridden by the inheriting model.
+        Results are used by ``delete_by_user_value`` to redact PII before delete.
+        """
+        return {}
+
+    @classmethod
     def delete_by_user_value(cls, value, field):
         """
-        Deletes instances of this model where ``field`` equals ``value``.
+        Redacts as-needed and always deletes instances of this model where ``field`` equals ``value``.
 
         e.g.
             ``delete_by_user_value(value='learner@example.com', field='email')``
+
+        If ``redact_before_delete_fields()`` returns a non-empty dict, the
+        returned PII fields are redacted before any records are deleted.
 
         Returns True if any instances were deleted.
         Returns False otherwise.
         """
         filter_kwargs = {field: value}
         records_matching_user_value = cls.objects.filter(**filter_kwargs)
-
-        if not records_matching_user_value.exists():
+        record_ids_matching_user_value = list(records_matching_user_value.values_list('id', flat=True))
+        if not record_ids_matching_user_value:
             return False
 
-        records_matching_user_value.delete()
+        # Converting to query set by id ensures we redact and delete the appropriate records
+        user_value_records_by_id = cls.objects.filter(id__in=record_ids_matching_user_value)
+        redact_fields = cls.redact_before_delete_fields()
+        if redact_fields:
+            user_value_records_by_id.update(**redact_fields)
+        user_value_records_by_id.delete()
         return True

--- a/openedx/core/djangolib/testing/utils.py
+++ b/openedx/core/djangolib/testing/utils.py
@@ -26,6 +26,44 @@ from edx_django_utils.cache import RequestCache
 from openedx.core.lib import ensure_cms, ensure_lms
 
 
+def assert_redact_before_delete(
+    sql_list,
+    table,
+    expected_redacted_value_list,
+    num_redact_delete_pairs=1,
+):
+    """
+    Assert that PII is redacted before deleted.
+
+    Redacting before deleting protects downstream sync of data from holding PII
+    in soft-deleted records. This helper ensures UPDATE and DELETE queries for
+    ``table`` occur in consecutive pairs, and that each UPDATE contains the
+    expected redacted values.
+    """
+    assert expected_redacted_value_list
+
+    table_key = table.upper()
+    expected_sql_list = [
+        sql for sql in sql_list
+        if table_key in sql.upper() and ('UPDATE' in sql.upper() or 'DELETE' in sql.upper())
+    ]
+
+    assert len(expected_sql_list) == num_redact_delete_pairs * 2, (
+        f'Expected {num_redact_delete_pairs * 2} UPDATE/DELETE queries on {table}, '
+        f'got {len(expected_sql_list)}'
+    )
+
+    for index in range(0, len(expected_sql_list), 2):
+        update_sql = expected_sql_list[index]
+        delete_sql = expected_sql_list[index + 1]
+        assert 'UPDATE' in update_sql.upper(), f'Expected UPDATE at position {index} for {table}'
+        assert 'DELETE' in delete_sql.upper(), f'Expected DELETE at position {index + 1} for {table}'
+        for expected_redacted_value in expected_redacted_value_list:
+            assert expected_redacted_value.upper() in update_sql.upper(), (
+                f'Expected UPDATE to set redacted value {expected_redacted_value} for {table}'
+            )
+
+
 class CacheIsolationMixin:
     """
     This class can be used to enable specific django caches for

--- a/openedx/core/djangolib/tests/test_model_mixins.py
+++ b/openedx/core/djangolib/tests/test_model_mixins.py
@@ -1,0 +1,90 @@
+"""
+Tests for model_mixins.py.
+"""
+
+from unittest import TestCase, mock
+
+import ddt
+
+from openedx.core.djangolib.model_mixins import DeletableByUserValue
+
+
+@ddt.ddt
+class TestDeletableByUserValue(TestCase):
+    """
+    Unit tests for DeletableByUserValue.
+    """
+
+    class NonRedactingModel(DeletableByUserValue):
+        """
+        Dummy model that uses default redaction behavior.
+        """
+
+    class RedactingModel(DeletableByUserValue):
+        """
+        Dummy model that overrides redaction fields.
+        """
+
+        @classmethod
+        def redact_before_delete_fields(cls):
+            return {'email': 'redacted@retired.invalid'}
+
+    def _make_queryset(self, exists):
+        """
+        Return a mock queryset with ``exists`` and ``values_list`` pre-configured.
+        """
+        queryset = mock.Mock()
+        queryset.exists.return_value = exists
+        queryset.values_list.return_value = [11, 12] if exists else []
+        return queryset
+
+    def test_redact_before_delete_fields_defaults_to_empty_dict(self):
+        """
+        Verify the default redaction hook does not request any field updates.
+        """
+        assert not self.NonRedactingModel.redact_before_delete_fields()
+
+    def test_delete_by_user_value_returns_false_when_no_matches(self):
+        """
+        Verify no updates or deletes occur when no rows match the filter.
+        """
+        queryset = self._make_queryset(exists=False)
+        with mock.patch.object(self.NonRedactingModel, 'objects', create=True) as mock_objects:
+            mock_objects.filter.return_value = queryset
+
+            was_deleted = self.NonRedactingModel.delete_by_user_value(value='missing@example.com', field='email')
+
+        assert not was_deleted
+        mock_objects.filter.assert_called_once_with(email='missing@example.com')
+        queryset.update.assert_not_called()
+        queryset.delete.assert_not_called()
+
+    @ddt.data(
+        ('NonRedactingModel', None),
+        ('RedactingModel', {'email': 'redacted@retired.invalid'}),
+    )
+    @ddt.unpack
+    def test_delete_by_user_value(self, model_name, expected_redact_fields):
+        """
+        Verify delete behavior with and without redaction configured.
+
+        When no redaction hook is set, rows are deleted directly.
+        When a redaction hook is set, fields are updated before deletion.
+        """
+        model_cls = getattr(self, model_name)
+        queryset = self._make_queryset(exists=True)
+        with mock.patch.object(model_cls, 'objects', create=True) as mock_objects:
+            mock_objects.filter.return_value = queryset
+
+            was_deleted = model_cls.delete_by_user_value(value='learner@example.com', field='email')
+
+        assert was_deleted
+        assert mock_objects.filter.call_args_list == [
+            mock.call(email='learner@example.com'),
+            mock.call(id__in=[11, 12]),
+        ]
+        if expected_redact_fields:
+            queryset.update.assert_called_once_with(**expected_redact_fields)
+        else:
+            queryset.update.assert_not_called()
+        queryset.delete.assert_called_once_with()


### PR DESCRIPTION
## Summary

Adds support for redacting sensitive PII fields before deletion in DeletableByUserValue models.

Changes include:
- Added redact_before_delete_fields hook to model mixin
- Redact emails before delete for:
  - CourseEnrollmentAllowed
  - PendingEmailChange
  - UnregisteredLearnerCohortAssignments
- Added SQL assertion helpers to verify UPDATE occurs before DELETE
- Added regression/unit tests for safe ID-filtered redaction and deletion flows
- Updated email change flow to use delete_by_user_value
## Ticket & Reference

https://2u-internal.atlassian.net/browse/BOMS-498

## Related Tickets
https://2u-internal.atlassian.net/browse/BOMS-565
https://2u-internal.atlassian.net/browse/BOMS-564
 