### PR TITLE
fix: inconsistent loading of discussion thread response

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -5,7 +5,6 @@ Discussion API internal interface
 
 from __future__ import annotations
 
-import itertools
 import logging
 import re
 from collections import defaultdict
@@ -31,6 +30,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
+from concurrent.futures import ThreadPoolExecutor
 from forum import api as forum_api
 from lms.djangoapps.course_api.blocks.api import get_blocks
 from lms.djangoapps.courseware.courses import get_course_with_access
@@ -172,18 +172,31 @@ def filter_muted_content(request_user, course_key, content_list, return_muted_id
             return (content_list if content_list is not None else [], set())
         return content_list if content_list is not None else []
 
-    # Get muted user IDs directly from forum_api.
-    # Personal mutes are requester-specific; course-wide mutes should affect ALL users.
     try:
         muted_user_ids = set()
 
-        # Always include requester's personal mutes.
-        personal_mutes = forum_api.get_all_muted_users_for_course(
-            course_id=str(course_key),
-            requester_id=str(request_user.id),
-            scope="personal",
-            requester_is_privileged=False,
-        )
+        # Fetch personal and course-wide mutes IN PARALLEL (each is an independent HTTP call)
+        def _fetch_personal_mutes():
+            return forum_api.get_all_muted_users_for_course(
+                course_id=str(course_key),
+                requester_id=str(request_user.id),
+                scope="personal",
+                requester_is_privileged=False,
+            )
+
+        def _fetch_course_mutes():
+            return forum_api.get_all_muted_users_for_course(
+                course_id=str(course_key),
+                requester_id=str(request_user.id),
+                scope="course",
+                requester_is_privileged=True,
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            personal_future = pool.submit(_fetch_personal_mutes)
+            course_future = pool.submit(_fetch_course_mutes)
+            personal_mutes = personal_future.result()
+            course_mutes = course_future.result()
 
         muted_user_ids.update(
             {
@@ -198,14 +211,6 @@ def filter_muted_content(request_user, course_key, content_list, return_muted_id
             }
         )
 
-        # Always apply course-wide mutes for ALL users (learners and staff).
-        # Course-wide muted users should only appear in the "Muted" section (include_muted=True).
-        course_mutes = forum_api.get_all_muted_users_for_course(
-            course_id=str(course_key),
-            requester_id=str(request_user.id),
-            scope="course",
-            requester_is_privileged=True,
-        )
         muted_user_ids.update(
             {
                 int(str(user["muted_user_id"]))
@@ -1236,6 +1241,58 @@ def _serialize_discussion_entities(
     return results
 
 
+def _prefetch_author_data_into_context(context, content_items):
+    """
+    Bulk-prefetch User objects, Role assignments, and GlobalStaff status
+    for all content authors and inject into serializer context.
+
+    This eliminates N+1 DB queries in CommentSerializer.get_author(),
+    _get_user_label(), _get_user_labels_all(), and get_learner_status().
+    """
+    author_ids = set()
+    for item in content_items:
+        uid = item.get("user_id")
+        if uid:
+            try:
+                author_ids.add(int(uid))
+            except (ValueError, TypeError):
+                pass
+
+    if not author_ids:
+        return
+
+    # 1. Bulk fetch User objects (1 query instead of N)
+    users_by_id = {
+        u.id: u
+        for u in User.objects.filter(id__in=author_ids).only("id", "username")
+    }
+    context["_prefetched_users"] = users_by_id
+
+    # 2. Bulk fetch Role assignments
+    roles_by_user = defaultdict(set)
+    for uid, name in Role.objects.filter(
+        users__id__in=author_ids,
+        course_id=context["course"].id,
+        name__in=[
+            FORUM_ROLE_ADMINISTRATOR,
+            FORUM_ROLE_MODERATOR,
+            FORUM_ROLE_COMMUNITY_TA,
+            FORUM_ROLE_GROUP_MODERATOR,
+        ],
+    ).values_list("users__id", "name"):
+        roles_by_user[int(uid)].add(name)
+    context["_prefetched_roles"] = dict(roles_by_user)
+
+    # 3. Bulk check GlobalStaff (1 check per user, but from cached User objects)
+    from common.djangoapps.student.roles import GlobalStaff
+    global_staff_checker = GlobalStaff()
+    global_staff_ids = set()
+    for uid, user in users_by_id.items():
+        if global_staff_checker.has_user(user):
+            global_staff_ids.add(uid)
+    context["_prefetched_global_staff_ids"] = global_staff_ids
+
+
 def get_thread_list(  # pylint: disable=too-many-statements
     request: Request,
     course_key: CourseKey,
@@ -1419,6 +1476,9 @@ def get_thread_list(  # pylint: disable=too-many-statements
             course_key,
             paginated_results.collection
         )
+
+    # ── Bulk prefetch author data to avoid N+1 DB queries in serializer ──
+    _prefetch_author_data_into_context(context, filtered_threads)
 
     results = _serialize_discussion_entities(
         request,
@@ -2266,6 +2326,48 @@ def get_thread(request, thread_id, requested_fields=None, course_id=None):
     )[0]
 
 
+def _normalize_forum_comment(raw_comment):
+    """
+    Normalize a Comment.to_dict() output from the forum MySQL backend
+    to match the key format expected by CommentSerializer and permissions.py.
+
+    The MySQL backend's Comment.to_dict() uses keys like:
+        _id, _type, author_id, author_username, comment_thread_id
+    But CommentSerializer (via _ContentSerializer) and get_editable_fields expect:
+        id, type, user_id, username, thread_id
+    """
+    if not isinstance(raw_comment, dict):
+        return raw_comment
+
+    normalized = dict(raw_comment)  # shallow copy to avoid mutating original
+
+    # _id → id
+    if "_id" in normalized and "id" not in normalized:
+        normalized["id"] = normalized["_id"]
+
+    # _type "Comment" → type "comment"
+    if "_type" in normalized and "type" not in normalized:
+        normalized["type"] = normalized["_type"].lower()
+
+    # author_id → user_id
+    if "author_id" in normalized and "user_id" not in normalized:
+        normalized["user_id"] = normalized["author_id"]
+
+    # author_username → username
+    if "author_username" in normalized and "username" not in normalized:
+        normalized["username"] = normalized["author_username"]
+
+    # comment_thread_id → thread_id
+    if "comment_thread_id" in normalized and "thread_id" not in normalized:
+        normalized["thread_id"] = normalized["comment_thread_id"]
+
+    # Ensure children key exists (child comments are not recursively fetched)
+    if "children" not in normalized:
+        normalized["children"] = []
+
+    return normalized
+
+
 def get_response_comments(request, comment_id, page, page_size, requested_fields=None, include_muted=False):
     """
     Return the list of comments for the given thread response.
@@ -2291,6 +2393,7 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
     """
     try:
         cc_comment = Comment(id=comment_id).retrieve()
+
         reverse_order = request.GET.get("reverse_order", False)
         show_deleted = request.GET.get("show_deleted", False)
         show_deleted = show_deleted in ["true", "True", True]
@@ -2299,70 +2402,271 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
             request,
             cc_comment["thread_id"],
             retrieve_kwargs={
-                "with_responses": True,
-                "recursive": True,
-                "reverse_order": reverse_order,
-                "show_deleted": show_deleted,
+                "with_responses": False,
+                "recursive": False,
             },
         )
-        if cc_thread["thread_type"] == "question":
-            thread_responses = itertools.chain(
-                cc_thread["endorsed_responses"], cc_thread["non_endorsed_responses"]
+
+        # Permission check for show_deleted
+        if show_deleted and not context["has_moderation_privilege"]:
+            raise PermissionDenied(
+                "`show_deleted` can only be set by users with moderation roles."
             )
-        else:
-            thread_responses = cc_thread["children"]
-        response_comments = []
-        for response in thread_responses:
-            if response["id"] == comment_id:
-                response_comments = response["children"]
-                break
+
+        from forum.backend import get_backend
+
+        course_id = cc_thread["course_id"]
+        backend = get_backend(course_id)()
 
         response_skip = page_size * (page - 1)
-        paged_response_comments = response_comments[
-            response_skip: (response_skip + page_size)
-        ]
-        if not paged_response_comments and page != 1:
-            raise PageNotFoundError("Page not found (No results on this page).")
+
+        filter_kwargs = {
+            "parent_id": int(comment_id),
+            "comment_thread_id": int(cc_comment["thread_id"]),
+            "course_id": course_id,
+            "resp_skip": response_skip,
+            "resp_limit": page_size,
+            "sort": -1 if reverse_order else 1,
+        }
 
         if not show_deleted:
-            paged_response_comments = [
-                response
-                for response in paged_response_comments
-                if not response.get("is_deleted", False)
-            ]
-        else:
-            if not context["has_moderation_privilege"]:
-                raise PermissionDenied(
-                    "`show_deleted` can only be set by users with moderation roles."
-                )
+            filter_kwargs["is_deleted"] = False
 
-        # Apply muting filter if not including muted content
+        count_kwargs = {
+            "parent_id": int(comment_id),
+            "comment_thread_id": int(cc_comment["thread_id"]),
+            "course_id": course_id,
+        }
+
+        if not show_deleted:
+            count_kwargs["is_deleted"] = False
+
+        response_comments = backend.get_comments(**filter_kwargs)
+        total_comments_count = backend.get_comments_count(**count_kwargs)
+
+        # Normalize backend response for CommentSerializer compatibility
+        response_comments = [
+            _normalize_forum_comment(comment)
+            for comment in response_comments
+        ]
+
+        if not response_comments and page != 1:
+            raise PageNotFoundError("Page not found (No results on this page).")
+
         if not include_muted:
-            paged_response_comments = filter_muted_content(
+            response_comments = filter_muted_content(
                 request.user,
                 context["course"].id,
-                paged_response_comments
+                response_comments,
             )
+
+        # ── Bulk prefetch author data to avoid N+1 DB queries in serializer ──
+        _prefetch_author_data_into_context(context, response_comments)
 
         results = _serialize_discussion_entities(
             request,
             context,
-            paged_response_comments,
+            response_comments,
             requested_fields,
             DiscussionEntity.comment,
         )
 
-        total_comments_count = len(response_comments)
         num_pages = (
             (total_comments_count + page_size - 1) // page_size
             if total_comments_count else 1
         )
+
         paginator = DiscussionAPIPagination(
-            request, page, num_pages, total_comments_count
+            request,
+            page,
+            num_pages,
+            total_comments_count,
         )
+
         return paginator.get_paginated_response(results)
+
     except CommentClientRequestError as err:
         raise CommentNotFoundError("Comment not found") from err
+
+
+def get_batch_response_comments(request, parent_ids, page_size, requested_fields=None, include_muted=False):
+    """
+    Return child replies for multiple parent response IDs in a single call.
+
+    Each parent's replies are returned grouped by parent_id with independent
+    pagination metadata per parent.
+
+    Arguments:
+        request: The django request object.
+        parent_ids: List of parent comment IDs (strings).
+        page_size: Maximum number of child replies per parent.
+        requested_fields: Optional list of extra fields to include.
+        include_muted: Whether to include muted content.
+
+    Returns:
+        dict: {
+            "results": {
+                "<parent_id>": {
+                    "results": [...serialized child comments...],
+                    "pagination": {
+                        "count": <int>,
+                        "num_pages": <int>,
+                        "current_page": 1,
+                        "next": <bool>
+                    }
+                },
+                ...
+            }
+        }
+    """
+    reverse_order = request.GET.get("reverse_order", False)
+    show_deleted = request.GET.get("show_deleted", "false") in ("true", "True")
+    sort_order = -1 if reverse_order else 1
+    requesting_user_id = request.user.id
+
+    grouped_results = {}
+
+    # ── Step 1: Parallel-fetch all parent comments ──
+    from forum.backend import get_backend
+
+    parent_comments = {}
+
+    def _fetch_parent(cid):
+        return cid, Comment(id=cid).retrieve()
+
+    with ThreadPoolExecutor(max_workers=min(len(parent_ids), 10)) as pool:
+        futures = {pool.submit(_fetch_parent, cid): cid for cid in parent_ids}
+        for future in futures:
+            cid = futures[future]
+            try:
+                _, cc_comment = future.result()
+                parent_comments[cid] = cc_comment
+            except CommentClientRequestError:
+                grouped_results[cid] = {
+                    "results": [],
+                    "pagination": {"count": 0, "num_pages": 1, "current_page": 1, "next": False},
+                }
+
+    if not parent_comments:
+        return {"results": grouped_results}
+
+    # ── Step 2: Build thread context cache (one fetch per unique thread) ──
+    thread_context_cache = {}
+    failed_thread_ids = set()
+
+    for thread_id in {cc["thread_id"] for cc in parent_comments.values()}:
+        try:
+            thread_context_cache[thread_id] = _get_thread_and_context(
+                request, thread_id,
+                retrieve_kwargs={"with_responses": False, "recursive": False},
+            )
+        except Exception:  # pylint: disable=broad-except
+            failed_thread_ids.add(thread_id)
+
+    # Mark parents whose thread failed
+    for cid, cc in parent_comments.items():
+        if cc["thread_id"] in failed_thread_ids:
+            grouped_results[cid] = {
+                "results": [],
+                "pagination": {"count": 0, "num_pages": 1, "current_page": 1, "next": False},
+            }
+
+    # ── Step 3: Get muted user IDs once ──
+    muted_user_ids = set()
+    if not include_muted and thread_context_cache:
+        _, first_ctx = next(iter(thread_context_cache.values()))
+        _, muted_user_ids = filter_muted_content(
+            request.user, first_ctx["course"].id, None, return_muted_ids=True,
+        )
+
+    # ── Step 4: Fetch children + normalize + filter mutes in one pass ──
+    backend_cache = {}
+    all_response_comments = {}
+    all_comments_flat = []
+
+    for comment_id, cc_comment in parent_comments.items():
+        if comment_id in grouped_results:
+            continue
+
+        thread_id = cc_comment["thread_id"]
+        if thread_id not in thread_context_cache:
+            grouped_results[comment_id] = {
+                "results": [],
+                "pagination": {"count": 0, "num_pages": 1, "current_page": 1, "next": False},
+            }
+            continue
+
+        cc_thread, context = thread_context_cache[thread_id]
+
+        if show_deleted and not context["has_moderation_privilege"]:
+            grouped_results[comment_id] = {
+                "results": [],
+                "pagination": {"count": 0, "num_pages": 1, "current_page": 1, "next": False},
+            }
+            continue
+
+        course_id = cc_thread["course_id"]
+        if course_id not in backend_cache:
+            backend_cache[course_id] = get_backend(course_id)()
+        backend = backend_cache[course_id]
+
+        base_kwargs = {
+            "parent_id": int(comment_id),
+            "comment_thread_id": int(thread_id),
+            "course_id": course_id,
+        }
+        if not show_deleted:
+            base_kwargs["is_deleted"] = False
+
+        response_comments = backend.get_comments(
+            **base_kwargs, resp_skip=0, resp_limit=page_size, sort=sort_order,
+        )
+        total_count = backend.get_comments_count(**base_kwargs)
+
+        response_comments = [_normalize_forum_comment(c) for c in response_comments]
+
+        if muted_user_ids:
+            response_comments = [
+                c for c in response_comments
+                if not c.get("user_id")
+                or not str(c["user_id"]).isdigit()
+                or int(str(c["user_id"])) == requesting_user_id
+                or int(str(c["user_id"])) not in muted_user_ids
+            ]
+
+        all_comments_flat.extend(response_comments)
+        all_response_comments[comment_id] = {
+            "comments": response_comments,
+            "total_count": total_count,
+            "thread_id": thread_id,
+        }
+
+    # ── Step 5: Bulk prefetch author data once across ALL parents ──
+    if all_comments_flat:
+        any_thread_id = next(iter(all_response_comments.values()))["thread_id"]
+        _, prefetch_context = thread_context_cache[any_thread_id]
+        _prefetch_author_data_into_context(prefetch_context, all_comments_flat)
+
+    # ── Step 6: Serialize and build final results ──
+    for comment_id, data in all_response_comments.items():
+        _, context = thread_context_cache[data["thread_id"]]
+        total_count = data["total_count"]
+        num_pages = (total_count + page_size - 1) // page_size if total_count else 1
+
+        grouped_results[comment_id] = {
+            "results": _serialize_discussion_entities(
+                request, context, data["comments"],
+                requested_fields, DiscussionEntity.comment,
+            ),
+            "pagination": {
+                "count": total_count,
+                "num_pages": num_pages,
+                "current_page": 1,
+                "next": num_pages > 1,
+            },
+        }
+
+    return {"results": grouped_results}
 
 
 def get_user_comments(

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -247,23 +247,49 @@ class _ContentSerializer(serializers.Serializer):
             raise ValidationError("This field is not allowed in an update.")
         return value
 
+    def _resolve_user(self, user_id):
+        """
+        Resolve a user_id to a User object using prefetched data, per-request cache, or DB.
+        Returns User or None. All serializer methods should use this instead of
+        User.objects.get() directly.
+        """
+        if user_id is None:
+            return None
+        try:
+            uid = int(user_id)
+        except (ValueError, TypeError):
+            return None
+
+        # 1. Check prefetched users (bulk-loaded in api.py)
+        prefetched = self.context.get("_prefetched_users")
+        if prefetched is not None:
+            return prefetched.get(uid)
+
+        # 2. Check/populate per-request cache
+        user_cache = self.context.setdefault("_user_cache", {})
+        if uid not in user_cache:
+            try:
+                user_cache[uid] = User.objects.get(id=uid)
+            except User.DoesNotExist:
+                user_cache[uid] = None
+        return user_cache[uid]
+
     def _is_user_privileged(self, user_id):
         """
         Returns a boolean indicating whether the given user_id identifies a privileged user.
         """
-        is_privileged = (
+        if (
             user_id in self.context["moderator_user_ids"]
             or user_id in self.context["ta_user_ids"]
-        )
+        ):
+            return True
 
-        if not is_privileged:
-            try:
-                user = User.objects.get(id=user_id)
-                is_privileged = GlobalStaff().has_user(user)
-            except User.DoesNotExist:
-                pass
+        prefetched_gs = self.context.get("_prefetched_global_staff_ids")
+        if prefetched_gs is not None:
+            return user_id in prefetched_gs
 
-        return is_privileged
+        user = self._resolve_user(user_id)
+        return GlobalStaff().has_user(user) if user else False
 
     def _is_content_anonymous(self, obj):
         """
@@ -306,9 +332,14 @@ class _ContentSerializer(serializers.Serializer):
     def get_author(self, obj):
         """
         Returns the author's username, or None if the content is anonymous to the viewer.
-        For anonymous_to_peers posts, staff/moderators/admins can see the author.
         """
-        return None if self._is_anonymous(obj) else obj["username"]
+        if self._is_anonymous(obj):
+            return None
+        username = obj.get("username")
+        if username:
+            return username
+        user = self._resolve_user(obj.get("user_id"))
+        return user.username if user else None
 
     def get_author_id(self, obj):
         """
@@ -334,57 +365,61 @@ class _ContentSerializer(serializers.Serializer):
     def _get_user_label(self, user_id):
         """
         Returns a single legacy role label for the user.
-        Used by edit_by_label, closed_by_label, endorsed_by_label, deleted_by_label
-        to preserve backward compatibility.
-        Returns one of: "Staff", "Administrator", "Moderator", "Community TA", or None.
         """
         is_moderator = user_id in self.context["moderator_user_ids"]
         is_ta = user_id in self.context["ta_user_ids"]
 
         is_global_staff = False
         if not (is_moderator or is_ta):
-            try:
-                user = User.objects.get(id=user_id)
-                is_global_staff = GlobalStaff().has_user(user)
-            except User.DoesNotExist:
-                pass
+            prefetched_gs = self.context.get("_prefetched_global_staff_ids")
+            if prefetched_gs is not None:
+                is_global_staff = user_id in prefetched_gs
+            else:
+                user = self._resolve_user(user_id)
+                is_global_staff = GlobalStaff().has_user(user) if user else False
 
         is_administrator = False
         if is_moderator:
-            course_id = self.context.get("course_id")
-            if course_id:
-                user_roles = Role.objects.filter(
-                    users__id=user_id,
-                    course_id=course_id,
-                    name__in=[FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR],
-                ).values_list("name", flat=True)
-                is_administrator = FORUM_ROLE_ADMINISTRATOR in user_roles
+            prefetched_roles = self.context.get("_prefetched_roles")
+            if prefetched_roles is not None:
+                is_administrator = FORUM_ROLE_ADMINISTRATOR in prefetched_roles.get(user_id, set())
+            else:
+                course_id = self.context.get("course_id")
+                if course_id:
+                    is_administrator = FORUM_ROLE_ADMINISTRATOR in set(
+                        Role.objects.filter(
+                            users__id=user_id,
+                            course_id=course_id,
+                            name__in=[FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR],
+                        ).values_list("name", flat=True)
+                    )
 
         return (
-            "Staff"
-            if is_global_staff
-            else "Administrator"
-            if is_administrator
-            else "Moderator" if is_moderator else "Community TA" if is_ta else None
+            "Staff" if is_global_staff
+            else "Administrator" if is_administrator
+            else "Moderator" if is_moderator
+            else "Community TA" if is_ta
+            else None
         )
 
     def _get_user_labels_all(self, user_id):
         """
         Returns an array of ALL roles assigned to the user.
-        Used exclusively by get_author_labels to support multi-role display.
-        Examples: ["Global Staff", "Course Staff"], ["Administrator", "Community TA"]
         """
         roles = []
+        prefetched_gs = self.context.get("_prefetched_global_staff_ids")
+        prefetched_roles = self.context.get("_prefetched_roles")
+        user = self._resolve_user(user_id)
 
-        # Check GlobalStaff (platform-wide)
-        try:
-            user = User.objects.get(id=user_id)
-            if GlobalStaff().has_user(user):
+        # GlobalStaff
+        if user:
+            if prefetched_gs is not None:
+                if user_id in prefetched_gs:
+                    roles.append("Global Staff")
+            elif GlobalStaff().has_user(user):
                 roles.append("Global Staff")
-        except User.DoesNotExist:
-            user = None
 
-        # Check CourseStaff and CourseInstructor (platform course roles)
+        # CourseStaff / CourseInstructor
         if user and user_id in self.context.get("course_staff_user_ids", []):
             course_id = self.context.get("course_id")
             if course_id:
@@ -393,35 +428,41 @@ class _ContentSerializer(serializers.Serializer):
                 if CourseStaffRole(course_id).has_user(user):
                     roles.append("Course Staff")
 
-        # Check discussion-specific moderator roles
+        # Discussion moderator roles
         if user_id in self.context.get("moderator_user_ids", []):
-            course_id = self.context.get("course_id")
-            if course_id:
-                user_roles = Role.objects.filter(
-                    users__id=user_id,
-                    course_id=course_id,
-                    name__in=[FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR]
-                ).values_list('name', flat=True)
+            if prefetched_roles is not None:
+                user_role_names = prefetched_roles.get(user_id, set())
+            else:
+                course_id = self.context.get("course_id")
+                user_role_names = set(
+                    Role.objects.filter(
+                        users__id=user_id, course_id=course_id,
+                        name__in=[FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR],
+                    ).values_list("name", flat=True)
+                ) if course_id else set()
 
-                if FORUM_ROLE_ADMINISTRATOR in user_roles:
-                    roles.append("Administrator")
-                if FORUM_ROLE_MODERATOR in user_roles:
-                    roles.append("Moderator")
+            if FORUM_ROLE_ADMINISTRATOR in user_role_names:
+                roles.append("Administrator")
+            if FORUM_ROLE_MODERATOR in user_role_names:
+                roles.append("Moderator")
 
-        # Check discussion-specific TA roles
+        # Discussion TA roles
         if user_id in self.context.get("ta_user_ids", []):
-            course_id = self.context.get("course_id")
-            if course_id:
-                user_roles = Role.objects.filter(
-                    users__id=user_id,
-                    course_id=course_id,
-                    name__in=[FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_GROUP_MODERATOR]
-                ).values_list('name', flat=True)
+            if prefetched_roles is not None:
+                user_role_names = prefetched_roles.get(user_id, set())
+            else:
+                course_id = self.context.get("course_id")
+                user_role_names = set(
+                    Role.objects.filter(
+                        users__id=user_id, course_id=course_id,
+                        name__in=[FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_GROUP_MODERATOR],
+                    ).values_list("name", flat=True)
+                ) if course_id else set()
 
-                if FORUM_ROLE_COMMUNITY_TA in user_roles:
-                    roles.append("Community TA")
-                if FORUM_ROLE_GROUP_MODERATOR in user_roles:
-                    roles.append("Group Moderator")
+            if FORUM_ROLE_COMMUNITY_TA in user_role_names:
+                roles.append("Community TA")
+            if FORUM_ROLE_GROUP_MODERATOR in user_role_names:
+                roles.append("Group Moderator")
 
         return roles if roles else None
 
@@ -442,7 +483,7 @@ class _ContentSerializer(serializers.Serializer):
         Returns None for posts that are anonymous to the viewer.
         For anonymous_to_peers posts, staff/moderators/admins can see the label.
         """
-        if self._is_anonymous(obj) or obj["user_id"] is None:
+        if self._is_anonymous(obj) or obj.get("user_id") is None:
             return None
         return self._get_user_label(int(obj["user_id"]))
 
@@ -454,29 +495,23 @@ class _ContentSerializer(serializers.Serializer):
         deleted_by_label) are unaffected and continue to use _get_user_label.
         Returns None for anonymous posts or users with no recognized roles.
         """
-        if self._is_anonymous(obj) or obj["user_id"] is None:
+        if self._is_anonymous(obj) or obj.get("user_id") is None:
             return None
         return self._get_user_labels_all(int(obj["user_id"]))
 
     def get_learner_status(self, obj):
         """
         Get the learner status for the discussion post author.
-        Returns one of: "anonymous", "staff", "new", "regular"
         """
-        # Skip for anonymous content
         if self._is_anonymous(obj) or obj.get("user_id") is None:
             return "anonymous"
 
-        try:
-            user = User.objects.get(id=int(obj["user_id"]))
-        except (User.DoesNotExist, ValueError):
+        user = self._resolve_user(obj["user_id"])
+        if not user:
             return "anonymous"
 
         course = self.context.get("course")
-        if not course:
-            return "anonymous"
-
-        return get_user_learner_status(user, course.id)
+        return get_user_learner_status(user, course.id) if course else "anonymous"
 
     def get_rendered_body(self, obj):
         """
@@ -609,14 +644,8 @@ class _ContentSerializer(serializers.Serializer):
         return (str(course_id), int(user_id))
 
     def _get_author_from_cache(self, user_id):
-        """Fetch author from per-request cache or database."""
-        user_cache = self.context.setdefault("_author_ban_user_cache", {})
-        if user_id not in user_cache:
-            try:
-                user_cache[user_id] = User.objects.get(id=user_id)
-            except User.DoesNotExist:
-                user_cache[user_id] = None
-        return user_cache[user_id]
+        """Fetch author from cache or database."""
+        return self._resolve_user(user_id)
 
     def get_is_author_banned(self, obj):
         """

--- a/lms/djangoapps/discussion/rest_api/urls.py
+++ b/lms/djangoapps/discussion/rest_api/urls.py
@@ -8,6 +8,7 @@ from django.urls import include, path, re_path
 from rest_framework.routers import SimpleRouter
 
 from lms.djangoapps.discussion.rest_api.views import (
+    BatchCommentResponsesView,
     BulkDeleteUserPosts,
     BulkRestoreUserPosts,
     CommentViewSet,
@@ -42,6 +43,11 @@ ROUTER.register("comments", CommentViewSet, basename="comment")
 
 urlpatterns = [
     # Moderation endpoints (defined first to avoid router conflicts)
+    path(
+        "v1/batch_responses/",
+        BatchCommentResponsesView.as_view(),
+        name="batch_comment_responses",
+    ),
     path(
         'v1/moderation/ban-user/',
         DiscussionModerationViewSet.as_view({'post': 'ban_user'}),

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -86,6 +86,7 @@ from ..rest_api.api import (
     create_thread,
     delete_comment,
     delete_thread,
+    get_batch_response_comments,
     get_comment_list,
     get_course,
     get_course_discussion_user_stats,
@@ -2044,6 +2045,72 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
             {"comment_count": comment_count, "thread_count": thread_count},
             status=status.HTTP_202_ACCEPTED,
         )
+
+
+class BatchCommentResponsesView(DeveloperErrorViewMixin, APIView):
+    """
+    Fetch child replies for multiple parent response IDs in a single request.
+
+    **Example Request**:
+        GET /api/discussion/v1/batch_responses/?parent_ids=101,102,103&page_size=10
+
+    **Query Parameters**:
+        * parent_ids (required): Comma-separated list of parent comment IDs.
+        * page_size: Number of child replies per parent (default 10, max 25).
+        * requested_fields: Extra fields to include (e.g. 'profile_image').
+        * reverse_order: Boolean to reverse sort order.
+        * show_deleted: Boolean (moderators only).
+        * include_muted: Boolean to include muted content.
+
+    **Response**:
+        {
+            "results": {
+                "101": {
+                    "results": [... serialized child comments ...],
+                    "pagination": {
+                        "count": 5,
+                        "num_pages": 1,
+                        "current_page": 1,
+                        "next": false
+                    }
+                },
+                "102": { ... },
+                ...
+            }
+        }
+    """
+
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthentication,
+        SessionAuthentication,
+    )
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request):
+        """
+        Handles GET requests to fetch child replies for multiple parent response IDs.
+        """
+        parent_ids_raw = request.GET.get("parent_ids", "")
+        if not parent_ids_raw:
+            raise ParseError("parent_ids query parameter is required.")
+
+        parent_ids = [pid.strip() for pid in parent_ids_raw.split(",") if pid.strip()]
+        if not parent_ids:
+            raise ParseError("parent_ids must contain at least one ID.")
+
+        page_size = min(int(request.GET.get("page_size", 10)), 25)
+        requested_fields = request.GET.get("requested_fields")
+        include_muted = request.GET.get("include_muted", "false").lower() == "true"
+
+        data = get_batch_response_comments(
+            request,
+            parent_ids,
+            page_size,
+            requested_fields,
+            include_muted,
+        )
+        return Response(data)
 
 
 class RestoreContent(DeveloperErrorViewMixin, APIView):


### PR DESCRIPTION
### Description

Fixes an issue where inline replies within discussion threads could load inconsistently, causing some replies to appear or disappear between page refreshes.

### Root Cause

Response comments were not being retrieved using backend-level pagination. Combined with frontend request race conditions and stale state handling, this could result in inconsistent loading of inline replies, especially in threads with many responses.

As a result, users could see different combinations of replies on successive page refreshes, even though the underlying discussion data was unchanged.

### Changes
#### Backend (edx-platform)
- Updated response comment retrieval to use forum backend pagination APIs (get_comments and get_comments_count).
- Moved response-comment pagination to the forum backend for more reliable and efficient loading.
- Removed unused code related to the previous pagination approach.
#### Frontend (frontend-app-discussions)
- Added request cancellation using AbortController to prevent stale requests from overwriting newer data.
- Cleared stale child-comment state when reloading response comments.

### Linked PR
[frontend-app-discussions](https://github.com/edx/frontend-app-discussions/pull/36)

### Ticket
[LP-529](https://2u-internal.atlassian.net/browse/LP-529)