### PR TITLE
fix: remove annotated models from safelist and annotate openedx models on PII

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -106,57 +106,12 @@ enterprise.HistoricalEnterpriseCustomerEntitlement:
   ".. no_pii:": "No PII"
 
 # Via edx-ora2, these can be removed once the models are annotated for real
-assessment.Assessment:
-  ".. no_pii:": "No PII"
-assessment.AssessmentFeedback:
-  ".. no_pii:": "No PII"
-assessment.AssessmentFeedbackOption:
-  ".. no_pii:": "No PII"
-assessment.AssessmentPart:
-  ".. no_pii:": "No PII"
-assessment.Criterion:
-  ".. no_pii:": "No PII"
-assessment.CriterionOption:
-  ".. no_pii:": "No PII"
-assessment.PeerWorkflow:
-  ".. no_pii:": "No PII"
-assessment.PeerWorkflowItem:
-  ".. no_pii:": "No PII"
-assessment.Rubric:
-  ".. no_pii:": "No PII"
-assessment.StaffWorkflow:
-  ".. no_pii:": "No PII"
-assessment.StudentTrainingWorkflow:
-  ".. no_pii:": "No PII"
-assessment.StudentTrainingWorkflowItem:
-  ".. no_pii:": "No PII"
-assessment.TrainingExample:
-  ".. no_pii:": "No PII"
-workflow.AssessmentWorkflow:
-  ".. no_pii:": "No PII"
-workflow.AssessmentWorkflowCancellation:
-  ".. no_pii:": "No PII"
-workflow.AssessmentWorkflowStep:
-  ".. no_pii:": "No PII"
-
 # Via edx-celeryutils
 celery_utils.ChordData:
   ".. no_pii:": "No PII"
 
 # Via completion XBlock
-completion.BlockCompletion:
-  ".. no_pii:": "No PII"
-
 # Via django_notify (required / installed by wiki)
-django_notify.Notification:
-  ".. no_pii:": "No PII"
-django_notify.NotificationType:
-  ".. no_pii:": "No PII"
-django_notify.Settings:
-  ".. no_pii:": "No PII"
-django_notify.Subscription:
-  ".. no_pii:": "No PII"
-
 # Via django-openid-auth https://github.com/edx/django-openid-auth
 django_openid_auth.Association:
   ".. no_pii:": "No PII"
@@ -204,23 +159,6 @@ edx_name_affirmation.HistoricalVerifiedName:
   ".. pii_retirement:": "local_api"
 
 # Via VAL
-edxval.CourseVideo:
-  ".. no_pii:": "No PII"
-edxval.EncodedVideo:
-  ".. no_pii:": "No PII"
-edxval.Profile:
-  ".. no_pii:": "No PII"
-edxval.ThirdPartyTranscriptCredentialsState:
-  ".. no_pii:": "No PII"
-edxval.TranscriptPreference:
-  ".. no_pii:": "No PII"
-edxval.Video:
-  ".. no_pii:": "No PII"
-edxval.VideoImage:
-  ".. no_pii:": "No PII"
-edxval.VideoTranscript:
-  ".. no_pii:": "No PII"
-
 # Via PyLTI1p3
 lti1p3_tool_config.LtiTool:
   ".. no_pii:": "No PII"
@@ -228,17 +166,6 @@ lti1p3_tool_config.LtiToolKey:
   ".. no_pii:": "No PII"
 
 # Via Milestones
-milestones.CourseContentMilestone:
-  ".. no_pii:": "No PII"
-milestones.CourseMilestone:
-  ".. no_pii:": "No PII"
-milestones.Milestone:
-  ".. no_pii:": "No PII"
-milestones.MilestoneRelationshipType:
-  ".. no_pii:": "No PII"
-milestones.UserMilestone:
-  ".. no_pii:": "No PII"
-
 # Via Django OAuth2 Provider https://github.com/edx/django-oauth2-provider
 oauth2.Client:
   ".. no_pii:": "No PII"
@@ -290,11 +217,6 @@ oauth_provider.Token:
   ".. pii_retirement:": retained
 
 # Via edx-organizations
-organizations.Organization:
-  ".. no_pii:": "No PII"
-organizations.OrganizationCourse:
-  ".. no_pii:": "No PII"
-
 # Via Problem Builder XBlock
 problem_builder.Answer:
   ".. no_pii:": "No PII"
@@ -322,29 +244,11 @@ splash.SplashConfig:
   ".. no_pii:": "No PII"
 
 # Via edx-submissions
-submissions.Score:
-  ".. no_pii:": "No PII"
-submissions.ScoreAnnotation:
-  ".. no_pii:": "No PII"
-submissions.ScoreSummary:
-  ".. no_pii:": "No PII"
-submissions.StudentItem:
-  ".. no_pii:": "No PII"
-submissions.Submission:
-  ".. no_pii:": "No PII"
-submissions.TeamSubmission:
-  ".. no_pii:": "No PII"
-
 # Via sorl-thumbnail https://github.com/jazzband/sorl-thumbnail
 thumbnail.KVStore:
   ".. no_pii:": "No PII"
 
 # Via django-user-tasks
-user_tasks.UserTaskArtifact:
-  ".. no_pii:": "No PII"
-user_tasks.UserTaskStatus:
-  ".. no_pii:": "No PII"
-
 # Via waffle
 waffle.Flag:
   ".. no_pii:": "No PII"
@@ -354,21 +258,199 @@ waffle.Switch:
   ".. no_pii:": "No PII"
 
 # Via django-wiki https://github.com/openedx/django-wiki
-wiki.Article:
+
+# Additional non-local or generated models requiring safelist coverage
+agreements.HistoricalUserAgreement:
   ".. no_pii:": "No PII"
-wiki.ArticleForObject:
+assessment.HistoricalSharedFileUpload:
   ".. no_pii:": "No PII"
-wiki.ArticlePlugin:
+casbin_adapter.CasbinRule:
   ".. no_pii:": "No PII"
-wiki.ArticleRevision:
+channel_integration.ApiResponseRecord:
   ".. no_pii:": "No PII"
-wiki.ReusablePlugin:
+channel_integration.GenericEnterpriseCustomerPluginConfiguration:
   ".. no_pii:": "No PII"
-wiki.RevisionPlugin:
+channel_integration.IntegratedChannelAPIRequestLogs:
   ".. no_pii:": "No PII"
-wiki.RevisionPluginRevision:
+channel_integration.OrphanedContentTransmissions:
   ".. no_pii:": "No PII"
-wiki.SimplePlugin:
+edx_proctoring.HistoricalProctoredExam:
   ".. no_pii:": "No PII"
-wiki.URLPath:
+edx_proctoring.HistoricalProctoredExamStudentAttempt:
   ".. no_pii:": "No PII"
+enterprise.HistoricalDefaultEnterpriseEnrollmentIntention:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalDefaultEnterpriseEnrollmentRealization:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalEnterpriseCourseEntitlement:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalEnterpriseCustomerInviteKey:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalEnterpriseCustomerSsoConfiguration:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalEnterpriseCustomerUser:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalEnterpriseGroup:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalEnterpriseGroupMembership:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalLearnerCreditEnterpriseCourseEnrollment:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalLicensedEnterpriseCourseEnrollment:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalPendingEnrollment:
+  ".. no_pii:": "No PII"
+enterprise.HistoricalPendingEnterpriseCustomerAdminUser:
+  ".. pii:": "Contains pending enterprise admin email address."
+  ".. pii_types:": "email_address"
+  ".. pii_retirement:": "consumer_api"
+enterprise.HistoricalPendingEnterpriseCustomerUser:
+  ".. pii:": "Contains pending enterprise learner email address."
+  ".. pii_types:": "email_address"
+  ".. pii_retirement:": "consumer_api"
+enterprise.HistoricalSystemWideEnterpriseUserRoleAssignment:
+  ".. no_pii:": "No PII"
+forum.AbuseFlagger:
+  ".. no_pii:": "No PII"
+forum.Comment:
+  ".. pii:": "Forum comments may contain user-generated content and usernames."
+  ".. pii_types:": "username, biography"
+  ".. pii_retirement:": "local_api"
+forum.CommentThread:
+  ".. pii:": "Forum thread content may include user-generated text and usernames."
+  ".. pii_types:": "username, biography"
+  ".. pii_retirement:": "local_api"
+forum.CourseStat:
+  ".. no_pii:": "No PII"
+forum.EditHistory:
+  ".. pii:": "Forum edit history stores user-generated text and author identifiers."
+  ".. pii_types:": "username, biography"
+  ".. pii_retirement:": "local_api"
+forum.ForumUser:
+  ".. pii:": "Forum profile links and username data."
+  ".. pii_types:": "username"
+  ".. pii_retirement:": "local_api"
+forum.HistoricalAbuseFlagger:
+  ".. no_pii:": "No PII"
+forum.LastReadTime:
+  ".. no_pii:": "No PII"
+forum.MongoContent:
+  ".. no_pii:": "No PII"
+forum.ReadState:
+  ".. no_pii:": "No PII"
+forum.Subscription:
+  ".. no_pii:": "No PII"
+forum.UserVote:
+  ".. no_pii:": "No PII"
+lti_consumer.Lti1p3Passport:
+  ".. pii:": "Stores third-party LTI service credentials and identifiers."
+  ".. pii_types:": "password, external_service"
+  ".. pii_retirement:": "retained"
+oel_collections.Collection:
+  ".. no_pii:": "No PII"
+oel_components.Component:
+  ".. no_pii:": "No PII"
+oel_publishing.Container:
+  ".. no_pii:": "No PII"
+oel_publishing.DraftChangeLog:
+  ".. no_pii:": "No PII"
+oel_publishing.DraftChangeLogRecord:
+  ".. no_pii:": "No PII"
+oel_publishing.LearningPackage:
+  ".. no_pii:": "No PII"
+oel_publishing.PublishableEntity:
+  ".. no_pii:": "No PII"
+oel_tagging.ObjectTag:
+  ".. no_pii:": "No PII"
+oel_tagging.Tag:
+  ".. no_pii:": "No PII"
+oel_tagging.TagImportTask:
+  ".. no_pii:": "No PII"
+oel_tagging.Taxonomy:
+  ".. no_pii:": "No PII"
+openedx_catalog.CatalogCourse:
+  ".. no_pii:": "No PII"
+openedx_catalog.CourseRun:
+  ".. no_pii:": "No PII"
+openedx_content.Collection:
+  ".. no_pii:": "No PII"
+openedx_content.CollectionPublishableEntity:
+  ".. no_pii:": "No PII"
+openedx_content.Component:
+  ".. no_pii:": "No PII"
+openedx_content.ComponentType:
+  ".. no_pii:": "No PII"
+openedx_content.ComponentVersion:
+  ".. no_pii:": "No PII"
+openedx_content.ComponentVersionMedia:
+  ".. no_pii:": "No PII"
+openedx_content.Container:
+  ".. no_pii:": "No PII"
+openedx_content.ContainerType:
+  ".. no_pii:": "No PII"
+openedx_content.ContainerVersion:
+  ".. no_pii:": "No PII"
+openedx_content.Draft:
+  ".. no_pii:": "No PII"
+openedx_content.EntityList:
+  ".. no_pii:": "No PII"
+openedx_content.EntityListRow:
+  ".. no_pii:": "No PII"
+openedx_content.LearningPackage:
+  ".. no_pii:": "No PII"
+openedx_content.Media:
+  ".. no_pii:": "No PII"
+openedx_content.MediaType:
+  ".. no_pii:": "No PII"
+openedx_content.PublishLog:
+  ".. no_pii:": "No PII"
+openedx_content.PublishLogRecord:
+  ".. no_pii:": "No PII"
+openedx_content.PublishableEntity:
+  ".. no_pii:": "No PII"
+openedx_content.PublishableEntityVersion:
+  ".. no_pii:": "No PII"
+openedx_content.PublishableEntityVersionDependency:
+  ".. no_pii:": "No PII"
+openedx_content.Published:
+  ".. no_pii:": "No PII"
+openedx_content.Section:
+  ".. no_pii:": "No PII"
+openedx_content.SectionVersion:
+  ".. no_pii:": "No PII"
+openedx_content.Subsection:
+  ".. no_pii:": "No PII"
+openedx_content.SubsectionVersion:
+  ".. no_pii:": "No PII"
+openedx_content.Unit:
+  ".. no_pii:": "No PII"
+openedx_content.UnitVersion:
+  ".. no_pii:": "No PII"
+organizations.HistoricalOrganization:
+  ".. no_pii:": "No PII"
+organizations.HistoricalOrganizationCourse:
+  ".. no_pii:": "No PII"
+push_notifications.APNSDevice:
+  ".. pii:": "Contains mobile push tokens tied to users/devices."
+  ".. pii_types:": "external_service"
+  ".. pii_retirement:": "local_api"
+push_notifications.GCMDevice:
+  ".. pii:": "Contains mobile push tokens tied to users/devices."
+  ".. pii_types:": "external_service"
+  ".. pii_retirement:": "local_api"
+push_notifications.WNSDevice:
+  ".. pii:": "Contains mobile push tokens tied to users/devices."
+  ".. pii_types:": "external_service"
+  ".. pii_retirement:": "local_api"
+push_notifications.WebPushDevice:
+  ".. pii:": "Contains web push endpoint/subscription data tied to users/devices."
+  ".. pii_types:": "external_service"
+  ".. pii_retirement:": "local_api"
+submissions.ExternalGraderDetail:
+  ".. no_pii:": "No PII"
+submissions.SubmissionFile:
+  ".. no_pii:": "No PII"
+support.HistoricalUserSocialAuth:
+  ".. pii:": "Historical social auth linkage to third-party identity providers."
+  ".. pii_types:": "external_service"
+  ".. pii_retirement:": "local_api"

--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -105,13 +105,10 @@ enterprise.HistoricalEnterpriseCustomerCatalog:
 enterprise.HistoricalEnterpriseCustomerEntitlement:
   ".. no_pii:": "No PII"
 
-# Via edx-ora2, these can be removed once the models are annotated for real
 # Via edx-celeryutils
 celery_utils.ChordData:
   ".. no_pii:": "No PII"
 
-# Via completion XBlock
-# Via django_notify (required / installed by wiki)
 # Via django-openid-auth https://github.com/edx/django-openid-auth
 django_openid_auth.Association:
   ".. no_pii:": "No PII"
@@ -158,14 +155,12 @@ edx_name_affirmation.HistoricalVerifiedName:
   ".. pii_types:": "name"
   ".. pii_retirement:": "local_api"
 
-# Via VAL
 # Via PyLTI1p3
 lti1p3_tool_config.LtiTool:
   ".. no_pii:": "No PII"
 lti1p3_tool_config.LtiToolKey:
   ".. no_pii:": "No PII"
 
-# Via Milestones
 # Via Django OAuth2 Provider https://github.com/edx/django-oauth2-provider
 oauth2.Client:
   ".. no_pii:": "No PII"
@@ -216,7 +211,6 @@ oauth_provider.Token:
   ".. pii_types:": external_service, password
   ".. pii_retirement:": retained
 
-# Via edx-organizations
 # Via Problem Builder XBlock
 problem_builder.Answer:
   ".. no_pii:": "No PII"
@@ -243,12 +237,10 @@ social_django.UserSocialAuth:
 splash.SplashConfig:
   ".. no_pii:": "No PII"
 
-# Via edx-submissions
 # Via sorl-thumbnail https://github.com/jazzband/sorl-thumbnail
 thumbnail.KVStore:
   ".. no_pii:": "No PII"
 
-# Via django-user-tasks
 # Via waffle
 waffle.Flag:
   ".. no_pii:": "No PII"
@@ -256,8 +248,6 @@ waffle.Sample:
   ".. no_pii:": "No PII"
 waffle.Switch:
   ".. no_pii:": "No PII"
-
-# Via django-wiki https://github.com/openedx/django-wiki
 
 # Additional non-local or generated models requiring safelist coverage
 agreements.HistoricalUserAgreement:

--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -342,10 +342,6 @@ oel_components.Component:
   ".. no_pii:": "No PII"
 oel_publishing.Container:
   ".. no_pii:": "No PII"
-oel_publishing.DraftChangeLog:
-  ".. no_pii:": "No PII"
-oel_publishing.DraftChangeLogRecord:
-  ".. no_pii:": "No PII"
 oel_publishing.LearningPackage:
   ".. no_pii:": "No PII"
 oel_publishing.PublishableEntity:
@@ -357,6 +353,47 @@ oel_tagging.Tag:
 oel_tagging.TagImportTask:
   ".. no_pii:": "No PII"
 oel_tagging.Taxonomy:
+  ".. no_pii:": "No PII"
+# Via openedx_content library - additional models without edx-platform source annotations
+oel_collections.CollectionPublishableEntity:
+  ".. no_pii:": "No PII"
+oel_components.ComponentType:
+  ".. no_pii:": "No PII"
+oel_components.ComponentVersion:
+  ".. no_pii:": "No PII"
+oel_components.ComponentVersionContent:
+  ".. no_pii:": "No PII"
+oel_contents.Content:
+  ".. no_pii:": "No PII"
+oel_contents.MediaType:
+  ".. no_pii:": "No PII"
+oel_publishing.ContainerVersion:
+  ".. no_pii:": "No PII"
+oel_publishing.Draft:
+  ".. no_pii:": "No PII"
+oel_publishing.EntityList:
+  ".. no_pii:": "No PII"
+oel_publishing.EntityListRow:
+  ".. no_pii:": "No PII"
+oel_publishing.PublishLog:
+  ".. no_pii:": "No PII"
+oel_publishing.PublishLogRecord:
+  ".. no_pii:": "No PII"
+oel_publishing.PublishableEntityVersion:
+  ".. no_pii:": "No PII"
+oel_publishing.Published:
+  ".. no_pii:": "No PII"
+oel_sections.Section:
+  ".. no_pii:": "No PII"
+oel_sections.SectionVersion:
+  ".. no_pii:": "No PII"
+oel_subsections.Subsection:
+  ".. no_pii:": "No PII"
+oel_subsections.SubsectionVersion:
+  ".. no_pii:": "No PII"
+oel_units.Unit:
+  ".. no_pii:": "No PII"
+oel_units.UnitVersion:
   ".. no_pii:": "No PII"
 openedx_catalog.CatalogCourse:
   ".. no_pii:": "No PII"

--- a/.pii_annotations.yml
+++ b/.pii_annotations.yml
@@ -1,7 +1,7 @@
 source_path: ./
 report_path: pii_report
 safelist_path: .annotation_safe_list.yml
-coverage_target: 85.3
+coverage_target: 100.0
 # See OEP-30 for more information on these values and what they mean:
 # https://open-edx-proposals.readthedocs.io/en/latest/oep-0030-arch-pii-markup-and-auditing.html#docstring-annotations
 annotations:

--- a/Makefile
+++ b/Makefile
@@ -185,14 +185,12 @@ pii_check: ## check django models for pii annotations
 	DJANGO_SETTINGS_MODULE=cms.envs.test \
 	code_annotations django_find_annotations \
 		--config_file .pii_annotations.yml \
-		--app_name cms \
 		--coverage \
 		--lint
 
 	DJANGO_SETTINGS_MODULE=lms.envs.test \
 	code_annotations django_find_annotations \
 		--config_file .pii_annotations.yml \
-		--app_name lms \
 		--coverage \
 		--lint
 

--- a/cms/djangoapps/contentstore/models.py
+++ b/cms/djangoapps/contentstore/models.py
@@ -138,6 +138,8 @@ class ComponentLink(EntityLinkBase):
     """
     This represents link between any two publishable entities or link between publishable entity and a course
     XBlock. It helps in tracking relationship between XBlocks imported from libraries and used in different courses.
+
+    .. no_pii:
     """
     upstream_block = models.ForeignKey(
         Component,
@@ -310,6 +312,8 @@ class ContainerLink(EntityLinkBase):
     """
     This represents link between any two publishable entities or link between publishable entity and a course
     xblock. It helps in tracking relationship between xblocks imported from libraries and used in different courses.
+
+    .. no_pii:
     """
     upstream_container = models.ForeignKey(
         Container,
@@ -547,6 +551,8 @@ class LearningContextLinksStatus(models.Model):
     """
     This table stores current processing status of upstream-downstream links in ComponentLink table for a
     course or a learning context.
+
+    .. no_pii:
     """
     context_key = CourseKeyField(
         max_length=255,

--- a/cms/djangoapps/modulestore_migrator/models.py
+++ b/cms/djangoapps/modulestore_migrator/models.py
@@ -25,6 +25,25 @@ User = get_user_model()
 class ModulestoreSource(models.Model):
     """
     A legacy learning context (course or library) which can be a source of a migration.
+
+    One source can be associated with multiple (successful or unsuccessful) ModulestoreMigrations.
+    If a source has been migrated multiple times, then at most one of them can be considered the
+    "official" or "authoritative" migration; this is indicated by setting the `forwarded` field to
+    that ModulestoreMigration object.
+
+    Note that `forwarded` can be NULL even when 1+ migrations have happened for this source. This just
+    means that none of them were authoritative. In other words, they were all "imports"/"copies" rather
+    than true "migrations".
+
+    In practice, as of Ulmo:
+    * The `forwarded` field is used to decide how to update legacy library_content references.
+    * When using the Libraries Migration UI in Studio, `forwarded` is always set to the first
+      successful ModulestoreMigration.
+    * When using the REST API directly, the default is to use the same behavior as the UI, but
+      clients can also explicitly specify the `forward_source_to_target` boolean param in order to
+      control whether `forwarded` is set to any given migration.
+
+        .. no_pii:
     """
     key = LearningContextKeyField(
         max_length=255,
@@ -58,6 +77,8 @@ class ModulestoreMigration(models.Model):
       contains the progress of the import.
     * A single ModulestoreSource may very well have multiple ModulestoreMigrations; however,
       at most one of them with be the "authoritative" migration, as indicated by `forwarded`.
+
+        .. no_pii:
     """
 
     ## MIGRATION SPECIFICATION
@@ -145,6 +166,11 @@ class ModulestoreMigration(models.Model):
 class ModulestoreBlockSource(TimeStampedModel):
     """
     A legacy block usage (in a course or library) which can be a source of a block migration.
+
+    The semantics of `forwarded` directly mirror those of `ModulestoreSource.forwarded`. Please see
+    that class's docstring for details.
+
+    .. no_pii:
     """
     overall_source = models.ForeignKey(
         ModulestoreSource,
@@ -182,6 +208,8 @@ class ModulestoreBlockMigration(TimeStampedModel):
     * A single ModulestoreBlockSource may very well have multiple ModulestoreBlockMigrations; however,
       at most one of them with be the "authoritative" migration, as indicated by `forwarded`.
       This will coincide with the `overall_migration` being pointed to by `forwarded` as well.
+
+        .. no_pii:
     """
     overall_migration = models.ForeignKey(
         ModulestoreMigration,

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -1753,9 +1753,9 @@ class AccountRecovery(models.Model):
 
 class AllowedAuthUser(TimeStampedModel):
     """
-    Tracks which employee email addresses are allowed to log in with password on a given site.
+    Tracks which email addresses are allowed to log in with password on a given site.
 
-    .. pii: Contains employee email address.
+    .. pii: Contains email address.
     .. pii_types: email_address
     .. pii_retirement: local_api
     """

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -1140,6 +1140,8 @@ class CourseAccessRole(models.Model):
 class CourseAccessRoleHistory(TimeStampedModel):
     """
     Stores the change history for CourseAccessRole objects.
+
+    .. no_pii:
     """
     ACTION_CHOICES = (
         ('created', 'Created'),
@@ -1750,6 +1752,13 @@ class AccountRecovery(models.Model):
 
 
 class AllowedAuthUser(TimeStampedModel):
+    """
+    Tracks which employee email addresses are allowed to log in with password on a given site.
+
+    .. pii: Contains employee email address.
+    .. pii_types: email_address
+    .. pii_retirement: local_api
+    """
     site = models.ForeignKey(Site, related_name='allowed_auth_users', on_delete=models.CASCADE)
     email = models.EmailField(
         help_text=_(

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -1073,6 +1073,10 @@ class AppleMigrationUserIdInfo(models.Model):
     """
     Model to store users' Apple Unique Identifier during migration
     process of Apple team from edx Inc. to edx LLC.
+
+    .. pii: Contains Apple user identifiers (old_apple_id, transfer_id, new_apple_id).
+    .. pii_types: external_service
+    .. pii_retirement: local_api
     """
     old_apple_id = models.CharField(max_length=255)
     transfer_id = models.CharField(max_length=255, null=True, blank=True)

--- a/openedx/core/djangoapps/content/search/models.py
+++ b/openedx/core/djangoapps/content/search/models.py
@@ -21,6 +21,8 @@ class SearchAccess(models.Model):
 
     a) in some deployments, users may be granted access to more than 1_000 individual courses, and
     b) the search filter request is stored in the JWT, which is limited to 8Kib.
+
+    .. no_pii:
     """
     id = models.BigAutoField(
         primary_key=True,
@@ -70,6 +72,8 @@ def get_access_ids_for_request(request: Request, omit_orgs: list[str] = None) ->
 class IncrementalIndexCompleted(models.Model):
     """
     Stores the contex keys of aleady indexed courses and libraries for incremental indexing.
+
+    .. no_pii:
     """
 
     context_key = LearningContextKeyField(

--- a/openedx/core/djangoapps/content_staging/models.py
+++ b/openedx/core/djangoapps/content_staging/models.py
@@ -37,6 +37,8 @@ class StagedContent(models.Model):
     Use as a clipboard: for any given user, the most recent row with
     purpose=CLIPBOARD is the "current" clipboard content. But it can only be
     pasted if its status is READY.
+
+    .. no_pii:
     """
 
     class Meta:
@@ -89,6 +91,8 @@ class StagedContentFile(models.Model):
     These usually come from a course's Files & Uploads page, but can also come
     from per-xblock file storage (e.g. video transcripts or images used in
     v2 content libraries).
+
+    .. no_pii:
     """
     for_content = models.ForeignKey(StagedContent, on_delete=models.CASCADE, related_name="files")
     filename = models.CharField(max_length=255, blank=False)
@@ -106,6 +110,8 @@ class UserClipboard(models.Model):
     Each user has a clipboard that can hold one item at a time, where an item
     is some OLX content that can be used in a course, such as an XBlock, a Unit,
     or a Subsection.
+
+    .. no_pii:
     """
     # The user that copied something. Clipboards are user-specific and
     # previously copied items are not kept.

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -559,7 +559,7 @@ class DiscussionTopicLink(models.Model):
     """
     A model linking discussion topics ids to the part of a course they are linked to.
 
-    ..no_pii:
+    .. no_pii:
     """
     context_key = LearningContextKeyField(
         db_index=True,

--- a/openedx/core/djangoapps/embargo/models.py
+++ b/openedx/core/djangoapps/embargo/models.py
@@ -665,6 +665,8 @@ class CourseAccessRuleHistory(models.Model):
 class GlobalRestrictedCountry(models.Model):
     """
     Model to restrict access to specific countries globally.
+
+    .. no_pii:
     """
     country = models.ForeignKey(
         "Country",

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -165,7 +165,9 @@ class Notification(TimeStampedModel):
 
 class NotificationPreference(TimeStampedModel):
     """
-    Model to store notification preferences for users at account level
+    Model to store notification preferences for users at account level.
+
+    .. no_pii:
     """
 
     class EmailCadenceChoices(models.TextChoices):

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -818,7 +818,7 @@ openedx-django-pyfs==3.8.0
     #   xblocks-contrib
 openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
-openedx-django-wiki==3.1.1
+openedx-django-wiki==3.1.2
     # via -r requirements/edx/kernel.in
 openedx-events==10.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1361,7 +1361,7 @@ openedx-django-require==3.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-django-wiki==3.1.1
+openedx-django-wiki==3.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -990,7 +990,7 @@ openedx-django-pyfs==3.8.0
     #   xblocks-contrib
 openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
-openedx-django-wiki==3.1.1
+openedx-django-wiki==3.1.2
     # via -r requirements/edx/base.txt
 openedx-events==10.5.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1035,7 +1035,7 @@ openedx-django-pyfs==3.8.0
     #   xblocks-contrib
 openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
-openedx-django-wiki==3.1.1
+openedx-django-wiki==3.1.2
     # via -r requirements/edx/base.txt
 openedx-events==10.5.0
     # via


### PR DESCRIPTION
### Description:
This PR fixes pii_check for edx-platform by adding missing model annotations and correcting the safelist so the annotation tool passes cleanly.

### Changes:

- Added/fixed inline PII annotations in the targeted edx-platform models (including no_pii and pii metadata where required).
- Cleaned safelist conflicts by removing entries for models that are now annotated inline.
- Restored required safelist entries for non-local, generated, and historical models so coverage is complete.
- Fixed malformed annotation syntax in one model block.

### Validation:

- Ran the pii annotation check with lint and coverage.
- Result: lint passed and coverage reached 100% (all eligible models annotated).

### Private JIRA Link:
[BOMS-572](https://2u-internal.atlassian.net/browse/BOMS-572)
