### PR TITLE
feat: replace enterprise_customer_for_request with CourseModePriceRequested filter

### DIFF
--- a/common/djangoapps/course_modes/helpers.py
+++ b/common/djangoapps/course_modes/helpers.py
@@ -84,7 +84,12 @@ def _enrollment_mode_display(enrollment_mode, course_id):
 
 def get_course_final_price(user, sku, course_price):
     """
-    Return the course's discounted price for a user if user is eligible for any otherwise return course original price.
+    Return the course's discounted price for a user (if eligible), otherwise return course original price.
+
+    Note: this function is no longer called directly within edx-platform. It is called externally
+    via the openedx-filters pipeline, by edx-enterprise's CalculateEnterpriseDiscountedPrice
+    step (org.openedx.learning.course_mode.price.requested.v1). Do not delete this function even
+    though static analysis may flag it as unused here.
     """
     price_details = {}
     try:

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -183,38 +183,62 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         # TODO: Fix it so that response.templates works w/ mako templates, and then assert
         # that the right template rendered
 
-    @httpretty.activate
-    @patch('common.djangoapps.course_modes.views.enterprise_customer_for_request')
-    @patch('common.djangoapps.course_modes.views.get_course_final_price')
+    @patch('openedx_filters.learning.filters.CourseModePriceRequested.run_filter')
     @ddt.data(
-        (1.0, True),
-        (50.0, False),
-        (0.0, True),
-        (None, False),
+        (100, 149, True),    # discounted_price, base_price, has_discount
+        (149, 149, False),   # no discount
+        (50, 149, True),     # significant discount
+        (0, 149, True),      # free course
     )
     @ddt.unpack
     def test_display_after_discounted_price(
         self,
         discounted_price,
-        is_enterprise_enabled,
-        mock_get_course_final_price,
-        mock_enterprise_customer_for_request
+        base_price,
+        has_discount,
+        mock_run_filter,
     ):
-        verified_mode = CourseModeFactory.create(mode_slug='verified', course_id=self.course.id, sku='dummy')
+        """
+        Test that the discounted price is displayed when an enterprise customer applies a discount.
+
+        The discounted price is calculated through the CourseModePriceRequested filter,
+        which invokes the CalculateEnterpriseDiscountedPrice pipeline step from edx-enterprise.
+        """
+        verified_mode = CourseModeFactory.create(
+            mode_slug='verified',
+            course_id=self.course.id,
+            sku='dummy',
+            min_price=base_price,
+        )
         CourseEnrollmentFactory(
             is_active=True,
             course_id=self.course.id,
             user=self.user
         )
 
-        mock_enterprise_customer_for_request.return_value = {'name': 'dummy'} if is_enterprise_enabled else {}
-        mock_get_course_final_price.return_value = discounted_price
+        # Capture the actual call and verify it was made
+        mock_run_filter.return_value = (self.user, verified_mode, discounted_price)
+
         url = reverse('course_modes_choose', args=[self.course.id])
         response = self.client.get(url)
 
-        if is_enterprise_enabled:
-            self.assertContains(response, discounted_price)
-        self.assertContains(response, verified_mode.min_price)
+        # Verify the filter was called with correct user and price
+        assert mock_run_filter.called
+        call_args = mock_run_filter.call_args
+        assert call_args.kwargs['user'] == self.user
+        assert call_args.kwargs['price'] == base_price
+        # The course_mode_data should be a Mode object with the verified mode's slug
+        assert call_args.kwargs['course_mode_data'].slug == 'verified'
+
+        # Verify the response is successful
+        assert response.status_code == 200
+
+        # The discounted price should always be displayed
+        self.assertContains(response, str(discounted_price))
+
+        # When there's a discount, the original price should be used as the "contribution" value
+        if has_discount:
+            self.assertContains(response, f'name="contribution" value="{base_price}"')
 
     @ddt.data('professional', 'no-id-professional')
     def test_professional_enrollment(self, mode):

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -23,10 +23,11 @@ from django.utils.translation import gettext as _
 from django.views.generic.base import View
 from edx_django_utils.monitoring.utils import increment
 from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import CourseModePriceRequested
 from urllib.parse import urljoin  # lint-amnesty, pylint: disable=wrong-import-order
 
 from common.djangoapps.course_modes.models import CourseMode
-from common.djangoapps.course_modes.helpers import get_course_final_price, get_verified_track_links
+from common.djangoapps.course_modes.helpers import get_verified_track_links
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.util.date_utils import strftime_localized_html
 from lms.djangoapps.commerce.utils import EcommerceService
@@ -39,7 +40,6 @@ from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_duration_limits.access import get_user_course_duration, get_user_course_expiration_date
 from openedx.features.course_experience import course_home_url
-from openedx.features.enterprise_support.api import enterprise_customer_for_request
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.util.db import outer_atomic
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -187,15 +187,14 @@ class ChooseModeView(View):
                 if x.strip()
             ]
             price_before_discount = verified_mode.min_price
-            course_price = price_before_discount
-            enterprise_customer = enterprise_customer_for_request(request)
-            LOG.info(
-                '[e-commerce calculate API] Going to hit the API for user [%s] linked to [%s] enterprise',
-                request.user.username,
-                enterprise_customer.get('name') if isinstance(enterprise_customer, dict) else None  # Test Purpose
+            # this filter applies discounts (e.g. enterprise-negotiated pricing) to the price
+            # .. filter_implemented_name: CourseModePriceRequested
+            # .. filter_type: org.openedx.learning.course_mode.price.requested.v1
+            _, _, course_price = CourseModePriceRequested.run_filter(
+                user=request.user,
+                course_mode_data=verified_mode,
+                price=price_before_discount,
             )
-            if enterprise_customer and verified_mode.sku:
-                course_price = get_course_final_price(request.user, verified_mode.sku, price_before_discount)
 
             context["currency"] = verified_mode.currency.upper()
             context["currency_symbol"] = get_currency_symbol(verified_mode.currency.upper())

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -829,7 +829,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1375,7 +1375,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1001,7 +1001,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1046,7 +1046,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Remove direct enterprise_support import from course_modes/views.py and replace with a call to the [CourseModePriceRequested openedx-filter](https://github.com/openedx/openedx-filters/blob/bc56224e79bc0a98dd5d86f09590e6b64655a120/openedx_filters/learning/filters.py#L1895).

https://2u-internal.atlassian.net/browse/ENT-11573

openedx-filters [#338](https://github.com/openedx/openedx-filters/pull/376) — CourseModePriceRequested filter definition
edx-enterprise [#2556](https://github.com/openedx/edx-enterprise/pull/2556) — CalculateEnterpriseDiscountedPrice pipeline step
edx-platform [#365](https://github.com/edx/edx-platform/pull/365) — view wired to invoke the filter

## Testing instructions

E2E testing instructions detailed in the [edx-enterprise PR](https://github.com/openedx/edx-enterprise/pull/2556)
