### PR TITLE
chore: update enterprise-integrated-channels to 0.1.61

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -563,7 +563,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-enterprise-integrated-channels==0.1.60
+enterprise-integrated-channels==0.1.61
     # via -r requirements/edx/bundled.in
 event-tracking==3.3.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -875,7 +875,7 @@ enmerkar-underscore==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-enterprise-integrated-channels==0.1.60
+enterprise-integrated-channels==0.1.61
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -653,7 +653,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.60
+enterprise-integrated-channels==0.1.61
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -676,7 +676,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.60
+enterprise-integrated-channels==0.1.61
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via


### PR DESCRIPTION
Bump enterprise-integrated-channels 0.1.60 → 0.1.61 (moves integrated-channels structured-logging config into the library; replaces the closed #357).
Draft — depends on the 0.1.61 release (openedx/enterprise-integrated-channels#172); CI stays red until it's published to PyPI, then mark ready for review.