### PR TITLE
fix: keep social auth links during Day 0 deactivation (#38729)

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -195,8 +195,8 @@ class TestDeactivateLogout(RetirementTestCase):
     @mock.patch('openedx.core.djangoapps.user_api.accounts.utils.retire_dot_oauth2_models')
     def test_user_can_deactivate_self(self, mock_retire_dot):
         """
-        Verify a user calling the deactivation endpoint logs out the user, deletes all their SSO tokens,
-        and creates a user retirement row.
+        Verify a user calling the deactivation endpoint logs out the user,
+        redacts user account record, and creates a user retirement row.
         """
         self.client.login(username=self.test_user.username, password=self.test_password)
         headers = build_jwt_headers(self.test_user)
@@ -206,7 +206,7 @@ class TestDeactivateLogout(RetirementTestCase):
         updated_user = User.objects.get(id=self.test_user.id)
         assert get_retired_email_by_email(self.test_user.email) == updated_user.email
         assert not updated_user.has_usable_password()
-        assert not list(UserSocialAuth.objects.filter(user=self.test_user))
+        assert list(UserSocialAuth.objects.filter(user=self.test_user))
         assert not list(Registration.objects.filter(user=self.test_user))
         assert len(UserRetirementStatus.objects.filter(user_id=self.test_user.id)) == 1
         # these retirement utils are tested elsewhere; just make sure we called them

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -252,14 +252,11 @@ def redact_and_delete_historical_social_auth(user_id):
 
 def create_retirement_request_and_deactivate_account(user):
     """
-    Adds user to retirement queue, unlinks social auth accounts, changes user passwords
-    and delete tokens and activation keys
+    Adds user to retirement queue, changes user passwords
+    and delete tokens and activation keys.
     """
     # Add user to retirement queue.
     UserRetirementStatus.create_retirement(user)
-
-    # Redact and unlink LMS social auth accounts.
-    redact_and_delete_social_auth(user.id)
 
     # Change LMS password & email
     user.email = get_retired_email_by_email(user.email)

--- a/openedx/core/djangoapps/user_api/management/tests/test_retire_user.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_retire_user.py
@@ -10,9 +10,7 @@ from unittest import mock
 import pytest
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.management import CommandError, call_command
-from django.db import connection
 from django.db.models.signals import pre_delete
-from django.test.utils import CaptureQueriesContext
 from social_django.models import UserSocialAuth
 
 from common.djangoapps.student.tests.factories import UserFactory
@@ -22,11 +20,7 @@ from openedx.core.djangoapps.user_api.accounts.signals import (
 from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (
     setup_retirement_states,  # noqa: F401
 )
-from openedx.core.djangoapps.user_api.accounts.utils import REDACTED_SOCIAL_AUTH_UID_PREFIX
-from openedx.core.djangolib.testing.utils import (
-    assert_redact_before_delete,
-    skip_unless_lms,
-)
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from ...models import UserRetirementStatus
 
@@ -166,11 +160,8 @@ def test_retire_user_calls_shared_deactivate_helper(mock_deactivate_helper):
 ])
 def test_retire_user_redacts_sso_pii_before_deletion(setup_retirement_states, social_auth_configs):  # lint-amnesty, pylint: disable=redefined-outer-name, unused-argument  # noqa: F811
     """
-    Test that SSO PII is redacted before UserSocialAuth records are deleted during retirement.
+    Test that Day 0 retirement preserves UserSocialAuth records.
     Covers both single and multiple SSO provider scenarios.
-
-    The safety-net pre_delete signal handler is disconnected so we verify the redaction
-    comes from retire_user itself, not the fallback signal.
     """
     user = UserFactory.create(username='sso-user', email='sso-user@example.com')
     auth_ids = [
@@ -178,16 +169,11 @@ def test_retire_user_redacts_sso_pii_before_deletion(setup_retirement_states, so
         for cfg in social_auth_configs
     ]
 
-    with disconnected_social_auth_redaction_signal(), CaptureQueriesContext(connection) as ctx:
+    with disconnected_social_auth_redaction_signal():
         call_command('retire_user', username=user.username, user_email=user.email)
 
-    assert_redact_before_delete(
-        [query['sql'] for query in ctx],
-        table=UserSocialAuth._meta.db_table,
-        expected_redacted_value_list=[REDACTED_SOCIAL_AUTH_UID_PREFIX],
-    )
     for auth_id in auth_ids:
-        assert not UserSocialAuth.objects.filter(id=auth_id).exists()
+        assert UserSocialAuth.objects.filter(id=auth_id).exists()
 
     retired_user_status = UserRetirementStatus.objects.filter(original_username=user.username).first()
     assert retired_user_status is not None


### PR DESCRIPTION
## Summary 
Remove Day 0 social-auth unlinking from deactivation flow in `openedx/core/djangoapps/user_api/accounts/utils.py`, so cancel-retirement can safely restore access during the 14-day window.
Also updates the related expectation in `openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py`.

## Ticket
https://2u-internal.atlassian.net/browse/BOMS-625