### PR TITLE
feat: decouple enterprise from course start-date validation

### DIFF
--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -1,7 +1,7 @@
 """
 This file contains all the classes used by has_access for error handling
 """
-
+from datetime import datetime
 
 from django.utils.translation import gettext as _
 
@@ -124,12 +124,23 @@ class StartDateError(AccessError):
     Access denied because the course has not started yet and the user
     is not staff
     """
-    def __init__(self, start_date, display_error_to_user=True):
+    def __init__(
+        self,
+        start_date: datetime,
+        display_error_to_user=True,
+        error_code_override: str | None = None,
+        developer_message_override: str | None = None,
+        user_message_override: str | None = None,
+    ):
         """
         Arguments:
+            start_date: The future start date of the course, used for messaging.
             display_error_to_user: If True, display this error to users in the UI.
+            error_code_override: Optional override error_code.
+            developer_message_override: Optional override developer_message.
+            user_message_override: Optional override user_message.
         """
-        error_code = "course_not_started"
+        error_code = error_code_override or "course_not_started"
         if start_date == DEFAULT_START_DATE:
             developer_message = "Course has not started"
             user_message = _("Course has not started")
@@ -137,33 +148,11 @@ class StartDateError(AccessError):
             developer_message = f"Course does not start until {start_date}"
             user_message = _("Course does not start until {}"  # lint-amnesty, pylint: disable=translation-of-non-string
                              .format(f"{start_date:%B %d, %Y}"))
-        super().__init__(
-            error_code,
-            developer_message,
-            user_message if display_error_to_user else None
-        )
 
+        # Use override message if available.
+        developer_message = developer_message_override or developer_message
+        user_message = user_message_override or user_message
 
-class StartDateEnterpriseLearnerError(AccessError):
-    """
-    Access denied because the course has not started yet and the user is not staff.  Use this error when this user is
-    also an enterprise learner and enrolled in the requested course.
-    """
-    def __init__(self, start_date, display_error_to_user=True):
-        """
-        Arguments:
-            display_error_to_user: If True, display this error to users in the UI.
-        """
-        error_code = "course_not_started_enterprise_learner"
-        if start_date == DEFAULT_START_DATE:
-            developer_message = "Course has not started, and the learner is enrolled via an enterprise subsidy."
-            user_message = _("Course has not started")
-        else:
-            developer_message = (
-                f"Course does not start until {start_date}, and the learner is enrolled via an enterprise subsidy."
-            )
-            user_message = _("Course does not start until {}"  # lint-amnesty, pylint: disable=translation-of-non-string
-                             .format(f"{start_date:%B %d, %Y}"))
         super().__init__(
             error_code,
             developer_message,

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -9,6 +9,7 @@ from logging import getLogger
 from crum import get_current_request
 from django.conf import settings
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
+from openedx_filters.learning.filters import CourseStartDateValidationFailed
 from pytz import UTC
 
 from common.djangoapps.student.models import CourseEnrollment
@@ -19,7 +20,6 @@ from lms.djangoapps.courseware.access_response import (
     DataSharingConsentRequiredAccessError,
     EnrollmentRequiredAccessError,
     IncorrectActiveEnterpriseAccessError,
-    StartDateEnterpriseLearnerError,
     StartDateError,
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
@@ -66,60 +66,6 @@ def adjust_start_date(user, days_early_for_beta, start, course_key):
     return start
 
 
-def enterprise_learner_enrolled(request, user, course_key):
-    """
-    Determine if the learner should be redirected to the enterprise learner portal by checking their enterprise
-    memberships/enrollments.  If all of the following are true, then we are safe to redirect the learner:
-
-    * The learner is linked to an enterprise customer,
-    * The enterprise customer has subsidized the learner's enrollment in the requested course,
-    * The enterprise customer has the learner portal enabled.
-
-    NOTE: This function MUST be called from a view, or it will throw an exception.
-
-    Args:
-        request (django.http.HttpRequest): The current request being handled.  Must not be None.
-        user (User): The requesting enter, potentially an enterprise learner.
-        course_key (str): The requested course to check for enrollment.
-
-    Returns:
-        bool: True if the learner is enrolled via a linked enterprise customer and can safely be redirected to the
-        enterprise learner dashboard.
-    """
-    from openedx.features.enterprise_support.api import enterprise_customer_from_session_or_learner_data
-
-    if not user.is_authenticated:
-        return False
-
-    # enterprise_customer_data is either None (if learner is not linked to any customer) or a serialized
-    # EnterpriseCustomer representing the learner's active linked customer.
-    enterprise_customer_data = enterprise_customer_from_session_or_learner_data(request)
-    learner_portal_enabled = enterprise_customer_data and enterprise_customer_data["enable_learner_portal"]
-    if not learner_portal_enabled:
-        return False
-
-    # Additionally make sure the enterprise learner is actually enrolled in the requested course, subsidized
-    # via the discovered customer.
-    enterprise_enrollments = EnterpriseCourseEnrollment.objects.filter(
-        course_id=course_key,
-        enterprise_customer_user__user_id=user.id,
-        enterprise_customer_user__enterprise_customer__uuid=enterprise_customer_data["uuid"],
-    )
-    enterprise_enrollment_exists = enterprise_enrollments.exists()
-    log.info(
-        (
-            "[enterprise_learner_enrolled] Checking for an enterprise enrollment for "
-            "lms_user_id=%s in course_key=%s via enterprise_customer_uuid=%s. "
-            "Exists: %s"
-        ),
-        user.id,
-        course_key,
-        enterprise_customer_data["uuid"],
-        enterprise_enrollment_exists,
-    )
-    return enterprise_enrollment_exists
-
-
 def check_start_date(user, days_early_for_beta, start, course_key, display_error_to_user=True, now=None):
     """
     Verifies whether the given user is allowed access given the
@@ -148,11 +94,20 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
         if should_grant_access:
             return ACCESS_GRANTED
 
-        # Before returning a StartDateError, determine if the learner should be redirected to the enterprise learner
-        # portal by returning StartDateEnterpriseLearnerError instead.
-        request = get_current_request()
-        if request and enterprise_learner_enrolled(request, user, course_key):
-            return StartDateEnterpriseLearnerError(start, display_error_to_user=display_error_to_user)
+        # Before returning a StartDateError, give plugins a chance to substitute a more specific access-error payload.
+        try:
+            CourseStartDateValidationFailed.run_filter(
+                course_key=course_key,
+                start_date=start,
+            )
+        except CourseStartDateValidationFailed.OverrideStartDateError as exc:
+            return StartDateError(
+                start_date=start,
+                display_error_to_user=display_error_to_user,
+                error_code_override=exc.error_code,
+                developer_message_override=exc.developer_message,
+                user_message_override=exc.user_message,
+            )
 
         return StartDateError(start, display_error_to_user=display_error_to_user)
 

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -59,14 +59,6 @@ from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: di
 )
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import MINIMUM_UNUSED_PARTITION_ID, Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
-from openedx.features.enterprise_support.api import add_enterprise_customer_to_session
-from enterprise.api.v1.serializers import EnterpriseCustomerSerializer
-from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerUserFactory,
-    EnterpriseCustomerFactory
-)
-from crum import set_current_request
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES
 
@@ -817,7 +809,7 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
     )
     @ddt.unpack
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    def test_course_catalog_access_num_queries_no_enterprise(self, user_attr_name, action, course_attr_name):
+    def test_course_catalog_access_num_queries(self, user_attr_name, action, course_attr_name):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime.datetime(2018, 1, 1))
 
         course = getattr(self, course_attr_name)
@@ -856,71 +848,3 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
         course_overview = CourseOverview.get_from_id(course.id)
         with self.assertNumQueries(num_queries, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
             bool(access.has_access(user, action, course_overview, course_key=course.id))
-
-    @ddt.data(
-        *itertools.product(
-            ['user_normal', 'user_staff', 'user_anonymous'],
-            ['course_started', 'course_not_started'],
-        )
-    )
-    @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False, 'ENABLE_ENTERPRISE_INTEGRATION': True})
-    def test_course_catalog_access_num_queries_enterprise(self, user_attr_name, course_attr_name):
-        """
-        Similar to test_course_catalog_access_num_queries_no_enterprise, except enable enterprise features and make the
-        basic enrollment look like an enterprise-subsidized enrollment, setting up one of each:
-
-        * EnterpriseCustomer
-        * EnterpriseCustomerUser
-        * EnterpriseCourseEnrollment
-        * A mock request session to pre-cache the enterprise customer data.
-        """
-        ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime.datetime(2018, 1, 1))
-
-        course = getattr(self, course_attr_name)
-
-        request = RequestFactory().get('/')
-        request.session = {}
-
-        # get a fresh user object that won't have any cached role information
-        if user_attr_name == 'user_anonymous':
-            user = AnonymousUserFactory()
-            request.user = user
-        else:
-            user = getattr(self, user_attr_name)
-            user = User.objects.get(id=user.id)
-            request.user = user
-            course_enrollment = CourseEnrollmentFactory(user=user, course_id=course.id)
-            enterprise_customer = EnterpriseCustomerFactory(enable_learner_portal=True)
-            add_enterprise_customer_to_session(request, EnterpriseCustomerSerializer(enterprise_customer).data)
-            enterprise_customer_user = EnterpriseCustomerUserFactory(
-                user_id=user.id,
-                enterprise_customer=enterprise_customer,
-            )
-            EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
-        set_current_request(request)
-
-        if user_attr_name == 'user_staff':
-            if course_attr_name == 'course_started':
-                # read: CourseAccessRole + django_comment_client.Role
-                num_queries = 2
-            else:
-                # read: CourseAccessRole + EnterpriseCourseEnrollment
-                num_queries = 2
-        elif user_attr_name == 'user_normal':
-            if course_attr_name == 'course_started':
-                # read: CourseAccessRole + django_comment_client.Role + FBEEnrollmentExclusion + CourseMode
-                num_queries = 4
-            else:
-                # read: CourseAccessRole + CourseEnrollmentAllowed + EnterpriseCourseEnrollment
-                num_queries = 3
-        elif user_attr_name == 'user_anonymous':
-            if course_attr_name == 'course_started':
-                # read: CourseMode
-                num_queries = 1
-            else:
-                num_queries = 0
-
-        course_overview = CourseOverview.get_from_id(course.id)
-        with self.assertNumQueries(num_queries, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
-            bool(access.has_access(user, 'see_exists', course_overview, course_key=course.id))

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -26,7 +26,7 @@ from edx_django_utils.cache.utils import RequestCache
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from freezegun import freeze_time
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from openedx_filters.learning.filters import CoursewareViewStarted
+from openedx_filters.learning.filters import CourseStartDateValidationFailed, CoursewareViewStarted
 from pytz import UTC
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
 from rest_framework import status
@@ -107,13 +107,6 @@ from openedx.features.course_experience.url_helpers import (
     get_learning_mfe_home_url,
     make_learning_mfe_courseware_url
 )
-from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerUserFactory,
-    EnterpriseCustomerFactory
-)
-from openedx.features.enterprise_support.api import add_enterprise_customer_to_session
-from enterprise.api.v1.serializers import EnterpriseCustomerSerializer
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES
 
@@ -2645,27 +2638,21 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
     @ddt.data(
         {
             'start_date_modifier': 1,  # course starts in future
-            'setup_enterprise_enrollment': False,
+            'filter_raises_override': False,
             'expected_has_access': False,
             'expected_error_code': 'course_not_started',
         },
         {
             'start_date_modifier': -1,  # course already started
-            'setup_enterprise_enrollment': False,
+            'filter_raises_override': False,
             'expected_has_access': True,
             'expected_error_code': None,
         },
         {
-            'start_date_modifier': 1,  # course starts in future
-            'setup_enterprise_enrollment': True,
+            'start_date_modifier': 1,  # course starts in future, filter overrides error
+            'filter_raises_override': True,
             'expected_has_access': False,
             'expected_error_code': 'course_not_started_enterprise_learner',
-        },
-        {
-            'start_date_modifier': -1,  # course already started
-            'setup_enterprise_enrollment': True,
-            'expected_has_access': True,
-            'expected_error_code': None,
         },
     )
     @ddt.unpack
@@ -2673,38 +2660,33 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
     def test_is_course_open_for_learner(
         self,
         start_date_modifier,
-        setup_enterprise_enrollment,
+        filter_raises_override,
         expected_has_access,
         expected_error_code,
     ):
-        """
-        Test is_course_open_for_learner().
-
-        When setup_enterprise_enrollment == True, make an enterprise-subsidized enrollment, setting up one of each:
-        * CourseEnrollment
-        * EnterpriseCustomer
-        * EnterpriseCustomerUser
-        * EnterpriseCourseEnrollment
-        * A mock request session to pre-cache the enterprise customer data.
-        """
+        """Test is_course_open_for_learner()."""
         staff_user = AdminFactory()
         start_date = datetime.now(UTC) + timedelta(days=start_date_modifier)
         course = CourseFactory.create(start=start_date)
         request = RequestFactory().get('/')
         request.user = staff_user
         request.session = {}
-        if setup_enterprise_enrollment:
-            course_enrollment = CourseEnrollmentFactory(mode=CourseMode.VERIFIED, user=staff_user, course_id=course.id)
-            enterprise_customer = EnterpriseCustomerFactory(enable_learner_portal=True)
-            add_enterprise_customer_to_session(request, EnterpriseCustomerSerializer(enterprise_customer).data)
-            enterprise_customer_user = EnterpriseCustomerUserFactory(
-                user_id=staff_user.id,
-                enterprise_customer=enterprise_customer,
-            )
-            EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
         set_current_request(request)
 
-        access_response = check_course_open_for_learner(staff_user, course)
+        if filter_raises_override:
+            # Mock the filter to simulate a plugin substituting the start-date error payload.
+            with patch(
+                'openedx_filters.learning.filters.CourseStartDateValidationFailed.run_filter'
+            ) as mock_filter:
+                mock_filter.side_effect = CourseStartDateValidationFailed.OverrideStartDateError(
+                    message='message',
+                    error_code='course_not_started_enterprise_learner',
+                    developer_message='developer message',
+                    user_message='user message',
+                )
+                access_response = check_course_open_for_learner(staff_user, course)
+        else:
+            access_response = check_course_open_for_learner(staff_user, course)
         assert bool(access_response) == expected_has_access
         assert access_response.error_code == expected_error_code
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -42,7 +42,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==8.1.0
+edx-enterprise==8.1.1
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -473,7 +473,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.1.0
+edx-enterprise==8.1.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.1.0
+edx-enterprise==8.1.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -557,7 +557,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.1.0
+edx-enterprise==8.1.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -578,7 +578,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.1.0
+edx-enterprise==8.1.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Instead of enterprise-specific logic throwing an enterprise-specific start date validation error, CourseStartDateValidationFailed filter can now be used by plugins to throw a custom start date error.

ENT-11544

---

blocked by:
* https://github.com/openedx/openedx-filters/pull/336
* https://github.com/openedx/edx-enterprise/pull/2548
* https://github.com/edx/edx-platform/pull/338

blocks:
* https://github.com/edx/edx-platform/pull/340
* https://github.com/openedx/openedx-platform/pull/38102

---

## Integration Testing

I ran `scripts/provision-integration-test-ENT-11544.sh` then manually tested the following scenarios in devstack:

1. Enterprise learner has a subsidized enrollment in a future course:
   * Test: Login as `enterprise_learner_test-enterprise@example.com` then try to load http://localhost:2010/course/course-v1:edX+FutureX+2027
   * Expected: get redirected to enterprise learner dashboard.
2. Enterprise learner has a subsidized enrollment in an unscheduled course:
   * Test: Login as `enterprise_learner_test-enterprise@example.com` then try to load http://localhost:2010/course/course-v1:edX+UnschedX+TBD
   * Expected: get redirected to enterprise learner dashboard.
3. Enterprise learner has a NON-subsidized enrollment in a future course:
   * Test: Login as `test-enterprise_learner_2@example.com` then try to load http://localhost:2010/course/course-v1:edX+FutureX+2027
   * Expected: get redirected to LMS learner dashboard.
4. NON-enterprise learner has a NON-subsidized enrolled in a future course:
   * Test: Login as `audit@example.com` then try to load http://localhost:2010/course/course-v1:edX+FutureX+2027
   * Expected: get redirected to LMS learner dashboard.
audit@example.com