### PR TITLE
feat: add edx-proctoring-proctortrack for translation extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ swagger: ## generate the swagger.yaml file
 extract_translations: ## extract localizable strings from sources
 	i18n_tool extract --no-segment -v
 	cd conf/locale/en/LC_MESSAGES && msgcat djangojs.po underscore.po -o djangojs.po
-	cd conf/locale/en/LC_MESSAGES && msgcat django.po wiki.po mako.po -o django.po
-	cd conf/locale/en/LC_MESSAGES && rm wiki.po mako.po underscore.po
+	cd conf/locale/en/LC_MESSAGES && msgcat django.po wiki.po edx_proctoring_proctortrack.po mako.po -o django.po
+	cd conf/locale/en/LC_MESSAGES && rm wiki.po edx_proctoring_proctortrack.po mako.po underscore.po
 
 pull_plugin_translations:  ## Pull translations for edx_django_utils.plugins for both lms and cms
 	python manage.py lms pull_plugin_translations --verbose $(ATLAS_OPTIONS)

--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -52,7 +52,7 @@ ignore_dirs:
 # Makefile `extract_translations` target to ensure it makes to Transifex.
 third_party:
     - wiki
-    - edx-proctoring-proctortrack
+    - edx_proctoring_proctortrack
 
 # How should .po files be segmented?  See i18n/segment.py for details. Strings
 # that are only found in a particular segment are segregated into that .po file

--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -52,7 +52,7 @@ ignore_dirs:
 # Makefile `extract_translations` target to ensure it makes to Transifex.
 third_party:
     - wiki
-
+    - edx-proctoring-proctortrack
 
 # How should .po files be segmented?  See i18n/segment.py for details. Strings
 # that are only found in a particular segment are segregated into that .po file

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -511,7 +511,11 @@ edx-opaque-keys[django]==3.0.0
 edx-organizations==7.3.0
     # via -r requirements/edx/kernel.in
 edx-proctoring==5.2.0
-    # via -r requirements/edx/kernel.in
+    # via
+    #   -r requirements/edx/kernel.in
+    #   edx-proctoring-proctortrack
+edx-proctoring-proctortrack==1.2.1
+    # via -r requirements/edx/bundled.in
 edx-rbac==2.1.0
     # via
     #   edx-enterprise

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -44,3 +44,4 @@ xblocks-contrib                     # Package having multiple core XBlocks, http
 
 ## Integrated Channels
 enterprise-integrated-channels      # Integrated Channels to transmit content metadata and learner data.
+edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -803,6 +803,11 @@ edx-proctoring==5.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   edx-proctoring-proctortrack
+edx-proctoring-proctortrack==1.2.1
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
 edx-rbac==2.1.0
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -595,6 +595,10 @@ edx-opaque-keys[django]==3.0.0
 edx-organizations==7.3.0
     # via -r requirements/edx/base.txt
 edx-proctoring==5.2.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   edx-proctoring-proctortrack
+edx-proctoring-proctortrack==1.2.1
     # via -r requirements/edx/base.txt
 edx-rbac==2.1.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -618,6 +618,10 @@ edx-opaque-keys[django]==3.0.0
 edx-organizations==7.3.0
     # via -r requirements/edx/base.txt
 edx-proctoring==5.2.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   edx-proctoring-proctortrack
+edx-proctoring-proctortrack==1.2.1
     # via -r requirements/edx/base.txt
 edx-rbac==2.1.0
     # via

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,6 +1,6 @@
 -c constraints.txt
 # Core dependencies for installing other dependencies
 
-pip
+pip<25.3
 setuptools
 wheel

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,6 +1,6 @@
 -c constraints.txt
 # Core dependencies for installing other dependencies
 
-pip<25.3
+pip
 setuptools
 wheel


### PR DESCRIPTION
**Title:** fix: Restore edx_proctoring_proctortrack.po generation (AU-2967)

**Description:**

**Summary**
This PR restores the generation of edx_proctoring_proctortrack.po translation file by adding edx-proctoring-proctortrack as a dependency and configuring it for i18n extraction.

**Changes**
requirements/edx/bundled.in
Added edx_proctoring_proctortrack to bundled dependencies

requirements/edx/*.txt
Added edx-proctoring-proctortrack==1.2.1 to base.txt, doc.txt, testing.txt, and development.txt

Updated edx-proctoring via comments to reflect the new reverse dependency

conf/locale/config.yaml
Added edx_proctoring_proctortrack to the third_party list for i18n extraction

Added edx_proctoring_proctortrack.po to generate_merge → django.po for translation merging

**Testing**
Verified make compile-requirements produces no diff (consistent dependencies)

Triggered the Extract translation source files workflow against this branch to confirm edx_proctoring_proctortrack.po is generated successfully

**Ticket**
https://2u-internal.atlassian.net/browse/AU-2967