### PR TITLE
fix: filter edx_toggles no-request warning inside Celery tasks

### DIFF
--- a/openedx/core/djangoapps/util/signals.py
+++ b/openedx/core/djangoapps/util/signals.py
@@ -6,11 +6,49 @@ Signal handler for exceptions.
 
 import logging
 
+from celery import current_task
 from celery.signals import task_postrun
 from django.conf import settings
 from django.core.signals import got_request_exception
 from django.dispatch import receiver
 from edx_django_utils.cache import RequestCache
+
+
+class _SuppressToggleNoRequestWarningInTasks(logging.Filter):
+    """
+    edx_toggles logs a WARNING whenever a CourseWaffleFlag/WaffleFlag is checked
+    with no request bound (see
+    edx_toggles.toggles.internal.waffle.flag._get_flag_active_no_request). That's
+    expected and harmless inside a Celery task, since tasks are invoked off a
+    queue and never have an HTTP request attached.
+
+    This drops only that specific message, and only when `celery.current_task`
+    confirms we're actually executing inside a task right now - every other
+    message from this logger, and this same message when it fires outside of a
+    task (a genuine signal something is wrong), is left untouched.
+
+    Implemented as a per-record filter, evaluated fresh on every log call,
+    rather than toggling the logger's level around task_prerun/task_postrun:
+    that approach relied on shared module state, which isn't safe across
+    concurrently running tasks under non-prefork execution pools (e.g.
+    eventlet/gevent/threads), and would have hidden every message from this
+    logger - not just this one - for the duration of any task.
+    """
+
+    MESSAGE_FRAGMENT = "accessed without a request"
+
+    def filter(self, record):
+        # `current_task` is a celery Proxy, not the actual task object - it is
+        # never literally `None` even when unbound, so check its truthiness
+        # rather than `is not None`.
+        if self.MESSAGE_FRAGMENT in record.getMessage() and current_task:
+            return False
+        return True
+
+
+logging.getLogger('edx_toggles.toggles.internal.waffle.flag').addFilter(
+    _SuppressToggleNoRequestWarningInTasks()
+)
 
 
 @receiver(got_request_exception)

--- a/openedx/core/djangoapps/util/tests/test_signals.py
+++ b/openedx/core/djangoapps/util/tests/test_signals.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-member, missing-docstring
 
 
+import logging
 from unittest import TestCase
 from pytest import mark
 
@@ -26,3 +27,37 @@ class TestClearRequestCache(TestCase):
     def test_clear_cache_celery(self):
         self._dummy_task.apply(args=(self,)).get()
         assert not self._get_cache().get_cached_response('cache_key').is_found
+
+
+class TestSuppressToggleNoRequestWarningInTasks(TestCase):
+    """
+    Tests that the "accessed without a request" toggle warning is dropped only
+    when logged from inside a celery task, and only that specific message -
+    every other message from the same logger, and this message when logged
+    outside of a task, must still go through.
+    """
+    logger = logging.getLogger('edx_toggles.toggles.internal.waffle.flag')
+
+    @shared_task
+    def _dummy_task(self):
+        """ A task that logs the same warning edx_toggles would log with no request bound. """
+        self.logger.warning("Flag 'some.flag' accessed without a request, which is likely in the context of a celery task.")  # pylint: disable=line-too-long
+        self.logger.warning("some other warning text")
+
+    def test_warning_dropped_inside_task(self):
+        with self.assertLogs(self.logger, level='WARNING') as captured:
+            self._dummy_task.apply(args=(self,)).get()
+            # The matching warning is dropped; an unrelated message from the
+            # same logger still goes through untouched.
+            self.logger.warning("marker so assertLogs has something to capture")
+        messages = [record.getMessage() for record in captured.records]
+        assert "some other warning text" in messages
+        assert not any("accessed without a request" in message for message in messages)
+
+    def test_warning_not_dropped_outside_task(self):
+        with self.assertLogs(self.logger, level='WARNING') as captured:
+            self.logger.warning(
+                "Flag 'some.flag' accessed without a request, which is likely in the context of a celery task."
+            )
+        messages = [record.getMessage() for record in captured.records]
+        assert any("accessed without a request" in message for message in messages)

--- a/openedx/core/djangoapps/util/tests/test_signals.py
+++ b/openedx/core/djangoapps/util/tests/test_signals.py
@@ -38,7 +38,11 @@ class TestSuppressToggleNoRequestWarningInTasks(TestCase):
     """
     logger = logging.getLogger('edx_toggles.toggles.internal.waffle.flag')
 
-    @shared_task
+    # shared_task derives its registered name from the plain function name
+    # only, not the enclosing class - an unqualified name here would collide
+    # with TestClearRequestCache._dummy_task above, since both would register
+    # as "_dummy_task" in celery's global task registry.
+    @shared_task(name='test_signals.suppress_toggle_warning_dummy_task')
     def _dummy_task(self):
         """ A task that logs the same warning edx_toggles would log with no request bound. """
         self.logger.warning("Flag 'some.flag' accessed without a request, which is likely in the context of a celery task.")  # pylint: disable=line-too-long


### PR DESCRIPTION
**Problem**: When feature flags are accessed inside Celery tasks (where no HTTP request exists), edx_toggles logs noisy warnings like “accessed without a request.” These warnings are expected in background jobs but clutter logs and make it harder to spot real issues.
**Changes**: This change filters the edx_toggles “accessed without a request” warning when it originates from Celery task execution. It ensures the warning is suppressed only in task context while allowing all other log messages to pass through unchanged.
**jira_link** : [LP-866](https://2u-internal.atlassian.net/browse/LP-866?search_id=6f61f1a0-bee7-4f50-9fb6-56930e64e315)