### PR TITLE
fix: prevent password reset to current password

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -768,6 +768,12 @@ class LogistrationPasswordResetView(APIView):  # lint-amnesty, pylint: disable=m
 
             validate_password(password, user=user)
 
+            if user.check_password(password):
+                return Response({
+                    'reset_status': False,
+                    'err_msg': _('Your new password must be different from your current password.')
+                })
+
             if settings.ENABLE_AUTHN_RESET_PASSWORD_HIBP_POLICY:
                 # Checks the Pwned Databases for password vulnerability.
                 pwned_response = check_pwned_password(password)

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -770,7 +770,7 @@ class LogistrationPasswordResetView(APIView):  # lint-amnesty, pylint: disable=m
 
             if user.check_password(password):
                 return Response({
-                    'reset_status': False,
+                    'reset_status': reset_status,
                     'err_msg': _('Your new password must be different from your current password.')
                 })
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -1021,3 +1021,31 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
         # Verify that the user's login failures lockout count is not reset.
         assert not LoginFailures.is_feature_enabled()
         assert LoginFailures.is_user_locked_out(self.user)
+
+    def test_password_reset_with_same_current_password(self):
+        """
+        Test that user cannot reset password to their current password.
+        """
+        current_password = 'CurrentPass@123'
+        self.user.set_password(current_password)
+        self.user.save()
+
+        # Generate fresh token after password change
+        token = default_token_generator.make_token(self.user)
+        uidb36 = int_to_base36(self.user.id)
+
+        request_param = {'new_password1': current_password, 'new_password2': current_password}
+        post_request = self.request_factory.post(
+            reverse(
+                "logistration_password_reset",
+                kwargs={"uidb36": uidb36, "token": token}
+            ) + "?track=pwreset",
+            request_param, format='json'
+        )
+        post_request.user = AnonymousUser()
+        reset_view = LogistrationPasswordResetView.as_view()
+        json_response = reset_view(post_request, uidb36=uidb36, token=token).render()
+        json_response = json.loads(json_response.content.decode('utf-8'))
+
+        assert json_response.get('reset_status') is False
+        assert 'Your new password must be different from your current password' in json_response.get('err_msg', '')

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -1023,34 +1023,36 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
         assert LoginFailures.is_user_locked_out(self.user)
 
     def test_password_reset_with_same_current_password(self):
-        """
-        Test that user cannot reset password to their current password.
-        """
-        current_password = 'CurrentPass@123'
-        self.user.set_password(current_password)
-        self.user.save()
-        original_password_hash = self.user.password
+    """
+    Test that user cannot reset password to their current password.
+    """
+    current_password = 'CurrentPass@123'
+    self.user.set_password(current_password)
+    self.user.save()
+    original_password_hash = self.user.password
+    mail.outbox = []
 
-        # Generate fresh token after password change
-        token = default_token_generator.make_token(self.user)
-        uidb36 = int_to_base36(self.user.id)
+    # Generate fresh token after password change
+    token = default_token_generator.make_token(self.user)
+    uidb36 = int_to_base36(self.user.id)
 
-        request_param = {'new_password1': current_password, 'new_password2': current_password}
-        post_request = self.request_factory.post(
-            reverse(
-                "logistration_password_reset",
-                kwargs={"uidb36": uidb36, "token": token}
-            ) + "?track=pwreset",
-            request_param, format='json'
-        )
-        post_request.user = AnonymousUser()
-        reset_view = LogistrationPasswordResetView.as_view()
-        json_response = reset_view(post_request, uidb36=uidb36, token=token).render()
-        json_response = json.loads(json_response.content.decode('utf-8'))
+    request_param = {'new_password1': current_password, 'new_password2': current_password}
+    post_request = self.request_factory.post(
+        reverse(
+            "logistration_password_reset",
+            kwargs={"uidb36": uidb36, "token": token}
+        ) + "?track=pwreset",
+        request_param, format='json'
+    )
+    post_request.user = AnonymousUser()
+    reset_view = LogistrationPasswordResetView.as_view()
+    response = reset_view(post_request, uidb36=uidb36, token=token)
+    assert response.status_code == 200
+    response.render()
+    json_response = json.loads(response.content.decode('utf-8'))
 
-        assert json_response.get('reset_status') is False
-        assert 'Your new password must be different from your current password' in json_response.get('err_msg', '')
-
-        updated_user = User.objects.get(id=self.user.id)
-        assert updated_user.password == original_password_hash
-        assert len(mail.outbox) == 0
+    assert json_response.get('reset_status') is False
+    assert 'Your new password must be different from your current password.' in json_response.get('err_msg', '')
+    refreshed_user = User.objects.get(id=self.user.id)
+    assert refreshed_user.password == original_password_hash
+    assert len(mail.outbox) == 0

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -1050,3 +1050,7 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
 
         assert json_response.get('reset_status') is False
         assert 'Your new password must be different from your current password' in json_response.get('err_msg', '')
+
+        updated_user = User.objects.get(id=self.user.id)
+        assert updated_user.password == original_password_hash
+        assert len(mail.outbox) == 0

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -1029,6 +1029,7 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
         current_password = 'CurrentPass@123'
         self.user.set_password(current_password)
         self.user.save()
+        original_password_hash = self.user.password
 
         # Generate fresh token after password change
         token = default_token_generator.make_token(self.user)


### PR DESCRIPTION
## Problem
Users could reset their password to their current password via the MFE password reset flow (`LogistrationPasswordResetView`). The API returned `reset_status: true` and sent a success email even when the new password was identical to the existing one.

## Root Cause
`validate_password()` only checks complexity and length rules — it does not check password reuse against the current password.

## Fix
Added `user.check_password()` check in `LogistrationPasswordResetView.post()` after `validate_password()`. If the new password matches the current password, the API returns:
```json
{"reset_status": false, "err_msg": "Your new password must be different from your current password."}