### PR TITLE
feat: added read only mode toggle for discussion forum

### DIFF
--- a/lms/djangoapps/discussion/rest_api/forum_mute_views.py
+++ b/lms/djangoapps/discussion/rest_api/forum_mute_views.py
@@ -19,7 +19,8 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 
 from lms.djangoapps.discussion.rest_api.permissions import (
-    CanMuteUsers
+    CanMuteUsers,
+    IsDiscussionReadOnlyModeDisabled,
 )
 from lms.djangoapps.discussion.rest_api.serializers import (
     MuteRequestSerializer,
@@ -97,7 +98,7 @@ class ForumMuteUserView(DeveloperErrorViewMixin, APIView):
         JwtAuthentication,
         SessionAuthenticationAllowInactiveUser,
     ]
-    permission_classes = [CanMuteUsers]
+    permission_classes = [CanMuteUsers, IsDiscussionReadOnlyModeDisabled]
 
     def post(self, request, course_id):
         """Mute a user in discussions using forum service"""
@@ -154,7 +155,7 @@ class ForumUnmuteUserView(DeveloperErrorViewMixin, APIView):
         JwtAuthentication,
         SessionAuthenticationAllowInactiveUser,
     ]
-    permission_classes = [CanMuteUsers]
+    permission_classes = [CanMuteUsers, IsDiscussionReadOnlyModeDisabled]
 
     def post(self, request, course_id):
         """Unmute a user in discussions using forum service"""
@@ -212,7 +213,7 @@ class ForumMuteAndReportView(DeveloperErrorViewMixin, APIView):
         JwtAuthentication,
         SessionAuthenticationAllowInactiveUser,
     ]
-    permission_classes = [CanMuteUsers]
+    permission_classes = [CanMuteUsers, IsDiscussionReadOnlyModeDisabled]
 
     def post(self, request, course_id):
         """Mute a user and report their content using forum service"""
@@ -318,7 +319,7 @@ class ForumMutedUsersListView(DeveloperErrorViewMixin, APIView):
         JwtAuthentication,
         SessionAuthenticationAllowInactiveUser,
     ]
-    permission_classes = [CanMuteUsers]
+    permission_classes = [CanMuteUsers, IsDiscussionReadOnlyModeDisabled]
 
     def get(self, request, course_id):
         """Get list of muted users using forum service"""
@@ -358,12 +359,24 @@ class ForumMutedUsersListView(DeveloperErrorViewMixin, APIView):
 
         # Call forum API
         try:
-            result = forum_api.get_all_muted_users_for_course(
-                course_id=str(course_key),
-                requester_id=requester_id,
-                scope=scope,
-                requester_is_privileged=is_staff
-            )
+            if is_staff:
+                result = forum_api.get_all_muted_users_for_course(
+                    course_id=str(course_key),
+                    requester_id=requester_id,
+                    scope=scope,
+                    requester_is_privileged=is_staff,
+                )
+            else:
+                # Keep learner flow simple and avoid backend privilege re-check lookups.
+                # Learners should only see their own personal mutes.
+                muted_users = forum_api.get_muted_users(
+                    muter_id=str(request.user.id),
+                    course_id=str(course_key),
+                    scope='personal',
+                )
+                result = {
+                    'muted_users': muted_users,
+                }
 
             # Process results if usernames needed
             muted_users = result.get('muted_users', [])
@@ -422,7 +435,7 @@ class ForumMuteStatusView(DeveloperErrorViewMixin, APIView):
         JwtAuthentication,
         SessionAuthenticationAllowInactiveUser,
     ]
-    permission_classes = [CanMuteUsers]
+    permission_classes = [CanMuteUsers, IsDiscussionReadOnlyModeDisabled]
 
     def get(self, request, course_id, user_id):
         """Get mute status for a user using forum service"""

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -5,7 +5,7 @@ from typing import Dict, Set, Union
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from rest_framework import permissions
+from rest_framework import exceptions, permissions, status
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import (
@@ -17,6 +17,8 @@ from lms.djangoapps.discussion.django_comment_client.utils import (
     get_user_role_names,
     has_discussion_privileges,
 )
+from lms.djangoapps.discussion.rest_api.utils import get_course_id_from_thread_id
+from lms.djangoapps.discussion.toggles import READ_ONLY_MODE
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.thread import Thread
 from openedx.core.djangoapps.django_comment_common.models import (
@@ -223,6 +225,89 @@ def can_take_action_on_spam(user, course_id):
     if bool(user_roles & {FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR}):
         return True
     return False
+
+
+class DiscussionReadOnlyModeException(exceptions.APIException):
+    """Raised when a write operation is attempted while discussions are in read-only mode."""
+
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_code = "read_only_mode"
+    default_detail = (
+        "Discussions are temporarily in read-only mode while maintenance is in progress. "
+        "You can continue viewing content, but posting and other modifications are temporarily unavailable."
+    )
+
+
+class IsDiscussionReadOnlyModeDisabled(permissions.BasePermission):
+    """Block discussion write operations when the read-only waffle flag is enabled."""
+
+    SAFE_METHODS_WITH_TRACE = (*permissions.SAFE_METHODS, "TRACE")
+
+    def has_permission(self, request, view):
+        if request.method in self.SAFE_METHODS_WITH_TRACE:
+            return True
+
+        course_key = self._get_course_key(request, view)
+
+        if READ_ONLY_MODE.is_enabled(course_key):
+            raise DiscussionReadOnlyModeException()
+
+        return True
+
+    def _get_course_key(self, request, view):
+        """Best-effort course key extraction for discussion write requests."""
+        course_id = None
+        thread_id = None
+        comment_id = None
+
+        if hasattr(view, "kwargs") and view.kwargs:
+            course_id = view.kwargs.get("course_id") or view.kwargs.get("course_key_string")
+            thread_id = view.kwargs.get("thread_id")
+            comment_id = view.kwargs.get("comment_id")
+
+        if not course_id and hasattr(request, "data") and hasattr(request.data, "get"):
+            course_id = request.data.get("course_id")
+            thread_id = thread_id or request.data.get("thread_id")
+            comment_id = comment_id or request.data.get("comment_id")
+
+        if not course_id:
+            course_id = request.query_params.get("course_id")
+
+        if not course_id:
+            try:
+                if thread_id:
+                    course_id = get_course_id_from_thread_id(thread_id)
+                elif comment_id:
+                    cc_comment = Comment(id=comment_id).retrieve()
+                    course_id = get_course_id_from_thread_id(cc_comment["thread_id"])
+            except Exception:  # pylint: disable=broad-exception-caught
+                # Do not fail permission checks on backend lookup edge cases.
+                # The target view will still validate and return a proper response.
+                course_id = None
+
+        if (
+            not course_id
+            and hasattr(view, "kwargs")
+            and view.kwargs
+            and getattr(view, "action", None) == "unban_user_by_id"
+        ):
+            try:
+                from forum import api as forum_api
+
+                ban = forum_api.get_ban(view.kwargs.get("pk"))
+                course_id = ban.get("course_id") or (
+                    request.data.get("course_id") if hasattr(request.data, "get") else None
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                course_id = None
+
+        if not course_id:
+            return None
+
+        try:
+            return CourseKey.from_string(str(course_id))
+        except InvalidKeyError:
+            return None
 
 
 class IsAllowedToBulkDelete(permissions.BasePermission):

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -42,6 +42,7 @@ from lms.djangoapps.discussion.rate_limit import is_content_creation_rate_limite
 from lms.djangoapps.discussion.rest_api.permissions import (
     IsAllowedToBulkDelete,
     IsAllowedToRestore,
+    IsDiscussionReadOnlyModeDisabled,
     IsStaffOrAdmin,
     IsStaffOrCourseTeamOrEnrolled,
     can_take_action_on_spam,
@@ -761,6 +762,10 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
         MergePatchParser,
     )
 
+    def get_permissions(self):
+        """Append read-only mode check to permissions set by @view_auth_classes decorator."""
+        return super().get_permissions() + [IsDiscussionReadOnlyModeDisabled()]
+
     def list(self, request):
         """
         Implements the GET method for the list endpoint as described in the
@@ -1237,6 +1242,10 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
         MergePatchParser,
     )
 
+    def get_permissions(self):
+        """Append read-only mode check to permissions set by @view_auth_classes decorator."""
+        return super().get_permissions() + [IsDiscussionReadOnlyModeDisabled()]
+
     def list(self, request):
         """
         Implements the GET method for the list endpoint as described in
@@ -1511,6 +1520,7 @@ class UploadFileView(DeveloperErrorViewMixin, APIView):
     permission_classes = (
         permissions.IsAuthenticated,
         IsStaffOrCourseTeamOrEnrolled,
+        IsDiscussionReadOnlyModeDisabled,
     )
 
     def post(self, request, course_id):
@@ -1755,7 +1765,11 @@ class CourseDiscussionSettingsAPIView(DeveloperErrorViewMixin, APIView):
         JSONParser,
         MergePatchParser,
     )
-    permission_classes = (permissions.IsAuthenticated, IsStaffOrAdmin)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsStaffOrAdmin,
+        IsDiscussionReadOnlyModeDisabled,
+    )
 
     def _get_request_kwargs(self, course_id):
         return dict(course_id=course_id)
@@ -1879,7 +1893,11 @@ class CourseDiscussionRolesAPIView(DeveloperErrorViewMixin, APIView):
         BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
-    permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        permissions.IsAdminUser,
+        IsDiscussionReadOnlyModeDisabled,
+    )
 
     def _get_request_kwargs(self, course_id, rolename):
         return dict(course_id=course_id, rolename=rolename)
@@ -1960,7 +1978,11 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
         BearerAuthentication,
         SessionAuthentication,
     )
-    permission_classes = (permissions.IsAuthenticated, IsAllowedToBulkDelete)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsAllowedToBulkDelete,
+        IsDiscussionReadOnlyModeDisabled,
+    )
 
     def post(self, request, course_id):
         """
@@ -2047,7 +2069,11 @@ class RestoreContent(DeveloperErrorViewMixin, APIView):
         BearerAuthentication,
         SessionAuthentication,
     )
-    permission_classes = (permissions.IsAuthenticated, IsAllowedToRestore)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsAllowedToRestore,
+        IsDiscussionReadOnlyModeDisabled,
+    )
 
     def post(self, request):
         """
@@ -2150,7 +2176,11 @@ class BulkRestoreUserPosts(DeveloperErrorViewMixin, APIView):
         BearerAuthentication,
         SessionAuthentication,
     )
-    permission_classes = (permissions.IsAuthenticated, IsAllowedToBulkDelete)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsAllowedToBulkDelete,
+        IsDiscussionReadOnlyModeDisabled,
+    )
 
     def post(self, request, course_id):
         """
@@ -2337,7 +2367,11 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
     authentication_classes = (
         JwtAuthentication, BearerAuthentication, SessionAuthentication,
     )
-    permission_classes = (permissions.IsAuthenticated, IsAllowedToBulkDelete)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsAllowedToBulkDelete,
+        IsDiscussionReadOnlyModeDisabled,
+    )
 
     def get_permissions(self):
         """
@@ -2347,8 +2381,10 @@ class DiscussionModerationViewSet(DeveloperErrorViewMixin, ViewSet):
         because we check course-specific permissions inside the action method after retrieving the ban.
         For ban_user, we check permissions inside the action based on scope.
         """
-        if self.action in ['unban_user', 'unban_user_by_id', 'banned_users', 'ban_user']:
+        if self.action in ['banned_users']:
             return [permissions.IsAuthenticated()]
+        if self.action in ['unban_user', 'unban_user_by_id', 'ban_user']:
+            return [permissions.IsAuthenticated(), IsDiscussionReadOnlyModeDisabled()]
         return super().get_permissions()
 
     @apidocs.schema(

--- a/lms/djangoapps/discussion/toggles.py
+++ b/lms/djangoapps/discussion/toggles.py
@@ -55,3 +55,19 @@ ENABLE_RATE_LIMIT_IN_DISCUSSION = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.ena
 ENABLE_DISCUSSION_BAN = CourseWaffleFlag(
     f'{WAFFLE_FLAG_NAMESPACE}.enable_discussion_ban', __name__
 )
+
+
+# .. toggle_name: discussions.read_only_mode
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable read-only mode for discussions during maintenance/migration.
+#    When enabled, all write operations are blocked while read operations remain available.
+# .. toggle_use_cases: temporary, circuit_breaker
+# .. toggle_creation_date: 2026-06-03
+# .. toggle_target_removal_date: 2026-12-31
+# .. toggle_warning: When enabled, all post/comment creation, editing, deletion, voting, and moderation actions are blocked.
+#    Users will see a message: "Discussions are temporarily in read-only mode while maintenance is in progress."
+# .. toggle_tickets: FORUM-MIGRATION
+READ_ONLY_MODE = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.read_only_mode', __name__
+)


### PR DESCRIPTION
# Description

This PR introduces the `discussions.read_only_mode` feature toggle to support discussion maintenance activities, particularly the migration of Discussions data from MongoDB to MySQL.

When `discussions.read_only_mode` is enabled, Discussions operate in a read-only state. Users can continue to view and navigate discussion content, but all operations that modify discussion data are blocked.

Write operations return a `503 Service Unavailable` response along with a user-friendly maintenance message indicating that Discussions are temporarily in read-only mode.

## Behavior

### Allowed Operations

* View discussion posts
* View responses and comments
* Browse discussion topics and learner activity
* Search discussions

### Blocked Operations

* Create posts
* Create responses
* Create comments
* Edit content
* Delete content
* Restore content
* Close threads
* Follow threads
* Unfollow threads
* Vote on content
* Report content
* Mute users
* Unmute users
* Ban users
* Unban users
* Any other operation that modifies discussion data

## Error Handling

When a blocked operation is attempted while `discussions.read_only_mode` is enabled:

* The request returns a `503 Service Unavailable` response.
* A maintenance message is displayed to the user indicating that Discussions are temporarily in read-only mode.
* No discussion data is modified.

## Use Case

The primary use case for this feature is the migration of Discussions data from MongoDB to MySQL.

During the migration window, any new writes to Discussions could result in data inconsistencies or operations that are not captured in the migrated dataset. Enabling `discussions.read_only_mode` ensures that the source data remains stable throughout the migration process and prevents discussion activity from being lost or excluded from the migration.

Once the migration has been completed and validated, the toggle can be disabled to restore normal Discussions functionality.

## Related Ticket

* [COSMO2-970](https://2u-internal.atlassian.net/browse/COSMO2-970)

## Related PRs
https://github.com/edx/frontend-app-discussions/pull/35
