### PR TITLE
feat: decouple enterprise from course access checks

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -8,6 +8,7 @@ import ddt
 from django.db import transaction
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
+from openedx_filters.learning.filters import CoursewareAccessChecksRequested
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
@@ -25,10 +26,6 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION
 )
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
-from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerUserFactory
-)
 
 
 @ddt.ddt
@@ -125,7 +122,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'enroll_user': True,
             'instructor_role': False,
             'masquerade_role': None,
-            'dsc_required': False,
+            'filter_denies_access': False,
             'expect_course_access': True,
             'error_code': None,
         },
@@ -134,7 +131,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'enroll_user': False,
             'instructor_role': False,
             'masquerade_role': None,
-            'dsc_required': False,
+            'filter_denies_access': False,
             'expect_course_access': False,
             'error_code': 'enrollment_required'
         },
@@ -143,7 +140,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'enroll_user': False,
             'instructor_role': True,
             'masquerade_role': None,
-            'dsc_required': False,
+            'filter_denies_access': False,
             'expect_course_access': True,
             'error_code': None
         },
@@ -152,32 +149,32 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'enroll_user': False,
             'instructor_role': True,
             'masquerade_role': 'student',
-            'dsc_required': False,
+            'filter_denies_access': False,
             'expect_course_access': True,
             'error_code': None
         },
         {
-            # Data sharing Consent required learners should Not have access.
+            # Learners denied by an access-checks pipeline step should NOT have access.
             'enroll_user': True,
             'instructor_role': False,
             'masquerade_role': None,
-            'dsc_required': True,
+            'filter_denies_access': True,
             'expect_course_access': False,
-            'error_code': 'data_sharing_access_required'
+            'error_code': 'access_denied_by_filter'
         },
         {
-            # Data sharing Consent required staff should Not have access.
+            # Staff denied by an access-checks pipeline step should NOT have access.
             'enroll_user': True,
             'instructor_role': True,
             'masquerade_role': None,
-            'dsc_required': True,
+            'filter_denies_access': True,
             'expect_course_access': False,
-            'error_code': 'data_sharing_access_required'
+            'error_code': 'access_denied_by_filter'
         }
     )
     @ddt.unpack
     def test_course_access(
-        self, enroll_user, instructor_role, masquerade_role, dsc_required, expect_course_access, error_code
+        self, enroll_user, instructor_role, masquerade_role, filter_denies_access, expect_course_access, error_code
     ):
         """
         Test that course_access is calculated correctly based on
@@ -190,50 +187,22 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         if masquerade_role:
             self.update_masquerade(role=masquerade_role)
 
-        consent_url = 'dump/consent/url' if dsc_required else None
-        with patch('openedx.features.enterprise_support.api.get_enterprise_consent_url', return_value=consent_url):
+        if filter_denies_access:
+            mock_side_effect = CoursewareAccessChecksRequested.PreventCoursewareAccess(
+                message='Access denied by a courseware access-checks pipeline step',
+                error_code='access_denied_by_filter',
+                developer_message='https://example.com/redirect',
+                user_message='You are not allowed to access this course',
+            )
+            with patch(
+                'openedx_filters.learning.filters.CoursewareAccessChecksRequested.run_filter',
+                side_effect=mock_side_effect,
+            ):
+                response = self.client.get(self.url)
+        else:
             response = self.client.get(self.url)
 
         self._assert_course_access_response(response, expect_course_access, error_code)
-
-    @ddt.data(True, False)
-    def test_course_access_with_correct_active_enterprise(self, instructor_role):
-        """
-        Test that course_access is calculated correctly based on
-        access to MFE and access to the course itself.
-        """
-        if instructor_role:
-            CourseInstructorRole(self.course.id).add_users(self.user)
-
-        # Test with no EnterpriseCourseEnrollment
-        course_enrollment = CourseEnrollment.enroll(self.user, self.course.id, 'audit')
-        response = self.client.get(self.url)
-        self._assert_course_access_response(response, True, None)
-
-        # Test with EnterpriseCourseEnrollment and having correct active enterprise
-        course = course_enrollment.course
-        enterprise_customer_user = EnterpriseCustomerUserFactory(user_id=self.user.id)
-        EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
-        response = self.client.get(self.url)
-        self._assert_course_access_response(response, True, None)
-
-        # Test with incorrect active enterprise
-        enterprise_customer_user_2 = EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
-        enterprise_customer_user.refresh_from_db()
-        assert not enterprise_customer_user.active
-        assert enterprise_customer_user_2.active
-        response = self.client.get(self.url)
-        self._assert_course_access_response(response, False, 'incorrect_active_enterprise')
-
-        # test when no active enterprise at all (ideally this should never happen)
-        enterprise_customer_user_2.active = False
-        enterprise_customer_user_2.save()
-        enterprise_customer_user.refresh_from_db()
-        enterprise_customer_user_2.refresh_from_db()
-        assert not enterprise_customer_user.active
-        assert not enterprise_customer_user_2.active
-        response = self.client.get(self.url)
-        self._assert_course_access_response(response, False, 'incorrect_active_enterprise')
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     @ddt.data(True, False)

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -94,7 +94,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'load',
             check_if_enrolled=True,
             check_if_authenticated=True,
-            apply_enterprise_checks=True,
+            apply_priority_access_checks=True,
         )
 
         _, request.user = setup_masquerade(

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -243,31 +243,13 @@ class EnrollmentRequiredAccessError(AccessError):
         super().__init__(error_code, developer_message, user_message)
 
 
-class IncorrectActiveEnterpriseAccessError(AccessError):
+class PriorityAccessFiltersError(AccessError):
     """
-    Access denied because the user must login with correct enterprise.
-    """
-    def __init__(self, enrollment_enterprise_name, active_enterprise_name):
-        error_code = "incorrect_active_enterprise"
-        developer_message = "User active enterprise should be same as EnterpriseCourseEnrollment enterprise."
-        user_message = _("You are enrolled in this course with '{enrollment_enterprise_name}'. However, you are "
-                         "currently logged in as a '{active_enterprise_name}' user. Please log in with "
-                         "'{enrollment_enterprise_name}' to access this course.")
-        user_message = user_message.format(
-            enrollment_enterprise_name=enrollment_enterprise_name, active_enterprise_name=active_enterprise_name
-        )
-        super().__init__(error_code, developer_message, user_message)
+    Access denied by a plugin via the CoursewareAccessChecksRequested filter.
 
-
-class DataSharingConsentRequiredAccessError(AccessError):
+    Priority — non-bypassable by staff. The error_code, developer_message,
+    and user_message are supplied by the pipeline step that denied access.
     """
-    Access denied because the user must give Data sharing consent before access it.
-    """
-    def __init__(self, consent_url):
-        error_code = "data_sharing_access_required"
-        developer_message = consent_url
-        user_message = _("You must give Data Sharing Consent for the course")
-        super().__init__(error_code, developer_message, user_message)
 
 
 class AuthenticationRequiredAccessError(AccessError):

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -6,9 +6,7 @@ It allows us to share code between access.py and block transformers.
 from datetime import datetime, timedelta
 from logging import getLogger
 
-from crum import get_current_request
 from django.conf import settings
-from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
 from openedx_filters.learning.filters import CourseStartDateValidationFailed
 from pytz import UTC
 
@@ -17,9 +15,7 @@ from common.djangoapps.student.roles import CourseBetaTesterRole
 from lms.djangoapps.courseware.access_response import (
     AccessResponse,
     AuthenticationRequiredAccessError,
-    DataSharingConsentRequiredAccessError,
     EnrollmentRequiredAccessError,
-    IncorrectActiveEnterpriseAccessError,
     StartDateError,
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
@@ -176,68 +172,3 @@ def check_public_access(course, visibilities):
         return ACCESS_GRANTED
 
     return ACCESS_DENIED
-
-
-def check_data_sharing_consent(course_id):
-    """
-    Grants access if the user is do not need DataSharing consent, otherwise returns data sharing link.
-
-    Returns:
-        AccessResponse: Either ACCESS_GRANTED or DataSharingConsentRequiredAccessError
-    """
-    from openedx.features.enterprise_support.api import get_enterprise_consent_url
-
-    consent_url = get_enterprise_consent_url(
-        request=get_current_request(),
-        course_id=str(course_id),
-        return_to="courseware",
-        enrollment_exists=True,
-        source="CoursewareAccess",
-    )
-    if consent_url:
-        return DataSharingConsentRequiredAccessError(consent_url=consent_url)
-    return ACCESS_GRANTED
-
-
-def check_correct_active_enterprise_customer(user, course_id):
-    """
-    Grants access if the user's active enterprise customer is same as  EnterpriseCourseEnrollment's Enterprise.
-    Also, Grant access if enrollment is not Enterprise
-
-    Returns:
-        AccessResponse: Either ACCESS_GRANTED or IncorrectActiveEnterpriseAccessError
-    """
-    enterprise_enrollments = EnterpriseCourseEnrollment.objects.filter(
-        course_id=course_id, enterprise_customer_user__user_id=user.id
-    )
-    if not enterprise_enrollments.exists():
-        return ACCESS_GRANTED
-
-    try:
-        active_enterprise_customer_user = EnterpriseCustomerUser.objects.get(user_id=user.id, active=True)
-        if enterprise_enrollments.filter(enterprise_customer_user=active_enterprise_customer_user).exists():
-            return ACCESS_GRANTED
-
-        active_enterprise_name = active_enterprise_customer_user.enterprise_customer.name
-    except (EnterpriseCustomerUser.DoesNotExist, EnterpriseCustomerUser.MultipleObjectsReturned):
-        # Ideally this should not happen. As there should be only 1 active enterprise customer in our system
-        log.error("Multiple or No Active Enterprise found for the user %s.", user.id)
-        active_enterprise_name = "Incorrect"
-
-    enrollment_enterprise_name = enterprise_enrollments.first().enterprise_customer_user.enterprise_customer.name
-    return IncorrectActiveEnterpriseAccessError(enrollment_enterprise_name, active_enterprise_name)
-
-
-def is_priority_access_error(access_error):
-    """
-    Check if given access error is a priority Access Error or not.
-    Priority Access Error can not be bypassed by staff users.
-    """
-    priority_access_errors = [
-        DataSharingConsentRequiredAccessError,
-        IncorrectActiveEnterpriseAccessError,
-    ]
-    for priority_access_error in priority_access_errors:
-        if isinstance(access_error, priority_access_error):
-            return True
-    return False

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -20,6 +20,7 @@ from django.utils.translation import gettext as _
 from edx_django_utils.monitoring import function_trace, set_custom_attribute
 from fs.errors import ResourceNotFound
 from opaque_keys.edx.keys import UsageKey
+from openedx_filters.learning.filters import CoursewareAccessChecksRequested
 from path import Path as path
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
@@ -33,10 +34,13 @@ from lms.djangoapps.courseware.access_response import (
     EnrollmentRequiredAccessError,
     MilestoneAccessError,
     OldMongoAccessError,
-    StartDateError
+    PriorityAccessFiltersError,
+    StartDateError,
 )
-from lms.djangoapps.courseware.access_utils import check_authentication, check_data_sharing_consent, check_enrollment, \
-    check_correct_active_enterprise_customer, is_priority_access_error
+from lms.djangoapps.courseware.access_utils import (
+    check_authentication,
+    check_enrollment,
+)
 from lms.djangoapps.courseware.context_processor import get_user_timezone_or_last_seen_timezone_or_utc
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 from lms.djangoapps.courseware.date_summary import (
@@ -161,7 +165,7 @@ def check_course_access(
     check_if_enrolled=False,
     check_survey_complete=True,
     check_if_authenticated=False,
-    apply_enterprise_checks=False,
+    apply_priority_access_checks=False,
 ):
     """
     Check that the user has the access to perform the specified action
@@ -169,6 +173,11 @@ def check_course_access(
 
     check_if_enrolled: If true, additionally verifies that the user is enrolled.
     check_survey_complete: If true, additionally verifies that the user has completed the survey.
+    apply_priority_access_checks: If true, run the CoursewareAccessChecksRequested
+        filter pipeline so plugins can deny access with priority (non-bypassable)
+        errors. Used by views that surface the access error directly to the
+        client (e.g. course-home metadata) rather than relying on the redirect
+        machinery in ``check_course_access_with_redirect``.
     """
     def _check_nonstaff_access():
         # Below is a series of checks that must all pass for a user to be granted access
@@ -188,14 +197,13 @@ def check_course_access(
             if not enrollment_access_response:
                 return enrollment_access_response
 
-        if apply_enterprise_checks:
-            correct_active_enterprise_response = check_correct_active_enterprise_customer(user, course.id)
-            if not correct_active_enterprise_response:
-                return correct_active_enterprise_response
-
-            data_sharing_consent_response = check_data_sharing_consent(course.id)
-            if not data_sharing_consent_response:
-                return data_sharing_consent_response
+        if apply_priority_access_checks:
+            try:
+                CoursewareAccessChecksRequested.run_filter(user=user, course_key=course.id)
+            except CoursewareAccessChecksRequested.PreventCoursewareAccess as exc:
+                return PriorityAccessFiltersError(
+                    exc.error_code, exc.developer_message, exc.user_message,
+                )
 
         # Redirect if the user must answer a survey before entering the course.
         if check_survey_complete and action == 'load':
@@ -209,7 +217,7 @@ def check_course_access(
     non_staff_access_response = _check_nonstaff_access()
 
     # User has course access OR access error is a priority error
-    if non_staff_access_response or is_priority_access_error(non_staff_access_response):
+    if non_staff_access_response or isinstance(non_staff_access_response, PriorityAccessFiltersError):
         return non_staff_access_response
 
     # Allow staff full access to the course even if other checks fail

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -11,13 +11,10 @@ from crum import get_current_request
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.template.loader import render_to_string
-from django.urls import reverse
-from django.utils.http import urlencode
 from django.utils.translation import gettext as _
-from edx_django_utils.cache import TieredCache, get_cache_key
+from edx_django_utils.cache import get_cache_key
 from edx_rest_api_client.auth import SuppliedJwtAuth
 from requests.exceptions import HTTPError
 
@@ -26,7 +23,6 @@ from common.djangoapps.third_party_auth.provider import Registry
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.features.enterprise_support.utils import get_data_consent_share_cache_key
 
 try:
     from consent.models import DataSharingConsent, DataSharingConsentTextOverrides
@@ -568,170 +564,6 @@ def enterprise_customer_for_request(request):
     return enterprise_customer
 
 
-@enterprise_is_enabled(otherwise=False)
-def consent_needed_for_course(request, user, course_id, enrollment_exists=False):
-    """
-    Wraps the enterprise app check to determine if the user needs to grant
-    data sharing permissions before accessing a course.
-    """
-    LOGGER.info(
-        "[ENTERPRISE DSC] Determining if user [{username}] must consent to data sharing for course"
-        " [{course_id}]".format(
-            username=user.username,
-            course_id=course_id
-        )
-    )
-
-    active_enterprise_learner_info = get_active_enterprise_customer_user(user)
-    if not active_enterprise_learner_info:
-        # user is not linked to any enterprise so return False
-        LOGGER.info(
-            "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]."
-            " The user is not linked to an enterprise.".format(
-                username=user.username,
-                course_id=course_id
-            )
-        )
-        return False
-
-    active_enterprise_customer = active_enterprise_learner_info['enterprise_customer']
-
-    # Check if DSC required from cache
-    consent_cache_key = get_data_consent_share_cache_key(user.id, course_id, active_enterprise_customer['uuid'])
-    data_sharing_consent_needed_cache = TieredCache.get_cached_response(consent_cache_key)
-    if data_sharing_consent_needed_cache.is_found and data_sharing_consent_needed_cache.value == 0:
-        LOGGER.info(
-            "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]. "
-            "The DSC cache was checked and the value was 0.".format(
-                username=user.username,
-                course_id=course_id
-            )
-        )
-        return False
-
-    # Check if DSC enabled by the enterprise customer
-    enable_data_sharing_consent = active_enterprise_customer['enable_data_sharing_consent']
-    if not enable_data_sharing_consent:
-        # enterprise has disabled DSC so no need to move forward
-        LOGGER.info(
-            "[ENTERPRISE DSC] DSC is disabled for enterprise customer [{slug}]. Consent from user [{username}] is not "
-            "needed for course [{course_id}]".format(
-                slug=active_enterprise_customer['slug'],
-                username=user.username,
-                course_id=course_id
-            )
-        )
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-        return False
-
-    # check if the request enterprise and learner's active enterprise matches
-    current_enterprise_uuid = enterprise_customer_uuid_for_request(request)
-    active_enterprise_match = str(current_enterprise_uuid) == str(active_enterprise_customer['uuid'])
-    if not active_enterprise_match:
-        LOGGER.info(
-            '[ENTERPRISE DSC] Enterprise mismatch. USER: [{username}], RequestEnterprise: [{current_enterprise_uuid}], '
-            'LearnerEnterprise: [{active_enterprise_customer}]'.format(
-                username=user.username,
-                current_enterprise_uuid=current_enterprise_uuid,
-                active_enterprise_customer=active_enterprise_customer['uuid'],
-            )
-        )
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-        return False
-
-    # check if the enterprise and learner's site matches
-    enterprise_domain = Site.objects.get(domain=active_enterprise_customer['site']['domain'])
-    enterprise_and_learner_have_same_domain = enterprise_domain == request.site
-    if not enterprise_and_learner_have_same_domain:
-        LOGGER.info(
-            '[ENTERPRISE DSC] Site mismatch. USER: [{username}], RequestSite: [{request_site}], '
-            'LearnerEnterpriseDomain: [{enterprise_domain}]'.format(
-                username=user.username,
-                request_site=request.site,
-                enterprise_domain=enterprise_domain
-            )
-        )
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-        return False
-
-    # check if consent required
-    client = ConsentApiClient(user=request.user)
-    consent_required = client.consent_required(
-        username=user.username,
-        course_id=course_id,
-        enterprise_customer_uuid=current_enterprise_uuid,
-        enrollment_exists=enrollment_exists,
-    )
-    if not consent_required:
-        LOGGER.info(
-            "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]. The user's current"
-            " enterprise does not require data sharing consent.".format(
-                username=user.username,
-                course_id=course_id
-            )
-        )
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-        return False
-
-    LOGGER.info(
-        "[ENTERPRISE DSC] Consent from user [{username}] is needed for course [{course_id}]. The user's "
-        "current enterprise requires data sharing consent, and it has not been given.".format(
-            username=user.username,
-            course_id=course_id
-        )
-    )
-    return True
-
-
-@enterprise_is_enabled(otherwise='')
-def get_enterprise_consent_url(request, course_id, user=None, return_to=None, enrollment_exists=False, source='lms'):
-    """
-    Build a URL to redirect the user to the Enterprise app to provide data sharing
-    consent for a specific course ID.
-
-    Arguments:
-    * request: Request object
-    * course_id: Course key/identifier string.
-    * user: user to check for consent. If None, uses request.user
-    * return_to: url name label for the page to return to after consent is granted.
-                 If None, return to request.path instead.
-    """
-    user = user or request.user
-
-    LOGGER.info(
-        'Getting enterprise consent url for user [{username}] and course [{course_id}].'.format(
-            username=user.username,
-            course_id=course_id
-        )
-    )
-
-    if not consent_needed_for_course(request, user, course_id, enrollment_exists=enrollment_exists):
-        return None
-
-    if return_to is None:
-        return_path = request.path
-    else:
-        return_path = reverse(return_to, args=(course_id,))
-
-    url_params = {
-        'enterprise_customer_uuid': enterprise_customer_uuid_for_request(request),
-        'course_id': course_id,
-        'source': source,
-        'next': request.build_absolute_uri(return_path),
-        'failure_url': request.build_absolute_uri(
-            reverse('dashboard') + '?' + urlencode(
-                {
-                    CONSENT_FAILED_PARAMETER: course_id
-                }
-            )
-        ),
-    }
-    querystring = urlencode(url_params)
-    full_url = reverse('grant_data_sharing_permissions') + '?' + querystring
-    LOGGER.info('Redirecting to %s to complete data sharing consent', full_url)
-    return full_url
-
-
 @enterprise_is_enabled()
 def get_enterprise_learner_data_from_api(user):
     """
@@ -752,23 +584,6 @@ def get_enterprise_learner_data_from_db(user):
         queryset = EnterpriseCustomerUser.objects.filter(user_id=user.id)
         serializer = EnterpriseCustomerUserReadOnlySerializer(queryset, many=True)
         return serializer.data
-
-
-@enterprise_is_enabled(otherwise=None)
-def get_active_enterprise_customer_user(user):
-    """
-    Query the database to return active enterprise customer user and serialize the result. There can only be one active
-    EnterpriseCustomerUser instance against a user_id.
-    """
-    if user.is_authenticated:
-        try:
-            enterprise_customer_user = EnterpriseCustomerUser.objects.get(user_id=user.id, active=True)
-        except EnterpriseCustomerUser.DoesNotExist:
-            LOGGER.info(
-                "Active EnterpriseCustomerUser for user [{username}] does not exist".format(username=user.username)
-            )
-            return None
-        return EnterpriseCustomerUserReadOnlySerializer(instance=enterprise_customer_user).data
 
 
 @enterprise_is_enabled(otherwise=[])

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -6,19 +6,15 @@ from unittest import mock
 import ddt
 import httpretty
 import pytest
-from testfixtures import LogCapture
 from consent.models import DataSharingConsent
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.cache import cache
 from django.test.utils import override_settings
-from django.urls import reverse
-from edx_django_utils.cache import TieredCache, get_cache_key
+from edx_django_utils.cache import get_cache_key
 from requests.exceptions import HTTPError
-from six.moves.urllib.parse import parse_qs
 
 from common.djangoapps.student.tests.factories import UserFactory
-from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.features.enterprise_support.api import (
     _CACHE_MISS,
@@ -30,18 +26,15 @@ from openedx.features.enterprise_support.api import (
     EnterpriseApiServiceClient,
     activate_learner_enterprise,
     add_enterprise_customer_to_session,
-    consent_needed_for_course,
     enterprise_customer_for_request,
     enterprise_customer_from_api,
     enterprise_customer_from_session,
     enterprise_customer_from_session_or_learner_data,
     enterprise_customer_uuid_for_request,
     enterprise_enabled,
-    get_active_enterprise_customer_user,
     get_consent_notification_data,
     get_dashboard_consent_notification,
     get_data_sharing_consents,
-    get_enterprise_consent_url,
     get_enterprise_course_enrollments,
     get_enterprise_learner_data_from_api,
     get_enterprise_learner_data_from_db,
@@ -54,9 +47,6 @@ from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCustomerUserFactory,
 )
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
-from openedx.features.enterprise_support.utils import clear_data_consent_share_cache, get_data_consent_share_cache_key
-
-LOGGER_NAME = "edx.enterprise_helpers"
 
 
 class MockEnrollment(mock.MagicMock):
@@ -242,291 +232,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         mock_client.post.assert_called_once_with(consent_client.consent_endpoint, json=kwargs)
         mock_client.delete.assert_called_once_with(consent_client.consent_endpoint, json=kwargs)
 
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    def test_consent_needed_for_course_no_active_enterprise_user(self, mock_get_active_enterprise_customer_user):
-        """Tests that consent is not needed for non-enterprise user."""
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-        course_id = 'fake-course'
-        mock_get_active_enterprise_customer_user.return_value = None
-
-        # test that consent is not required for a non-enterprise learner and appropriate message is logged
-        expected_message = "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]." \
-                           " The user is not linked to an enterprise."
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(username=user.username, course_id=course_id),
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    def test_consent_needed_for_course_dsc_cache_found(self, mock_get_active_enterprise_customer_user):
-        """
-        Tests that a consent is not needed when a DSC record is already found in cache and it is equal to 0.
-        """
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-        )
-
-        # store a DSC record value in cache
-        consent_cache_key = get_data_consent_share_cache_key(user.id, course_id, ec_uuid)
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-
-        # test that consent is not required if DSC record is already found in cache.
-        expected_message = "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]. " \
-                           "The DSC cache was checked and the value was 0."
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(username=user.username, course_id=course_id),
-                )
-            )
-        # clearing up
-        clear_data_consent_share_cache(user.id, course_id, ec_uuid)
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    def test_consent_needed_for_course_dsc_not_enabled(self, mock_get_active_enterprise_customer_user):
-        """
-        Tests that a consent is not needed when enterprise customer has disabled DSC.
-        """
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        ent_slug = 'test-slug'
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-            enable_data_sharing_consent=False,
-            slug=ent_slug
-        )
-
-        # test that consent is not required if DSC is disabled for the enterprise.
-        expected_message = "[ENTERPRISE DSC] DSC is disabled for enterprise customer [{slug}]. " \
-                           "Consent from user [{username}] is not needed for course [{course_id}]"
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(slug=ent_slug, username=user.username, course_id=course_id)
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    def test_consent_needed_for_course_enterprise_mismatch(
-        self,
-        enterprise_customer_uuid_for_request_mock,
-        mock_get_active_enterprise_customer_user
-    ):
-        """
-        Tests that a consent is not needed when current request enterprise and learner's active
-        enterprise does not match.
-        """
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain='example.com'),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-
-        learner_enterprise = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        current_request_enterprise = '1234-23434-vfdfa-242sdczz'
-        course_id = 'fake-course'
-        enterprise_customer_uuid_for_request_mock.return_value = current_request_enterprise
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=learner_enterprise,
-        )
-
-        expected_message = '[ENTERPRISE DSC] Enterprise mismatch. USER: [{username}], RequestEnterprise: ' \
-                           '[{current_enterprise_uuid}], LearnerEnterprise: [{active_enterprise_customer}]'
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(
-                        username=user.username,
-                        current_enterprise_uuid=current_request_enterprise,
-                        active_enterprise_customer=learner_enterprise
-                    )
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    def test_consent_needed_for_course_site_mismatch(
-        self,
-        enterprise_customer_uuid_for_request_mock,
-        mock_get_active_enterprise_customer_user,
-    ):
-        """
-        Tests that a consent is not needed when enterprise customer and learner's site domain does not match.
-        """
-        user = UserFactory(username='janedoe')
-        request_site_domain = 'site-mismatch.com'
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain=request_site_domain),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        ent_site = SiteFactory(domain='ent-site.com')
-        enterprise_customer_uuid_for_request_mock.return_value = ec_uuid
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-            site_domain=str(ent_site.domain),
-        )
-
-        expected_message = "[ENTERPRISE DSC] Site mismatch. USER: [{username}], RequestSite: [{request_site}], " \
-                           "LearnerEnterpriseDomain: [{enterprise_domain}]"
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(
-                        username=user.username,
-                        request_site=request_site_domain,
-                        enterprise_domain=ent_site.domain
-                    )
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    @mock.patch('openedx.features.enterprise_support.api.ConsentApiClient.consent_required')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    def test_consent_needed_for_course_when_consent_is_not_required(
-        self,
-        enterprise_customer_uuid_for_request_mock,
-        mock_consent_required,
-        mock_get_active_enterprise_customer_user
-    ):
-        """
-        Tests that a consent is not needed when learner is not already enrolled and the enterprise requires consent.
-        """
-        mock_consent_required.return_value = False
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        enterprise_customer_uuid_for_request_mock.return_value = ec_uuid
-
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-        )
-
-        expected_message = "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]. " \
-                           "The user's current enterprise does not require data sharing consent."
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(username=user.username, course_id=course_id)
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    @mock.patch('openedx.features.enterprise_support.api.ConsentApiClient.consent_required')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    def test_consent_needed_for_course_when_consent_is_required(
-        self,
-        enterprise_customer_uuid_for_request_mock,
-        mock_consent_required,
-        mock_get_active_enterprise_customer_user
-    ):
-        """
-        Tests that a consent is needed when learner is not already enrolled and the enterprise requires consent.
-        """
-        mock_consent_required.return_value = True
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        enterprise_customer_uuid_for_request_mock.return_value = ec_uuid
-
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-        )
-
-        expected_message = "[ENTERPRISE DSC] Consent from user [{username}] is needed for course [{course_id}]. " \
-                           "The user's current enterprise requires data sharing consent, and it has not been given."
-        with LogCapture(LOGGER_NAME) as log:
-            assert consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(username=user.username, course_id=course_id)
-                )
-            )
-
     @mock.patch('openedx.features.enterprise_support.api.create_jwt_for_user')
     def test_fetch_enterprise_learner_data_unauthenticated(self, mock_jwt_builder):
         api_client = self._assert_api_client_with_user(EnterpriseApiClient, mock_jwt_builder)
@@ -609,35 +314,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         EnterpriseCustomerUserFactory(user_id=self.user.id)
         user_data = get_enterprise_learner_data_from_db(self.user)[0]['user']
         assert user_data['username'] == self.user.username
-
-    @ddt.data(True, False)
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
-    def test_get_active_enterprise_customer_user(self, is_enterprise_enabled, mock_enterprise_enabled):
-        """Tests that get_active_enterprise_customer_user utility returns correct user."""
-        mock_enterprise_enabled.return_value = is_enterprise_enabled
-        EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
-        if not is_enterprise_enabled:
-            assert not get_active_enterprise_customer_user(self.user)
-        else:
-            user_data = get_active_enterprise_customer_user(self.user)
-            assert user_data['user']['username'] == self.user.username
-            assert user_data['active']
-
-    def test_get_active_enterprise_customer_user_no_user_found(self):
-        """
-        Test that get_active_enterprise_customer_user utility returns None if active user not found.
-        And logs the appropriate message.
-        """
-        expected_logger_message = "Active EnterpriseCustomerUser for user [{username}] does not exist"
-        with LogCapture(LOGGER_NAME) as log:
-            assert not get_active_enterprise_customer_user(self.user)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_logger_message.format(username=self.user.username),
-                )
-            )
 
     @ddt.data(True, False)
     @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
@@ -816,55 +492,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
             assert enterprise_customer == enterprise_data
             assert mock_enterprise_customer_from_api.called is False
             assert mock_enterprise_customer_from_session.called is True
-
-    @ddt.data(True, False)
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    @mock.patch('openedx.features.enterprise_support.api.reverse')
-    @mock.patch('openedx.features.enterprise_support.api.consent_needed_for_course')
-    def test_get_enterprise_consent_url(
-            self,
-            is_return_to_null,
-            needed_for_course_mock,
-            reverse_mock,
-            enterprise_customer_uuid_for_request_mock,
-    ):
-        """
-        Verify that get_enterprise_consent_url correctly builds URLs.
-        """
-
-        def fake_reverse(*args, **kwargs):
-            if args[0] == 'grant_data_sharing_permissions':
-                return '/enterprise/grant_data_sharing_permissions'
-            return reverse(*args, **kwargs)
-
-        enterprise_customer_uuid_for_request_mock.return_value = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        reverse_mock.side_effect = fake_reverse
-        needed_for_course_mock.return_value = True
-        request_mock = mock.MagicMock(
-            user=self.user,
-            path='/request_path',
-            build_absolute_uri=lambda x: 'http://localhost:8000' + x  # Don't do it like this in prod. Ever.
-        )
-
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        return_to = None if is_return_to_null else 'courseware'
-
-        if is_return_to_null:
-            expected_path = request_mock.path
-        else:
-            expected_path = '/courses/course-v1:edX+DemoX+Demo_Course/courseware'
-        expected_url_args = {
-            'course_id': ['course-v1:edX+DemoX+Demo_Course'],
-            'source': ['lms'],
-            'failure_url': ['http://localhost:8000/dashboard?consent_failed=course-v1%3AedX%2BDemoX%2BDemo_Course'],
-            'enterprise_customer_uuid': ['cf246b88-d5f6-4908-a522-fc307e0b0c59'],
-            'next': [f'http://localhost:8000{expected_path}']
-        }
-
-        actual_url = get_enterprise_consent_url(request_mock, course_id, return_to=return_to)
-        actual_url_args = parse_qs(actual_url.split('/enterprise/grant_data_sharing_permissions?')[1])
-        assert actual_url_args == expected_url_args
 
     @ddt.data(
         (False, {'real': 'enterprise', 'uuid': ''}, 'course', [], [], "", ""),


### PR DESCRIPTION
Instead of enterprise/consent-specific access checks baked into check_course_access, the CoursewareAccessChecksRequested filter lets plugins deny courseware access with a generic priority access error.

This PR adds only one filter, but that one filter is mapped to TWO pipeline steps added in https://github.com/openedx/edx-enterprise/pull/2548:
* [ActiveEnterpriseCheckStep](https://github.com/openedx/edx-enterprise/blob/2a775c9/enterprise/filters/courseware.py#L71) - Deny access when the learner's active EnterpriseCustomer differs from the EnterpriseCustomer attached to their EnterpriseCourseEnrollment for this course.
* [DataSharingConsentCourseAccessStep](https://github.com/openedx/edx-enterprise/blob/2a775c9/consent/filters/courseware.py#L63) - Deny courseware access when data sharing consent is required but not granted.

This also removes orphaned utility functions from enterprise_support:

* consent_needed_for_course
* get_enterprise_consent_url
* get_active_enterprise_customer_user

ENT-11544

---

blocked by:
* https://github.com/openedx/openedx-filters/pull/336
* https://github.com/openedx/edx-enterprise/pull/2548
* https://github.com/edx/edx-platform/pull/338
* https://github.com/edx/edx-platform/pull/339

blocks:
* https://github.com/openedx/openedx-platform/pull/38102

---

## Testing

Test prerequisite:

- Run `./scripts/provision-integration-test-ENT-11544.sh` from edx-enterprise.

Tests for ActiveEnterpriseCheckStep:

1. Learner is linked to 2 customers, attempts to view an enrolled demo course, but the enrollment is subsidized by the non-active customer
   - Test: Login using `dual_linked_learner@example.com`, select "Test Enterprise" from the enterprise selector drop-down, go to http://localhost:2010/course/course-v1:edX+DemoX+Demo_Course
   - Expect: Error message "You are enrolled in this course with 'Other Enterprise'. However, you are currently logged in as a 'Test Enterprise' user. Please log in with 'Other Enterprise' to access this course."

Tests for DataSharingConsentCourseAccessStep:

2. Learner is linked to 2 customers, attempts to view an enrolled demo course, the enrollment is subsidized by the active customer, but DSC has not been granted.
   - Test: Login using `dual_linked_learner@example.com`, select "Other Enterprise" from the enterprise selector drop-down, go to http://localhost:2010/course/course-v1:edX+DemoX+Demo_Course
   - Expect: Redirect to DSC form.
3. Learner is linked to 1 customer, attempts to view an enrolled demo course, the enrollment is subsidized by the customer, but DSC has not been granted.
   - Test: Login using `enterprise_learner_test-enterprise@example.com`, go to http://localhost:2010/course/course-v1:edX+DemoX+Demo_Course
   - Expect: Redirect to DSC form.

Tests for both:

4. Learner is linked to 2 customers, attempts to view an enrolled demo course, the enrollment is subsidized by the active customer, DSC has been granted.
   - Test: Login using `enterprise_learner_test-enterprise@example.com`, go to http://localhost:2010/course/course-v1:edX+DemoX+Demo_Course , fill out DSC form to grant consent.
   - Expect: courseware renders successfully.