### PR TITLE
fix: enforce new password must differ from current on reset

### DIFF
--- a/openedx/core/djangoapps/user_authn/toggles.py
+++ b/openedx/core/djangoapps/user_authn/toggles.py
@@ -7,6 +7,7 @@ from django.conf import settings
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers import get_current_request
+from edx_toggles.toggles import WaffleFlag
 
 
 def is_require_third_party_auth_enabled():
@@ -42,3 +43,19 @@ def is_auto_generated_username_enabled():
     return configuration_helpers.get_value(
         'ENABLE_AUTO_GENERATED_USERNAME', settings.FEATURES.get('ENABLE_AUTO_GENERATED_USERNAME')
     )
+
+
+# .. toggle_name: user_authn.prevent_password_reuse_on_reset
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, prevents users from resetting their password
+#    to the same value as their current password.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-06-15
+# .. toggle_target_removal_date: 2026-08-15
+# .. toggle_tickets: https://2u-internal.atlassian.net/browse/AUT-139
+
+
+PREVENT_PASSWORD_REUSE_ON_RESET = WaffleFlag(
+    'user_authn.prevent_password_reuse_on_reset', __name__
+)

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
-from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
+from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX, check_password
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.views import INTERNAL_RESET_SESSION_TOKEN, PasswordResetConfirmView
@@ -768,7 +768,7 @@ class LogistrationPasswordResetView(APIView):  # lint-amnesty, pylint: disable=m
 
             validate_password(password, user=user)
 
-            if user.check_password(password):
+            if check_password(password, user.password):
                 return Response({
                     'reset_status': reset_status,
                     'err_msg': _('Your new password must be different from your current password.')

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -48,6 +48,7 @@ from common.djangoapps.student.forms import send_account_recovery_email_for_user
 from common.djangoapps.student.models import AccountRecovery, LoginFailures
 from common.djangoapps.util.json_request import JsonResponse
 from common.djangoapps.util.password_policy_validators import normalize_password, validate_password
+from openedx.core.djangoapps.user_authn.toggles import PREVENT_PASSWORD_REUSE_ON_RESET
 
 POST_EMAIL_KEY = 'openedx.core.djangoapps.util.ratelimit.request_post_email'
 REAL_IP_KEY = 'openedx.core.djangoapps.util.ratelimit.real_ip'
@@ -768,7 +769,7 @@ class LogistrationPasswordResetView(APIView):  # lint-amnesty, pylint: disable=m
 
             validate_password(password, user=user)
 
-            if check_password(password, user.password):
+            if PREVENT_PASSWORD_REUSE_ON_RESET.is_enabled() and check_password(password, user.password):
                 return Response({
                     'reset_status': reset_status,
                     'err_msg': _('Your new password must be different from your current password.')

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -767,13 +767,13 @@ class LogistrationPasswordResetView(APIView):  # lint-amnesty, pylint: disable=m
                 AUDIT_LOG.exception(f"Token validation failed for user {user_id}")
                 return Response({'reset_status': reset_status, 'token_invalid': True})
 
-            validate_password(password, user=user)
-
             if PREVENT_PASSWORD_REUSE_ON_RESET.is_enabled() and check_password(password, user.password):
                 return Response({
                     'reset_status': reset_status,
                     'err_msg': _('Your new password must be different from your current password.')
                 })
+
+            validate_password(password, user=user)
 
             if settings.ENABLE_AUTHN_RESET_PASSWORD_HIBP_POLICY:
                 # Checks the Pwned Databases for password vulnerability.

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -768,6 +768,12 @@ class LogistrationPasswordResetView(APIView):  # lint-amnesty, pylint: disable=m
 
             validate_password(password, user=user)
 
+            if user.check_password(password):
+                return Response({
+                    'reset_status': reset_status,
+                    'err_msg': _('Your new password must be different from your current password.')
+                })
+
             if settings.ENABLE_AUTHN_RESET_PASSWORD_HIBP_POLICY:
                 # Checks the Pwned Databases for password vulnerability.
                 pwned_response = check_pwned_password(password)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -43,6 +43,10 @@ from common.djangoapps.student.models import AccountRecovery, LoginFailures
 
 from common.djangoapps.util.password_policy_validators import create_validator_config
 from common.djangoapps.util.testing import EventTestMixin
+from django.utils.translation import gettext as _
+
+from edx_toggles.toggles.testutils import override_waffle_flag
+from openedx.core.djangoapps.user_authn.toggles import PREVENT_PASSWORD_REUSE_ON_RESET
 
 ENABLE_AUTHN_MICROFRONTEND = settings.FEATURES.copy()
 ENABLE_AUTHN_MICROFRONTEND['ENABLE_AUTHN_MICROFRONTEND'] = True
@@ -1022,17 +1026,17 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
         assert not LoginFailures.is_feature_enabled()
         assert LoginFailures.is_user_locked_out(self.user)
 
+    @override_waffle_flag(PREVENT_PASSWORD_REUSE_ON_RESET, active=True)
     def test_password_reset_with_same_current_password(self):
         """
-        Test that user cannot reset password to their current password.
+        Test that user cannot reset password to their current password
+        when waffle flag is enabled.
         """
         current_password = 'CurrentPass@123'
         self.user.set_password(current_password)
         self.user.save()
         original_password_hash = self.user.password
-        mail.outbox = []
 
-        # Generate fresh token after password change
         token = default_token_generator.make_token(self.user)
         uidb36 = int_to_base36(self.user.id)
 
@@ -1051,9 +1055,67 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
         response.render()
         json_response = json.loads(response.content.decode('utf-8'))
 
+        expected_msg = _('Your new password must be different from your current password.')
         assert json_response.get('reset_status') is False
-        assert 'Your new password must be different from your current password.' in json_response.get('err_msg', '')
+        assert expected_msg in json_response.get('err_msg', '')
         refreshed_user = User.objects.get(id=self.user.id)
         assert refreshed_user.password == original_password_hash
-        assert default_token_generator.check_token(refreshed_user, token)
-        assert len(mail.outbox) == 0
+
+    @override_waffle_flag(PREVENT_PASSWORD_REUSE_ON_RESET, active=False)
+    def test_same_password_allowed_when_flag_disabled(self):
+        """
+        Test that user CAN reset password to same password
+        when waffle flag is disabled (preserves old behavior).
+        """
+        current_password = 'CurrentPass@123'
+        self.user.set_password(current_password)
+        self.user.save()
+
+        token = default_token_generator.make_token(self.user)
+        uidb36 = int_to_base36(self.user.id)
+
+        request_param = {'new_password1': current_password, 'new_password2': current_password}
+        post_request = self.request_factory.post(
+            reverse(
+                "logistration_password_reset",
+                kwargs={"uidb36": uidb36, "token": token}
+            ) + "?track=pwreset",
+            request_param, format='json'
+        )
+        post_request.user = AnonymousUser()
+        reset_view = LogistrationPasswordResetView.as_view()
+        response = reset_view(post_request, uidb36=uidb36, token=token)
+        assert response.status_code == 200
+        response.render()
+        json_response = json.loads(response.content.decode('utf-8'))
+
+        assert json_response.get('reset_status') is True
+
+    @override_waffle_flag(PREVENT_PASSWORD_REUSE_ON_RESET, active=True)
+    def test_different_password_works_when_flag_enabled(self):
+        """
+        Test that user CAN reset to a different password
+        when waffle flag is enabled.
+        """
+        self.user.set_password('OldPassword@123')
+        self.user.save()
+
+        token = default_token_generator.make_token(self.user)
+        uidb36 = int_to_base36(self.user.id)
+
+        request_param = {'new_password1': 'NewPassword@456', 'new_password2': 'NewPassword@456'}
+        post_request = self.request_factory.post(
+            reverse(
+                "logistration_password_reset",
+                kwargs={"uidb36": uidb36, "token": token}
+            ) + "?track=pwreset",
+            request_param, format='json'
+        )
+        post_request.user = AnonymousUser()
+        reset_view = LogistrationPasswordResetView.as_view()
+        response = reset_view(post_request, uidb36=uidb36, token=token)
+        assert response.status_code == 200
+        response.render()
+        json_response = json.loads(response.content.decode('utf-8'))
+
+        assert json_response.get('reset_status') is True

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -1021,3 +1021,39 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
         # Verify that the user's login failures lockout count is not reset.
         assert not LoginFailures.is_feature_enabled()
         assert LoginFailures.is_user_locked_out(self.user)
+
+    def test_password_reset_with_same_current_password(self):
+        """
+        Test that user cannot reset password to their current password.
+        """
+        current_password = 'CurrentPass@123'
+        self.user.set_password(current_password)
+        self.user.save()
+        original_password_hash = self.user.password
+        mail.outbox = []
+
+        # Generate fresh token after password change
+        token = default_token_generator.make_token(self.user)
+        uidb36 = int_to_base36(self.user.id)
+
+        request_param = {'new_password1': current_password, 'new_password2': current_password}
+        post_request = self.request_factory.post(
+            reverse(
+                "logistration_password_reset",
+                kwargs={"uidb36": uidb36, "token": token}
+            ) + "?track=pwreset",
+            request_param, format='json'
+        )
+        post_request.user = AnonymousUser()
+        reset_view = LogistrationPasswordResetView.as_view()
+        response = reset_view(post_request, uidb36=uidb36, token=token)
+        assert response.status_code == 200
+        response.render()
+        json_response = json.loads(response.content.decode('utf-8'))
+
+        assert json_response.get('reset_status') is False
+        assert 'Your new password must be different from your current password.' in json_response.get('err_msg', '')
+        refreshed_user = User.objects.get(id=self.user.id)
+        assert refreshed_user.password == original_password_hash
+        assert default_token_generator.check_token(refreshed_user, token)
+        assert len(mail.outbox) == 0


### PR DESCRIPTION
## Problem
Users could reset their password to their current password via the MFE password reset flow (`LogistrationPasswordResetView`). The API returned `reset_status: true` and sent a success email even when the new password was identical to the existing one.

## Root Cause
`validate_password()` only checks complexity and length rules — it does not check password reuse against the current password.

## Fix
Added `user.check_password()` check in `LogistrationPasswordResetView.post()` after `validate_password()`. If the new password matches the current password, the API returns:
`{"reset_status": false, "err_msg": "Your new password must be different from your current password."}`

## Testing Instructions:
- Deploy code on Stage (release-ulmo branch)
- Django Admin: Set waffle flag user_authn.prevent_password_reuse_on_reset → Everyone = Yes
- URL: https://internal.courses.stage.edx.org/admin/waffle/flag/258/change/
- Go to https://authn.stage.edx.org/login → Forgot Password → enter email
- Open email → Click on reset link → Redirected to Reset Password Page
- Enter same current password → Submit → Should show `error`
- Enter different password → Submit → Should reset successfully
- Test with flag OFF (Everyone = No) → same password should be allowed

**`Note`**: This feature only affects password reset flow, not change password in Account Settings.

## Jira Ticket
https://2u-internal.atlassian.net/browse/AUT-139