### PR TITLE
feat: Set integrated_channels logger handler to json formater

### DIFF
--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -45,6 +45,15 @@ def get_logger_config(log_dir,  # lint-amnesty, pylint: disable=unused-argument
             },
             'syslog_format': {'format': syslog_format},
             'raw': {'format': '%(message)s'},
+            # Emits Datadog-ready JSON for the channel_integrations logger when
+            # INTEGRATED_CHANNELS_JSON_LOGGING is enabled. When the flag is off,
+            # JsonChannelFormatter falls back to logging.Formatter, so the
+            # 'format' below keeps legacy output byte-identical to 'standard'.
+            'integrated_channels_json': {
+                '()': 'channel_integrations.integrated_channel.structured_logging.JsonChannelFormatter',
+                'format': '%(asctime)s %(levelname)s %(process)d '
+                          '[%(name)s] [user %(userid)s] [ip %(remoteip)s] %(filename)s:%(lineno)d - %(message)s',
+            },
         },
         'filters': {
             'require_debug_false': {
@@ -62,6 +71,16 @@ def get_logger_config(log_dir,  # lint-amnesty, pylint: disable=unused-argument
                 'level': 'INFO',
                 'class': 'logging.StreamHandler',
                 'formatter': 'standard',
+                'filters': ['userid_context', 'remoteip_context'],
+                'stream': sys.stderr,
+            },
+            # Stderr handler dedicated to the channel_integrations logger. Mirrors
+            # 'console' but uses the JsonChannelFormatter so that enabling
+            # INTEGRATED_CHANNELS_JSON_LOGGING emits structured JSON for Datadog.
+            'integrated_channels_console': {
+                'level': 'INFO',
+                'class': 'logging.StreamHandler',
+                'formatter': 'integrated_channels_json',
                 'filters': ['userid_context', 'remoteip_context'],
                 'stream': sys.stderr,
             },
@@ -96,6 +115,16 @@ def get_logger_config(log_dir,  # lint-amnesty, pylint: disable=unused-argument
                 'handlers': ['console', 'local'],
                 'level': 'INFO',
                 'propagate': False
+            },
+            # Route integrated-channels logs through the JSON-capable stderr
+            # handler (in addition to syslog), without propagating to the root
+            # logger so records are not also emitted by the plain 'console'
+            # handler. Output matches the legacy format until
+            # INTEGRATED_CHANNELS_JSON_LOGGING is enabled.
+            'channel_integrations': {
+                'handlers': ['integrated_channels_console', 'local'],
+                'level': 'INFO',
+                'propagate': False,
             },
             'django.request': {
                 'handlers': ['mail_admins'],


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
