### PR TITLE
fix: Goal reminder optimization part 4

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -1,8 +1,11 @@
 """
 Command to trigger sending reminder emails for learners to achieve their Course Goals
 """
+import logging
 import string
 import time
+import uuid
+from collections import defaultdict
 from datetime import date, datetime, timedelta
 
 import boto3
@@ -10,19 +13,18 @@ import pytz
 from edx_ace.channel.django_email import DjangoEmailChannel
 from edx_ace.channel.mixins import EmailChannelMixin
 from eventtracking import tracker
-import logging
-import uuid
 
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 from django.db.models import CharField, Count, Exists, F, IntegerField, OuterRef, Q, Subquery, Value
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, NullIf
 from edx_ace import ace, presentation
 from edx_ace.message import Message
 from edx_ace.recipient import Recipient
 from edx_ace.utils.signals import send_ace_message_sent_signal
 from edx_django_utils.cache import RequestCache
+
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import GeneratedCertificate
@@ -43,8 +45,6 @@ log = logging.getLogger(__name__)
 
 MONDAY_WEEKDAY = 0
 SUNDAY_WEEKDAY = 6
-# Number of goals to process per chunk. Keeps memory stable and allows
-# bulk-fetching enrollments once per chunk instead of once per goal.
 CHUNK_SIZE = 2000
 
 
@@ -202,22 +202,6 @@ class Command(BaseCommand):
 
         Helpful notes for the function:
             weekday() returns an int 0-6 with Monday being 0 and Sunday being 6
-
-        Performance notes:
-            - Timezones are pre-filtered at the database level to only fetch goals
-              where the user's local time is between 8 AM and 6 PM.  This is done
-              by annotating each goal with the user's resolved timezone string
-              (UserPreference → LastSeenCoursewareTimezone → 'UTC') and filtering
-              against the set of timezone names that are currently in the 8-18 hour
-              window.  This typically reduces the result set by 60-90%.
-            - Ended-course exclusion is expressed as an inline Exists subquery on
-              CourseOverview, avoiding a separate distinct + count round-trip.
-            - Goals are processed in chunks of CHUNK_SIZE.  For each chunk, active
-              enrollments are bulk-fetched in one query and seeded into
-              RequestCache('get_enrollment') so that all downstream calls to
-              CourseEnrollment.get_enrollment() hit the cache instead of the DB.
-            - Expensive COUNT queries that previously took 3-4 minutes each on the
-              annotated queryset have been removed.  Totals are accumulated in Python.
         """
         today = date.today()
         sunday_date = today + timedelta(days=SUNDAY_WEEKDAY - today.weekday())
@@ -255,7 +239,6 @@ class Command(BaseCommand):
             Value(0),
         )
 
-        # Subquery: resolve the user's explicit timezone preference (UserPreference key='time_zone')
         user_tz_pref_subquery = Subquery(
             UserPreference.objects.filter(
                 user=OuterRef('user'),
@@ -263,8 +246,6 @@ class Command(BaseCommand):
             ).values('value')[:1],
             output_field=CharField(),
         )
-
-        # Subquery: fallback to the user's last-seen courseware timezone
         last_seen_tz_subquery = Subquery(
             LastSeenCoursewareTimezone.objects.filter(
                 user=OuterRef('user'),
@@ -272,19 +253,16 @@ class Command(BaseCommand):
             output_field=CharField(),
         )
 
-        # Compute the set of pytz common timezone names where the local hour is
-        # currently in the active window (8:00 AM inclusive – 6:00 PM exclusive).
-        # This list is computed once and reused for the entire run; it has at most
-        # ~440 entries (len(pytz.common_timezones)) and the computation is O(n) in
-        # Python so it is essentially free.
         now_utc = datetime.now(pytz.utc)
         active_timezones = [
-            tz_name for tz_name in pytz.common_timezones
+            tz_name
+            for tz_name in pytz.common_timezones
             if 8 <= now_utc.astimezone(pytz.timezone(tz_name)).hour < 18
         ]
 
-        # Only include goals where the user needs exactly days_left_in_week more days to hit their goal,
-        # i.e. required_days_left == days_left_in_week, i.e. days_per_week - week_activity_count == days_left_in_week
+        # Only include goals where the user needs exactly days_left_in_week more days to hit their goal.
+        # Keep the unsigned days_per_week field on the non-subtracted side because MySQL raises an
+        # out-of-range error when days_per_week is less than days_left_in_week.
         course_goals = CourseGoal.objects.filter(
             days_per_week__gt=0,
             subscribed_to_reminders=True,
@@ -295,7 +273,7 @@ class Command(BaseCommand):
         ).annotate(
             week_activity_count=week_activity_subquery,
         ).filter(
-            week_activity_count=F('days_per_week') - days_left_in_week,
+            days_per_week=F('week_activity_count') + days_left_in_week,
         ).exclude(
             # Exclude users who already have a downloadable certificate — they've completed the course
             Exists(
@@ -306,9 +284,6 @@ class Command(BaseCommand):
                 )
             )
         ).exclude(
-            # Exclude all courses whose end dates are earlier than Sunday so we don't send an email about hitting
-            # a course goal when it may not even be possible. Expressed as an inline Exists to avoid a separate
-            # distinct-count round-trip that previously cost ~2 minutes of wall-time.
             Exists(
                 CourseOverview.objects.filter(
                     id=OuterRef('course_key'),
@@ -316,31 +291,24 @@ class Command(BaseCommand):
                 )
             )
         ).annotate(
-            # Resolve each user's timezone at the DB level so we can filter to only
-            # goals where the local hour is in the active window, avoiding a per-goal
-            # call to get_user_timezone_or_last_seen_timezone_or_utc() (2 DB queries each).
-            user_timezone_str=Coalesce(user_tz_pref_subquery, last_seen_tz_subquery, Value('UTC')),
+            # NullIf preserves the existing Python fallback behavior for empty preferences.
+            user_timezone_str=Coalesce(
+                NullIf(user_tz_pref_subquery, Value('')),
+                NullIf(last_seen_tz_subquery, Value('')),
+                Value('UTC'),
+            ),
         ).filter(
-            # Include goals whose resolved timezone is currently in the active window OR
-            # whose stored timezone string is not a recognised pytz name (e.g. contains
-            # non-printable characters such as "America/New_York\x00"). Those dirty
-            # strings are excluded by the strict __in filter and would never reach the
-            # sanitization / UnknownTimeZoneError fallback in handle_goal, silently
-            # dropping reminders. Passing them through preserves the pre-optimisation
-            # behaviour: handle_goal strips non-printable chars and falls back to UTC,
-            # then re-checks the hour window.
+            # Unrecognized values must reach handle_goal so it can sanitize them or fall back to UTC.
             Q(user_timezone_str__in=active_timezones)
             | ~Q(user_timezone_str__in=pytz.common_timezones)
-        ).select_related('user').order_by('user')
+        ).select_related('user')
 
         tracker.emit(
             'edx.course.goal.email.session_started',
             {
                 'uuid': session_id,
                 'timestamp': datetime.now(),
-                # goal_count is intentionally absent here: a COUNT(*) on the
-                # fully-annotated queryset previously took 3-4 minutes.  The
-                # accurate total is emitted in session_completed below.
+                'goal_count': None,
             }
         )
         log.info(
@@ -348,32 +316,36 @@ class Command(BaseCommand):
             datetime.now(),
             session_id,
         )
-
         site = Site.objects.get_current()
         sent_count = 0
         filtered_count = 0
 
         for chunk in self._iter_chunks(course_goals, CHUNK_SIZE):
-            # Pre-fetch all enrollments for this chunk in one query and seed
-            # RequestCache so downstream get_enrollment() calls are cache hits.
-            self._prefetch_enrollments_into_cache(chunk)
+            enrollment_map = self._prefetch_enrollments_into_cache(chunk)
 
             for goal in chunk:
-                # emulate a request for waffle's benefit
                 with emulate_http_request(site=site, user=goal.user):
-                    if self.handle_goal(goal, today, sunday_date, monday_date, session_id):
+                    if self.handle_goal(
+                        goal,
+                        enrollment_map.get((goal.user_id, goal.course_key)),
+                        sunday_date,
+                        session_id,
+                    ):
                         sent_count += 1
                     else:
                         filtered_count += 1
 
-            # Clear the enrollment cache after each chunk to prevent memory growth.
             RequestCache('get_enrollment').clear()
 
             total_processed = sent_count + filtered_count
             if total_processed % 10000 == 0:
                 log.info(
                     'Processing course goals: sent %d filtered %d total %d, timestamp: %s, uuid: %s',
-                    sent_count, filtered_count, total_processed, datetime.now(), session_id,
+                    sent_count,
+                    filtered_count,
+                    total_processed,
+                    datetime.now(),
+                    session_id,
                 )
 
         tracker.emit(
@@ -388,94 +360,67 @@ class Command(BaseCommand):
         )
         log.info(
             'Processing course goals complete: sent %d emails, filtered out %d emails, timestamp: %s, uuid: %s',
-            sent_count, filtered_count, datetime.now(), session_id,
+            sent_count,
+            filtered_count,
+            datetime.now(),
+            session_id,
         )
 
     @staticmethod
     def _iter_chunks(queryset, chunk_size):
-        """
-        Yield successive list chunks from a queryset by buffering a server-side iterator.
-
-        We avoid offset-based slicing because the queryset excludes goals that have
-        already been marked email_reminder_sent=True.  As goals are processed and
-        marked within the same run, the live result set shrinks, which would cause
-        fixed offsets to skip rows.  Using queryset.iterator() opens a single
-        server-side cursor that streams rows sequentially, making it immune to
-        those mid-run writes.  The Python-side buffer gives us a concrete list per
-        chunk so we can bulk-fetch enrollments before processing any goal in it.
-        """
-        chunk = []
-        for item in queryset.iterator(chunk_size=chunk_size):
-            chunk.append(item)
-            if len(chunk) >= chunk_size:
-                yield chunk
-                chunk = []
-        if chunk:
+        """Yield stable primary-key chunks without offset pagination."""
+        last_pk = 0
+        while True:
+            chunk = list(queryset.filter(pk__gt=last_pk).order_by('pk')[:chunk_size])
+            if not chunk:
+                return
             yield chunk
+            last_pk = chunk[-1].pk
 
     @staticmethod
     def _prefetch_enrollments_into_cache(goals):
-        """
-        Bulk-fetch active enrollments for a list of goals and populate
-        RequestCache('get_enrollment') so that subsequent calls to
-        CourseEnrollment.get_enrollment(user, course_key, select_related=['course'])
-        are satisfied from cache without hitting the database.
-
-        This eliminates one DB query per goal (previously the dominant cost inside
-        handle_goal) by replacing N individual lookups with a single IN-query.
-        """
+        """Fetch and cache only the enrollment pairs represented by this goal chunk."""
         if not goals:
-            return
+            return {}
 
-        user_ids = list({goal.user.id for goal in goals})
-        course_keys = list({goal.course_key for goal in goals})
+        users_by_course = defaultdict(set)
+        for goal in goals:
+            users_by_course[goal.course_key].add(goal.user_id)
+
+        enrollment_filter = Q()
+        for course_key, user_ids in users_by_course.items():
+            enrollment_filter |= Q(course_id=course_key, user_id__in=user_ids)
 
         enrollments = CourseEnrollment.objects.filter(
-            user_id__in=user_ids,
-            course_id__in=course_keys,
+            enrollment_filter,
             is_active=True,
         ).select_related('course')
+        enrollment_map = {(enrollment.user_id, enrollment.course_id): enrollment for enrollment in enrollments}
 
-        enrollment_map = {(e.user_id, e.course_id): e for e in enrollments}
         request_cache = RequestCache('get_enrollment')
-
         for goal in goals:
-            enrollment = enrollment_map.get((goal.user.id, goal.course_key))
-            # Seed both cache-key variants used by get_enrollment():
-            #   (user_id, course_key)              — called without select_related
-            #   (user_id, course_key, 'course')    — called with select_related=['course']
-            request_cache.set((goal.user.id, goal.course_key), enrollment)
-            request_cache.set((goal.user.id, goal.course_key, 'course'), enrollment)
+            enrollment = enrollment_map.get((goal.user_id, goal.course_key))
+            request_cache.set((goal.user_id, goal.course_key), enrollment)
+            request_cache.set((goal.user_id, goal.course_key, 'course'), enrollment)
+
+        return enrollment_map
 
     @staticmethod
-    def handle_goal(goal, today, sunday_date, _monday_date, session_id):
+    def handle_goal(goal, enrollment, sunday_date, session_id):
         """Sends an email reminder for a single CourseGoal, if it passes all our checks.
 
-        Note: enrollment validity, certificate status, weekly activity count, and
-        timezone window are pre-filtered at the queryset level in _handle_all_goals.
-        This method handles the remaining checks that cannot be efficiently expressed
-        as DB filters (waffle flags, audit access expiration, course expiry).
-
-        The user's timezone string is available as goal.user_timezone_str (annotated
-        by the queryset) so we avoid calling get_user_timezone_or_last_seen_timezone_or_utc()
-        here (which would run 2 additional DB queries per goal).
-
-        The enrollment object is already seeded into RequestCache by
-        _prefetch_enrollments_into_cache(), so the get_enrollment() call below is a
-        cache hit with no DB round-trip.
+        Note: enrollment validity, certificate status, and weekly activity count are pre-filtered
+        at the queryset level in _handle_all_goals. This method handles the remaining checks that
+        cannot be efficiently expressed as DB filters.
         """
-        # Resolve timezone from the annotated field — no DB query needed.
-        # Sanitize to remove any non-printable characters (rare but observed in production).
+        # Check timezone first — cheapest check, no DB query
         user_timezone_str = ''.join(
-            c for c in getattr(goal, 'user_timezone_str', 'UTC') if c in string.printable
+            character for character in getattr(goal, 'user_timezone_str', 'UTC') if character in string.printable
         )
         try:
             user_timezone = pytz.timezone(user_timezone_str)
         except pytz.UnknownTimeZoneError:
             user_timezone = pytz.utc
-
-        # Safety-net timezone check: the queryset already filters on active_timezones,
-        # but the window may have shifted slightly between query build and processing.
         now_in_users_timezone = datetime.now(user_timezone)
         if not 8 <= now_in_users_timezone.hour < 18:
             tracker.emit(
@@ -493,13 +438,15 @@ class Command(BaseCommand):
         if not ENABLE_COURSE_GOALS.is_enabled(goal.course_key):
             return False
 
-        # Fetch enrollment — hits RequestCache seeded by _prefetch_enrollments_into_cache(),
-        # so this is a cache lookup, not a DB query.
-        enrollment = CourseEnrollment.get_enrollment(goal.user, goal.course_key, select_related=['course'])
+        # Fetch enrollment only to check audit access expiration date
         if not enrollment:
             return False
 
-        audit_access_expiration_date = get_user_course_expiration_date(goal.user, enrollment.course_overview)
+        audit_access_expiration_date = get_user_course_expiration_date(
+            goal.user,
+            enrollment.course_overview,
+            enrollment=enrollment,
+        )
         # If an audit user's access expires this week, exclude them from the email since they may not
         # be able to hit their goal anyway
         if audit_access_expiration_date and audit_access_expiration_date.date() <= sunday_date:

--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -16,7 +16,7 @@ import uuid
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
-from django.db.models import CharField, Count, Exists, F, IntegerField, OuterRef, Subquery, Value
+from django.db.models import CharField, Count, Exists, F, IntegerField, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Coalesce
 from edx_ace import ace, presentation
 from edx_ace.message import Message
@@ -321,7 +321,16 @@ class Command(BaseCommand):
             # call to get_user_timezone_or_last_seen_timezone_or_utc() (2 DB queries each).
             user_timezone_str=Coalesce(user_tz_pref_subquery, last_seen_tz_subquery, Value('UTC')),
         ).filter(
-            user_timezone_str__in=active_timezones,
+            # Include goals whose resolved timezone is currently in the active window OR
+            # whose stored timezone string is not a recognised pytz name (e.g. contains
+            # non-printable characters such as "America/New_York\x00"). Those dirty
+            # strings are excluded by the strict __in filter and would never reach the
+            # sanitization / UnknownTimeZoneError fallback in handle_goal, silently
+            # dropping reminders. Passing them through preserves the pre-optimisation
+            # behaviour: handle_goal strips non-printable chars and falls back to UTC,
+            # then re-checks the hour window.
+            Q(user_timezone_str__in=active_timezones)
+            | ~Q(user_timezone_str__in=pytz.common_timezones)
         ).select_related('user').order_by('user')
 
         tracker.emit(
@@ -329,10 +338,9 @@ class Command(BaseCommand):
             {
                 'uuid': session_id,
                 'timestamp': datetime.now(),
-                # goal_count is omitted here; a COUNT(*) on the fully-annotated
-                # queryset previously took 3-4 minutes. The final count is emitted
-                # accurately in session_completed below.
-                'goal_count': None,
+                # goal_count is intentionally absent here: a COUNT(*) on the
+                # fully-annotated queryset previously took 3-4 minutes.  The
+                # accurate total is emitted in session_completed below.
             }
         )
         log.info(
@@ -425,6 +433,7 @@ class Command(BaseCommand):
         enrollments = CourseEnrollment.objects.filter(
             user_id__in=user_ids,
             course_id__in=course_keys,
+            is_active=True,
         ).select_related('course')
 
         enrollment_map = {(e.user_id, e.course_id): e for e in enrollments}
@@ -442,10 +451,10 @@ class Command(BaseCommand):
     def handle_goal(goal, today, sunday_date, _monday_date, session_id):
         """Sends an email reminder for a single CourseGoal, if it passes all our checks.
 
-        Note: enrollment validity, certificate status, weekly activity count, course
-        expiry, and timezone window are pre-filtered at the queryset level in
-        _handle_all_goals. This method handles the remaining checks that cannot be
-        efficiently expressed as DB filters (waffle flags, audit access expiration).
+        Note: enrollment validity, certificate status, weekly activity count, and
+        timezone window are pre-filtered at the queryset level in _handle_all_goals.
+        This method handles the remaining checks that cannot be efficiently expressed
+        as DB filters (waffle flags, audit access expiration, course expiry).
 
         The user's timezone string is available as goal.user_timezone_str (annotated
         by the queryset) so we avoid calling get_user_timezone_or_last_seen_timezone_or_utc()

--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -1,10 +1,12 @@
 """
 Command to trigger sending reminder emails for learners to achieve their Course Goals
 """
+import string
 import time
 from datetime import date, datetime, timedelta
 
 import boto3
+import pytz
 from edx_ace.channel.django_email import DjangoEmailChannel
 from edx_ace.channel.mixins import EmailChannelMixin
 from eventtracking import tracker
@@ -14,21 +16,23 @@ import uuid
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
-from django.db.models import Count, Exists, F, IntegerField, OuterRef, Subquery, Value
+from django.db.models import CharField, Count, Exists, F, IntegerField, OuterRef, Subquery, Value
 from django.db.models.functions import Coalesce
 from edx_ace import ace, presentation
 from edx_ace.message import Message
 from edx_ace.recipient import Recipient
 from edx_ace.utils.signals import send_ace_message_sent_signal
+from edx_django_utils.cache import RequestCache
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import GeneratedCertificate
-from lms.djangoapps.courseware.context_processor import get_user_timezone_or_last_seen_timezone_or_utc
+from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from lms.djangoapps.course_goals.models import CourseGoal, CourseGoalReminderStatus, UserActivity
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.lib.celery.task_utils import emulate_http_request
 from openedx.features.course_duration_limits.access import get_user_course_expiration_date
@@ -39,6 +43,9 @@ log = logging.getLogger(__name__)
 
 MONDAY_WEEKDAY = 0
 SUNDAY_WEEKDAY = 6
+# Number of goals to process per chunk. Keeps memory stable and allows
+# bulk-fetching enrollments once per chunk instead of once per goal.
+CHUNK_SIZE = 2000
 
 
 def send_ace_message(goal, session_id):
@@ -195,6 +202,22 @@ class Command(BaseCommand):
 
         Helpful notes for the function:
             weekday() returns an int 0-6 with Monday being 0 and Sunday being 6
+
+        Performance notes:
+            - Timezones are pre-filtered at the database level to only fetch goals
+              where the user's local time is between 8 AM and 6 PM.  This is done
+              by annotating each goal with the user's resolved timezone string
+              (UserPreference → LastSeenCoursewareTimezone → 'UTC') and filtering
+              against the set of timezone names that are currently in the 8-18 hour
+              window.  This typically reduces the result set by 60-90%.
+            - Ended-course exclusion is expressed as an inline Exists subquery on
+              CourseOverview, avoiding a separate distinct + count round-trip.
+            - Goals are processed in chunks of CHUNK_SIZE.  For each chunk, active
+              enrollments are bulk-fetched in one query and seeded into
+              RequestCache('get_enrollment') so that all downstream calls to
+              CourseEnrollment.get_enrollment() hit the cache instead of the DB.
+            - Expensive COUNT queries that previously took 3-4 minutes each on the
+              annotated queryset have been removed.  Totals are accumulated in Python.
         """
         today = date.today()
         sunday_date = today + timedelta(days=SUNDAY_WEEKDAY - today.weekday())
@@ -232,6 +255,34 @@ class Command(BaseCommand):
             Value(0),
         )
 
+        # Subquery: resolve the user's explicit timezone preference (UserPreference key='time_zone')
+        user_tz_pref_subquery = Subquery(
+            UserPreference.objects.filter(
+                user=OuterRef('user'),
+                key='time_zone',
+            ).values('value')[:1],
+            output_field=CharField(),
+        )
+
+        # Subquery: fallback to the user's last-seen courseware timezone
+        last_seen_tz_subquery = Subquery(
+            LastSeenCoursewareTimezone.objects.filter(
+                user=OuterRef('user'),
+            ).values('last_seen_courseware_timezone')[:1],
+            output_field=CharField(),
+        )
+
+        # Compute the set of pytz common timezone names where the local hour is
+        # currently in the active window (8:00 AM inclusive – 6:00 PM exclusive).
+        # This list is computed once and reused for the entire run; it has at most
+        # ~440 entries (len(pytz.common_timezones)) and the computation is O(n) in
+        # Python so it is essentially free.
+        now_utc = datetime.now(pytz.utc)
+        active_timezones = [
+            tz_name for tz_name in pytz.common_timezones
+            if 8 <= now_utc.astimezone(pytz.timezone(tz_name)).hour < 18
+        ]
+
         # Only include goals where the user needs exactly days_left_in_week more days to hit their goal,
         # i.e. required_days_left == days_left_in_week, i.e. days_per_week - week_activity_count == days_left_in_week
         course_goals = CourseGoal.objects.filter(
@@ -254,79 +305,168 @@ class Command(BaseCommand):
                     status=CertificateStatuses.downloadable,
                 )
             )
-        )
-        all_goal_course_keys = course_goals.values_list('course_key', flat=True).distinct()
-        # Exclude all courses whose end dates are earlier than Sunday so we don't send an email about hitting
-        # a course goal when it may not even be possible.
-        courses_to_exclude = CourseOverview.objects.filter(
-            id__in=all_goal_course_keys, end__date__lte=sunday_date
-        ).values_list('id', flat=True)
-        log.info(
-            'Processing course goals across %s courses excluding %s ended courses',
-            all_goal_course_keys.count(),
-            courses_to_exclude.count(),
-        )
+        ).exclude(
+            # Exclude all courses whose end dates are earlier than Sunday so we don't send an email about hitting
+            # a course goal when it may not even be possible. Expressed as an inline Exists to avoid a separate
+            # distinct-count round-trip that previously cost ~2 minutes of wall-time.
+            Exists(
+                CourseOverview.objects.filter(
+                    id=OuterRef('course_key'),
+                    end__date__lte=sunday_date,
+                )
+            )
+        ).annotate(
+            # Resolve each user's timezone at the DB level so we can filter to only
+            # goals where the local hour is in the active window, avoiding a per-goal
+            # call to get_user_timezone_or_last_seen_timezone_or_utc() (2 DB queries each).
+            user_timezone_str=Coalesce(user_tz_pref_subquery, last_seen_tz_subquery, Value('UTC')),
+        ).filter(
+            user_timezone_str__in=active_timezones,
+        ).select_related('user').order_by('user')
 
-        sent_count = 0
-        filtered_count = 0
-        course_goals = course_goals.exclude(course_key__in=courses_to_exclude).select_related('user').order_by('user')
-        total_goals = course_goals.count()
         tracker.emit(
             'edx.course.goal.email.session_started',
             {
                 'uuid': session_id,
                 'timestamp': datetime.now(),
-                'goal_count': total_goals,
+                # goal_count is omitted here; a COUNT(*) on the fully-annotated
+                # queryset previously took 3-4 minutes. The final count is emitted
+                # accurately in session_completed below.
+                'goal_count': None,
             }
         )
         log.info(
-            'Processing course goals, total goal count %s, timestamp: %s, uuid: %s',
-            total_goals,
+            'Processing course goals started, timestamp: %s, uuid: %s',
             datetime.now(),
             session_id,
         )
+
         site = Site.objects.get_current()
-        for goal in course_goals.iterator(chunk_size=500):
-            # emulate a request for waffle's benefit
-            with emulate_http_request(site=site, user=goal.user):
-                if self.handle_goal(goal, today, sunday_date, monday_date, session_id):
-                    sent_count += 1
-                else:
-                    filtered_count += 1
-            if (sent_count + filtered_count) % 10000 == 0:
-                log.info('Processing course goals: sent {} filtered {} out of {}, timestamp: {}, uuid: {}'.format(
-                    sent_count,
-                    filtered_count,
-                    total_goals,
-                    datetime.now(),
-                    session_id
-                ))
+        sent_count = 0
+        filtered_count = 0
+
+        for chunk in self._iter_chunks(course_goals, CHUNK_SIZE):
+            # Pre-fetch all enrollments for this chunk in one query and seed
+            # RequestCache so downstream get_enrollment() calls are cache hits.
+            self._prefetch_enrollments_into_cache(chunk)
+
+            for goal in chunk:
+                # emulate a request for waffle's benefit
+                with emulate_http_request(site=site, user=goal.user):
+                    if self.handle_goal(goal, today, sunday_date, monday_date, session_id):
+                        sent_count += 1
+                    else:
+                        filtered_count += 1
+
+            # Clear the enrollment cache after each chunk to prevent memory growth.
+            RequestCache('get_enrollment').clear()
+
+            total_processed = sent_count + filtered_count
+            if total_processed % 10000 == 0:
+                log.info(
+                    'Processing course goals: sent %d filtered %d total %d, timestamp: %s, uuid: %s',
+                    sent_count, filtered_count, total_processed, datetime.now(), session_id,
+                )
 
         tracker.emit(
             'edx.course.goal.email.session_completed',
             {
                 'uuid': session_id,
                 'timestamp': datetime.now(),
-                'goal_count': total_goals,
+                'goal_count': sent_count + filtered_count,
                 'emails_sent': sent_count,
                 'emails_filtered': filtered_count,
             }
         )
-        log.info('Processing course goals complete: sent {} emails, '
-                 'filtered out {} emails, timestamp: {}, '
-                 'uuid: {}'.format(sent_count, filtered_count, datetime.now(), session_id)
-                 )
+        log.info(
+            'Processing course goals complete: sent %d emails, filtered out %d emails, timestamp: %s, uuid: %s',
+            sent_count, filtered_count, datetime.now(), session_id,
+        )
+
+    @staticmethod
+    def _iter_chunks(queryset, chunk_size):
+        """
+        Yield successive list chunks from a queryset by buffering a server-side iterator.
+
+        We avoid offset-based slicing because the queryset excludes goals that have
+        already been marked email_reminder_sent=True.  As goals are processed and
+        marked within the same run, the live result set shrinks, which would cause
+        fixed offsets to skip rows.  Using queryset.iterator() opens a single
+        server-side cursor that streams rows sequentially, making it immune to
+        those mid-run writes.  The Python-side buffer gives us a concrete list per
+        chunk so we can bulk-fetch enrollments before processing any goal in it.
+        """
+        chunk = []
+        for item in queryset.iterator(chunk_size=chunk_size):
+            chunk.append(item)
+            if len(chunk) >= chunk_size:
+                yield chunk
+                chunk = []
+        if chunk:
+            yield chunk
+
+    @staticmethod
+    def _prefetch_enrollments_into_cache(goals):
+        """
+        Bulk-fetch active enrollments for a list of goals and populate
+        RequestCache('get_enrollment') so that subsequent calls to
+        CourseEnrollment.get_enrollment(user, course_key, select_related=['course'])
+        are satisfied from cache without hitting the database.
+
+        This eliminates one DB query per goal (previously the dominant cost inside
+        handle_goal) by replacing N individual lookups with a single IN-query.
+        """
+        if not goals:
+            return
+
+        user_ids = list({goal.user.id for goal in goals})
+        course_keys = list({goal.course_key for goal in goals})
+
+        enrollments = CourseEnrollment.objects.filter(
+            user_id__in=user_ids,
+            course_id__in=course_keys,
+        ).select_related('course')
+
+        enrollment_map = {(e.user_id, e.course_id): e for e in enrollments}
+        request_cache = RequestCache('get_enrollment')
+
+        for goal in goals:
+            enrollment = enrollment_map.get((goal.user.id, goal.course_key))
+            # Seed both cache-key variants used by get_enrollment():
+            #   (user_id, course_key)              — called without select_related
+            #   (user_id, course_key, 'course')    — called with select_related=['course']
+            request_cache.set((goal.user.id, goal.course_key), enrollment)
+            request_cache.set((goal.user.id, goal.course_key, 'course'), enrollment)
 
     @staticmethod
     def handle_goal(goal, today, sunday_date, _monday_date, session_id):
         """Sends an email reminder for a single CourseGoal, if it passes all our checks.
 
-        Note: enrollment validity, certificate status, and weekly activity count are pre-filtered
-        at the queryset level in _handle_all_goals. This method handles the remaining checks that
-        cannot be efficiently expressed as DB filters.
+        Note: enrollment validity, certificate status, weekly activity count, course
+        expiry, and timezone window are pre-filtered at the queryset level in
+        _handle_all_goals. This method handles the remaining checks that cannot be
+        efficiently expressed as DB filters (waffle flags, audit access expiration).
+
+        The user's timezone string is available as goal.user_timezone_str (annotated
+        by the queryset) so we avoid calling get_user_timezone_or_last_seen_timezone_or_utc()
+        here (which would run 2 additional DB queries per goal).
+
+        The enrollment object is already seeded into RequestCache by
+        _prefetch_enrollments_into_cache(), so the get_enrollment() call below is a
+        cache hit with no DB round-trip.
         """
-        # Check timezone first — cheapest check, no DB query
-        user_timezone = get_user_timezone_or_last_seen_timezone_or_utc(goal.user)
+        # Resolve timezone from the annotated field — no DB query needed.
+        # Sanitize to remove any non-printable characters (rare but observed in production).
+        user_timezone_str = ''.join(
+            c for c in getattr(goal, 'user_timezone_str', 'UTC') if c in string.printable
+        )
+        try:
+            user_timezone = pytz.timezone(user_timezone_str)
+        except pytz.UnknownTimeZoneError:
+            user_timezone = pytz.utc
+
+        # Safety-net timezone check: the queryset already filters on active_timezones,
+        # but the window may have shifted slightly between query build and processing.
         now_in_users_timezone = datetime.now(user_timezone)
         if not 8 <= now_in_users_timezone.hour < 18:
             tracker.emit(
@@ -344,7 +484,8 @@ class Command(BaseCommand):
         if not ENABLE_COURSE_GOALS.is_enabled(goal.course_key):
             return False
 
-        # Fetch enrollment only to check audit access expiration date
+        # Fetch enrollment — hits RequestCache seeded by _prefetch_enrollments_into_cache(),
+        # so this is a cache lookup, not a DB query.
         enrollment = CourseEnrollment.get_enrollment(goal.user, goal.course_key, select_related=['course'])
         if not enrollment:
             return False

--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -197,12 +197,7 @@ class Command(BaseCommand):
             raise
 
     def _handle_all_goals(self):
-        """
-        Handle goal emails across all courses
-
-        Helpful notes for the function:
-            weekday() returns an int 0-6 with Monday being 0 and Sunday being 6
-        """
+        """Handle goal emails across all courses."""
         today = date.today()
         sunday_date = today + timedelta(days=SUNDAY_WEEKDAY - today.weekday())
         monday_date = today - timedelta(days=today.weekday())
@@ -215,8 +210,30 @@ class Command(BaseCommand):
             log.info('Cleared all reminder statuses')
             return
 
-        # The weekdays are 0 indexed, but we want this to be 1 to match required_days_left.
-        # Essentially, if today is Sunday, days_left_in_week should be 1 since they have Sunday to hit their goal.
+        course_goals = self._get_course_goals(today, sunday_date, monday_date)
+        sent_count, filtered_count = self._process_course_goals(course_goals, sunday_date, session_id)
+
+        tracker.emit(
+            'edx.course.goal.email.session_completed',
+            {
+                'uuid': session_id,
+                'timestamp': datetime.now(),
+                'goal_count': sent_count + filtered_count,
+                'emails_sent': sent_count,
+                'emails_filtered': filtered_count,
+            }
+        )
+        log.info(
+            'Processing course goals complete: sent %d emails, filtered out %d emails, timestamp: %s, uuid: %s',
+            sent_count,
+            filtered_count,
+            datetime.now(),
+            session_id,
+        )
+
+    @staticmethod
+    def _get_course_goals(today, sunday_date, monday_date):
+        """Build the queryset of goals eligible for reminders during this run."""
         days_left_in_week = SUNDAY_WEEKDAY - today.weekday() + 1
 
         active_enrollment_exists = CourseEnrollment.objects.filter(
@@ -303,12 +320,15 @@ class Command(BaseCommand):
             | ~Q(user_timezone_str__in=pytz.common_timezones)
         ).select_related('user')
 
+        return course_goals
+
+    def _process_course_goals(self, course_goals, sunday_date, session_id):
+        """Send reminders for an eligible queryset and return sent and filtered counts."""
         tracker.emit(
             'edx.course.goal.email.session_started',
             {
                 'uuid': session_id,
                 'timestamp': datetime.now(),
-                'goal_count': None,
             }
         )
         log.info(
@@ -348,23 +368,7 @@ class Command(BaseCommand):
                     session_id,
                 )
 
-        tracker.emit(
-            'edx.course.goal.email.session_completed',
-            {
-                'uuid': session_id,
-                'timestamp': datetime.now(),
-                'goal_count': sent_count + filtered_count,
-                'emails_sent': sent_count,
-                'emails_filtered': filtered_count,
-            }
-        )
-        log.info(
-            'Processing course goals complete: sent %d emails, filtered out %d emails, timestamp: %s, uuid: %s',
-            sent_count,
-            filtered_count,
-            datetime.now(),
-            session_id,
-        )
+        return sent_count, filtered_count
 
     @staticmethod
     def _iter_chunks(queryset, chunk_size):

--- a/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
@@ -25,6 +25,7 @@ from lms.djangoapps.course_goals.tests.factories import (
 )
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
+from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.core.lib.celery.task_utils import emulate_http_request
@@ -234,6 +235,29 @@ class TestGoalReminderEmailCommand(TestCase):
         goal.user.save()
         send_ace_message(goal, str(uuid.uuid4()))
         assert mock_ace.called is value
+
+
+    def test_dirty_timezone_string_still_receives_email(self):
+        """
+        Regression test: a LastSeenCoursewareTimezone value containing non-printable
+        characters (e.g. "America/New_York\x00") must NOT be silently excluded by the
+        DB-level timezone pre-filter.  The goal should still be fetched, reach
+        handle_goal, have its timezone string sanitized there, fall back to UTC, and
+        then be filtered by the in-process hour check.
+
+        We freeze time so that UTC is within the 08:00-18:00 window, which means after
+        sanitization the goal passes the hour check and an email is sent.
+        """
+        goal = self.make_valid_goal()
+        # Write a dirty timezone string directly to the DB (non-printable char appended).
+        LastSeenCoursewareTimezone.objects.update_or_create(
+            user=goal.user,
+            defaults={'last_seen_courseware_timezone': 'America/New_York\x00'},
+        )
+        # 2021-03-02 10:00 UTC — UTC hour is 10, inside the 08-18 window, so after
+        # sanitization (dirty string → pytz.UnknownTimeZoneError → pytz.utc) the goal
+        # still passes the hour check and an email should be sent.
+        self.call_command(expect_sent=True, time='2021-03-02 10:00:00')
 
 
 class TestGoalReminderEmailSES(TestCase):

--- a/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
@@ -18,7 +18,11 @@ from waffle import get_waffle_flag_model  # pylint: disable=invalid-django-waffl
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from lms.djangoapps.course_goals.management.commands.goal_reminder_email import send_email_using_ses, send_ace_message
+from lms.djangoapps.course_goals.management.commands.goal_reminder_email import (
+    Command,
+    send_ace_message,
+    send_email_using_ses,
+)
 from lms.djangoapps.course_goals.models import CourseGoalReminderStatus
 from lms.djangoapps.course_goals.tests.factories import (
     CourseGoalFactory, CourseGoalReminderStatusFactory, UserActivityFactory,
@@ -27,6 +31,7 @@ from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
+from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.core.lib.celery.task_utils import emulate_http_request
 from openedx.features.course_experience import ENABLE_COURSE_GOALS, ENABLE_SES_FOR_GOALREMINDER
@@ -183,6 +188,11 @@ class TestGoalReminderEmailCommand(TestCase):
         self.make_valid_goal(days_per_week=0)
         self.call_command(expect_sent=False)
 
+    def test_low_goal_does_not_underflow(self):
+        """A low unsigned days_per_week value must not be subtracted from in MySQL."""
+        self.make_valid_goal(days_per_week=1)
+        self.call_command(day=TUESDAY, expect_sent=False)
+
     @ddt.data(
         datetime(2021, 2, 1, tzinfo=UTC),  # very over and done with
         datetime(2021, 3, 7, tzinfo=UTC),  # ending this Sunday
@@ -236,28 +246,58 @@ class TestGoalReminderEmailCommand(TestCase):
         send_ace_message(goal, str(uuid.uuid4()))
         assert mock_ace.called is value
 
-
     def test_dirty_timezone_string_still_receives_email(self):
-        """
-        Regression test: a LastSeenCoursewareTimezone value containing non-printable
-        characters (e.g. "America/New_York\x00") must NOT be silently excluded by the
-        DB-level timezone pre-filter.  The goal should still be fetched, reach
-        handle_goal, have its timezone string sanitized there, fall back to UTC, and
-        then be filtered by the in-process hour check.
-
-        We freeze time so that UTC is within the 08:00-18:00 window, which means after
-        sanitization the goal passes the hour check and an email is sent.
-        """
         goal = self.make_valid_goal()
-        # Write a dirty timezone string directly to the DB (non-printable char appended).
         LastSeenCoursewareTimezone.objects.update_or_create(
             user=goal.user,
             defaults={'last_seen_courseware_timezone': 'America/New_York\x00'},
         )
-        # 2021-03-02 10:00 UTC — UTC hour is 10, inside the 08-18 window, so after
-        # sanitization (dirty string → pytz.UnknownTimeZoneError → pytz.utc) the goal
-        # still passes the hour check and an email should be sent.
+
+        # The dirty value sanitizes to America/New_York, where 15:00 UTC is inside the send window.
+        self.call_command(expect_sent=True, time='2021-03-02 15:00:00')
+
+    def test_invalid_timezone_falls_back_to_utc(self):
+        goal = self.make_valid_goal()
+        LastSeenCoursewareTimezone.objects.update_or_create(
+            user=goal.user,
+            defaults={'last_seen_courseware_timezone': 'Unknown/Timezone'},
+        )
+
         self.call_command(expect_sent=True, time='2021-03-02 10:00:00')
+
+    def test_empty_timezone_preference_uses_last_seen_timezone(self):
+        goal = self.make_valid_goal()
+        UserPreference.objects.create(user=goal.user, key='time_zone', value='')
+        LastSeenCoursewareTimezone.objects.update_or_create(
+            user=goal.user,
+            defaults={'last_seen_courseware_timezone': 'Asia/Tokyo'},
+        )
+
+        # At 00:00 UTC, UTC is outside the send window while Tokyo is at 09:00.
+        self.call_command(expect_sent=True, time='2021-03-02 00:00:00')
+
+    @mock.patch(
+        'lms.djangoapps.course_goals.management.commands.goal_reminder_email.CHUNK_SIZE',
+        1,
+    )
+    def test_processes_all_keyset_chunks(self):
+        self.make_valid_goal()
+        self.make_valid_goal()
+
+        self.call_command(expect_sent=True, expect_send_count=2)
+
+    def test_enrollment_prefetch_excludes_unrelated_user_course_pairs(self):
+        first_goal = self.make_valid_goal()
+        second_goal = self.make_valid_goal()
+        unrelated_enrollment = CourseEnrollmentFactory(
+            user=first_goal.user,
+            course_id=second_goal.course_key,
+        )
+
+        enrollment_map = Command._prefetch_enrollments_into_cache([first_goal, second_goal])
+
+        assert len(enrollment_map) == 2
+        assert (unrelated_enrollment.user_id, unrelated_enrollment.course_id) not in enrollment_map
 
 
 class TestGoalReminderEmailSES(TestCase):

--- a/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
@@ -286,6 +286,16 @@ class TestGoalReminderEmailCommand(TestCase):
 
         self.call_command(expect_sent=True, expect_send_count=2)
 
+    @mock.patch('lms.djangoapps.course_goals.management.commands.goal_reminder_email.tracker.emit')
+    def test_session_events_report_count_only_after_processing(self, mock_emit):
+        self.make_valid_goal()
+
+        self.call_command(expect_sent=True)
+
+        event_payloads = {call.args[0]: call.args[1] for call in mock_emit.call_args_list}
+        assert 'goal_count' not in event_payloads['edx.course.goal.email.session_started']
+        assert event_payloads['edx.course.goal.email.session_completed']['goal_count'] == 1
+
     def test_enrollment_prefetch_excludes_unrelated_user_course_pairs(self):
         first_goal = self.make_valid_goal()
         second_goal = self.make_valid_goal()
@@ -294,7 +304,9 @@ class TestGoalReminderEmailCommand(TestCase):
             course_id=second_goal.course_key,
         )
 
-        enrollment_map = Command._prefetch_enrollments_into_cache([first_goal, second_goal])
+        enrollment_map = Command._prefetch_enrollments_into_cache(  # pylint: disable=protected-access
+            [first_goal, second_goal]
+        )
 
         assert len(enrollment_map) == 2
         assert (unrelated_enrollment.user_id, unrelated_enrollment.course_id) not in enrollment_map


### PR DESCRIPTION
## Description

This PR optimizes the `goal_reminder_email` management command by reducing unnecessary per-goal processing and database work during goal reminder email runs. It moves more eligibility filtering into the queryset, including weekly activity matching, completed-course exclusion, ended-course exclusion, and timezone-based filtering. It also processes goals in chunks and prefetches active enrollments into `RequestCache` so `handle_goal` does not repeatedly perform enrollment lookups for each goal.

## Root Cause

The existing goal reminder job was doing too much work at runtime for a large goal set. Some filtering was happening after records were already selected, enrollments were looked up per goal, and the command also relied on expensive count-style operations/logging during processing. This made the `goal_reminder_email` command slower and more database-heavy than necessary, especially for large weekly reminder runs. 

## Ticket

COSMO2-937 — Goal reminder optimization part 4.