### PR TITLE
fix: support optional user ID and username export for LTI mapping

### DIFF
--- a/openedx/core/djangoapps/external_user_ids/management/commands/generate_lti_id_mapping.py
+++ b/openedx/core/djangoapps/external_user_ids/management/commands/generate_lti_id_mapping.py
@@ -6,9 +6,8 @@ This is useful when a partner is migrating from LTI 1.1 to LTI 1.3 and needs to
 match their existing per-user data (keyed by the LTI 1.1 hash) to the new LTI 1.3
 UUID that edX will send after the switch.
 
-Use ``--include-user-id`` to also export the Open edX user ID that was eligible
-to be sent as the optional LTI 1.1 ``lis_person_sourcedid`` parameter. User ID
-output contains PII and must be written to a file.
+Use ``--include-user-id`` to also export the Open edX user ID and username.
+This output contains PII and must be written to a file.
 
 Usage:
     ./manage.py lms generate_lti_id_mapping \\
@@ -28,7 +27,8 @@ Output columns:
     lti_13_uuid  - The UUID sent to LTI 1.3 tools (from the ExternalId table)
     course       - The course key
     lti_11_hash  - The anonymous user ID sent to LTI 1.1 tools (from AnonymousUserId)
-    lti_11_user_id - Optional PII column containing auth_user.username
+    lti_11_user_id - Optional PII column containing auth_user.id
+    lti_11_username - Optional PII column containing auth_user.username
 """
 
 import csv
@@ -81,8 +81,9 @@ class Command(BaseCommand):
             action='store_true',
             dest='include_user_id',
             help=(
-                'Include auth_user.username as lti_11_user_id. This value is PII '
-                'and requires --output.'
+                'Include auth_user.id as lti_11_user_id and auth_user.username '
+                'as lti_11_username. These values are PII '
+                'and require --output.'
             ),
         )
 
@@ -104,14 +105,14 @@ class Command(BaseCommand):
             writer = csv.writer(output_file)
             header = ['lti_13_uuid', 'course', 'lti_11_hash']
             if include_user_id:
-                header.append('lti_11_user_id')
+                header.extend(['lti_11_user_id', 'lti_11_username'])
             writer.writerow(header)
 
             # Single JOIN query at the DB level — no loops, no N+1.
             # Streams results in chunks of 1000 to keep memory flat.
             #
-            # User ID is selected only when explicitly requested. No email,
-            # name, or internal numeric user ID is selected or written to the output.
+            # User ID and username are selected only when explicitly requested.
+            # No email or name is selected or written to the output.
             #
             # De-duplicate: in rare cases a user may have multiple
             # AnonymousUserId rows per (user, course) due to historical
@@ -133,7 +134,7 @@ class Command(BaseCommand):
                 'anonymous_user_id',
             ]
             if include_user_id:
-                selected_fields.append('user__username')
+                selected_fields.extend(['user__id', 'user__username'])
 
             rows = (
                 AnonymousUserId.objects.filter(
@@ -152,7 +153,7 @@ class Command(BaseCommand):
                     row['anonymous_user_id'],
                 ]
                 if include_user_id:
-                    output_row.append(row['user__username'])
+                    output_row.extend([row['user__id'], row['user__username']])
                 writer.writerow(output_row)
                 row_count += 1
 

--- a/openedx/core/djangoapps/external_user_ids/management/commands/generate_lti_id_mapping.py
+++ b/openedx/core/djangoapps/external_user_ids/management/commands/generate_lti_id_mapping.py
@@ -6,8 +6,8 @@ This is useful when a partner is migrating from LTI 1.1 to LTI 1.3 and needs to
 match their existing per-user data (keyed by the LTI 1.1 hash) to the new LTI 1.3
 UUID that edX will send after the switch.
 
-Use ``--include-username`` to also export the Open edX username that was eligible
-to be sent as the optional LTI 1.1 ``lis_person_sourcedid`` parameter. Username
+Use ``--include-user-id`` to also export the Open edX user ID that was eligible
+to be sent as the optional LTI 1.1 ``lis_person_sourcedid`` parameter. User ID
 output contains PII and must be written to a file.
 
 Usage:
@@ -21,14 +21,14 @@ Usage:
         course-v1:BerkeleyX+Data88.1EX+3T2025 \\
         course-v1:BerkeleyX+Data88.2EX+3T2025 \\
         course-v1:BerkeleyX+Data88.3EX+3T2025 \\
-        --include-username \\
-        --output berkeley_lti_username_mapping.csv
+        --include-user-id \\
+        --output berkeley_lti_user_id_mapping.csv
 
 Output columns:
     lti_13_uuid  - The UUID sent to LTI 1.3 tools (from the ExternalId table)
     course       - The course key
     lti_11_hash  - The anonymous user ID sent to LTI 1.1 tools (from AnonymousUserId)
-    lti_11_username - Optional PII column containing auth_user.username
+    lti_11_user_id - Optional PII column containing auth_user.username
 """
 
 import csv
@@ -77,10 +77,11 @@ class Command(BaseCommand):
             help='Path to write the CSV file. Defaults to stdout.',
         )
         parser.add_argument(
-            '--include-username',
+            '--include-user-id',
             action='store_true',
+            dest='include_user_id',
             help=(
-                'Include auth_user.username as lti_11_username. This value is PII '
+                'Include auth_user.username as lti_11_user_id. This value is PII '
                 'and requires --output.'
             ),
         )
@@ -88,11 +89,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         course_keys = options['course_keys']
         output_path = options['output']
-        include_username = options['include_username']
+        include_user_id = options['include_user_id']
 
-        if include_username and not output_path:
+        if include_user_id and not output_path:
             raise CommandError(
-                '--output is required when --include-username is used because the CSV contains PII.'
+                '--output is required when --include-user-id is used because the CSV contains PII.'
             )
 
         output_file = self.stdout
@@ -102,15 +103,15 @@ class Command(BaseCommand):
         try:
             writer = csv.writer(output_file)
             header = ['lti_13_uuid', 'course', 'lti_11_hash']
-            if include_username:
-                header.append('lti_11_username')
+            if include_user_id:
+                header.append('lti_11_user_id')
             writer.writerow(header)
 
             # Single JOIN query at the DB level — no loops, no N+1.
             # Streams results in chunks of 1000 to keep memory flat.
             #
-            # Username is selected only when explicitly requested. No email,
-            # name, or internal user ID is selected or written to the output.
+            # User ID is selected only when explicitly requested. No email,
+            # name, or internal numeric user ID is selected or written to the output.
             #
             # De-duplicate: in rare cases a user may have multiple
             # AnonymousUserId rows per (user, course) due to historical
@@ -131,7 +132,7 @@ class Command(BaseCommand):
                 'course_id',
                 'anonymous_user_id',
             ]
-            if include_username:
+            if include_user_id:
                 selected_fields.append('user__username')
 
             rows = (
@@ -150,7 +151,7 @@ class Command(BaseCommand):
                     str(row['course_id']),
                     row['anonymous_user_id'],
                 ]
-                if include_username:
+                if include_user_id:
                     output_row.append(row['user__username'])
                 writer.writerow(output_row)
                 row_count += 1

--- a/openedx/core/djangoapps/external_user_ids/management/commands/generate_lti_id_mapping.py
+++ b/openedx/core/djangoapps/external_user_ids/management/commands/generate_lti_id_mapping.py
@@ -6,8 +6,9 @@ This is useful when a partner is migrating from LTI 1.1 to LTI 1.3 and needs to
 match their existing per-user data (keyed by the LTI 1.1 hash) to the new LTI 1.3
 UUID that edX will send after the switch.
 
-Use ``--include-user-id`` to also export the Open edX user ID and username.
-This output contains PII and must be written to a file.
+Use ``--include-user-id`` to also export the Open edX user ID, and
+``--include-username`` to also export the Open edX username. This output
+contains PII and must be written to a file.
 
 Usage:
     ./manage.py lms generate_lti_id_mapping \\
@@ -21,6 +22,7 @@ Usage:
         course-v1:BerkeleyX+Data88.2EX+3T2025 \\
         course-v1:BerkeleyX+Data88.3EX+3T2025 \\
         --include-user-id \\
+        --include-username \\
         --output berkeley_lti_user_id_mapping.csv
 
 Output columns:
@@ -81,9 +83,17 @@ class Command(BaseCommand):
             action='store_true',
             dest='include_user_id',
             help=(
-                'Include auth_user.id as lti_11_user_id and auth_user.username '
-                'as lti_11_username. These values are PII '
-                'and require --output.'
+                'Include auth_user.id as lti_11_user_id. This value is PII '
+                'and requires --output.'
+            ),
+        )
+        parser.add_argument(
+            '--include-username',
+            action='store_true',
+            dest='include_username',
+            help=(
+                'Include auth_user.username as lti_11_username. This value is PII '
+                'and requires --output.'
             ),
         )
 
@@ -91,10 +101,11 @@ class Command(BaseCommand):
         course_keys = options['course_keys']
         output_path = options['output']
         include_user_id = options['include_user_id']
+        include_username = options['include_username']
 
-        if include_user_id and not output_path:
+        if (include_user_id or include_username) and not output_path:
             raise CommandError(
-                '--output is required when --include-user-id is used because the CSV contains PII.'
+                '--output is required when exporting user ID or username because the CSV contains PII.'
             )
 
         output_file = self.stdout
@@ -105,7 +116,9 @@ class Command(BaseCommand):
             writer = csv.writer(output_file)
             header = ['lti_13_uuid', 'course', 'lti_11_hash']
             if include_user_id:
-                header.extend(['lti_11_user_id', 'lti_11_username'])
+                header.append('lti_11_user_id')
+            if include_username:
+                header.append('lti_11_username')
             writer.writerow(header)
 
             # Single JOIN query at the DB level — no loops, no N+1.
@@ -134,7 +147,9 @@ class Command(BaseCommand):
                 'anonymous_user_id',
             ]
             if include_user_id:
-                selected_fields.extend(['user__id', 'user__username'])
+                selected_fields.append('user__id')
+            if include_username:
+                selected_fields.append('user__username')
 
             rows = (
                 AnonymousUserId.objects.filter(
@@ -153,7 +168,9 @@ class Command(BaseCommand):
                     row['anonymous_user_id'],
                 ]
                 if include_user_id:
-                    output_row.extend([row['user__id'], row['user__username']])
+                    output_row.append(row['user__id'])
+                if include_username:
+                    output_row.append(row['user__username'])
                 writer.writerow(output_row)
                 row_count += 1
 


### PR DESCRIPTION
This PR updates the `generate_lti_id_mapping` management command to optionally include additional user identifiers for the Berkeley LTI 1.1 to LTI 1.3 migration.

The existing default CSV output remains unchanged:

```text
lti_13_uuid,course,lti_11_hash
```

Two new optional arguments are added:

```text
--include-user-id
--include-username
```

Behavior:

`--include-user-id` adds `lti_11_user_id`, sourced from `auth_user.id`.

`--include-username` adds `lti_11_username`, sourced from `auth_user.username`.

If both arguments are passed, both columns are included:

```text
lti_13_uuid,course,lti_11_hash,lti_11_user_id,lti_11_username
```

Because these additional fields contain PII, the command requires `--output` when either option is used.

Related ticket: LP-845.

SRE ticket to rerun the script - https://2u-internal.atlassian.net/browse/GSRE-4125