### PR TITLE
fix: add conditional decorator for meilisearch in course import signals

### DIFF
--- a/openedx/core/djangoapps/content/search/handlers.py
+++ b/openedx/core/djangoapps/content/search/handlers.py
@@ -334,6 +334,7 @@ def library_container_deleted(**kwargs) -> None:
 
 
 @receiver([COURSE_IMPORT_COMPLETED, COURSE_RERUN_COMPLETED])
+@only_if_meilisearch_enabled
 def handle_reindex_on_signal(**kwargs):
     """
     Automatically update Meiliesearch index for course in database on new import or rerun.


### PR DESCRIPTION
`handle_reindex_on_signal` was missing the `@only_if_meilisearch_enabled` guard, causing `upsert_course_blocks_docs` to be dispatched on every course import/rerun even when Meilisearch is not configured, resulting in a `RuntimeError` on every task invocation.

## Fix

Added the `@only_if_meilisearch_enabled` decorator to `handle_reindex_on_signal`, consistent with all other signal handlers.

**JIRA:** https://2u-internal.atlassian.net/browse/LP-829