### PR TITLE
chore: optimize/correct the VideoBlock code (#38012)

### DIFF
--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -118,8 +118,8 @@ EXPORT_IMPORT_COURSE_DIR = 'course'
 EXPORT_IMPORT_STATIC_DIR = 'static'
 
 
-@XBlock.wants('settings', 'completion', 'i18n', 'request_cache')
-@XBlock.needs('mako', 'user')
+@XBlock.wants('settings', 'completion', 'request_cache')
+@XBlock.needs('mako', 'user', 'i18n')
 class _BuiltInVideoBlock(
         VideoFields, VideoTranscriptsMixin, VideoStudioViewHandlers, VideoStudentViewHandlers,
         EmptyDataRawMixin, XmlMixin, EditingMixin, XModuleToXBlockMixin,
@@ -280,7 +280,7 @@ class _BuiltInVideoBlock(
 
         fragment = Fragment(self.get_html(view=PUBLIC_VIEW, context=context))
         add_css_to_fragment(fragment, 'VideoBlockDisplay.css')
-        add_webpack_js_to_fragment(fragment, 'VideoBlockMain')
+        add_webpack_js_to_fragment(fragment, 'VideoBlockDisplay')
         fragment.initialize_js('Video')
         return fragment
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This is a cherry pick of https://github.com/openedx/openedx-platform/commit/8dd99defac359cf7ec68f89dbed6aab65deb58a1.

`ulmo.1` contains a rename of `VideoBlockDisplay` to `VideoBlockMain`, which resulted in the below error when attempting to deploy `ulmo.1`.

```
File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/webpack_loader/loaders.py", line 201, in get_bundle
    raise WebpackBundleLookupError(
webpack_loader.exceptions.WebpackBundleLookupError: Cannot resolve bundle VideoBlockMain.
```

The commit message of the original commit is below.

---

- Change the `i18n` service declaration from `wants` to `needs`, since the runtime must provide it for the block to function correctly.

- Update the `public_view` webpack JS reference from `VideoBlockMain` to `VideoBlockDisplay`, as all VideoBlock JS files are bundled into `VideoBlockDisplay` and `VideoBlockMain` is not referring to anything or no longer exists in the repository.

## Supporting information

See https://github.com/openedx/openedx-platform/commit/8dd99defac359cf7ec68f89dbed6aab65deb58a1.

## Testing instructions

None.

## Deadline

None.

## Other information

The error did not occur frequently because the original change was only to the public videos view handler, which is very rarely used.
