### PR TITLE
fix: honor YAML SEARCH_ENGINE override in production settings for LMS and CMS for meilisearch

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -286,8 +286,8 @@ EVENT_TRACKING_BACKENDS['segmentio']['OPTIONS']['processors'][0]['OPTIONS']['whi
 
 
 if ENABLE_COURSEWARE_INDEX or ENABLE_LIBRARY_INDEX:
-    # Use ElasticSearch for the search engine
-    SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+    # Default to ElasticSearch, but honor explicit SEARCH_ENGINE overrides from YAML.
+    SEARCH_ENGINE = _YAML_TOKENS.get('SEARCH_ENGINE', "search.elastic.ElasticSearchEngine")
 
 # TODO: Once we have successfully upgraded to ES7, switch this back to ELASTIC_SEARCH_CONFIG.
 ELASTIC_SEARCH_CONFIG = _YAML_TOKENS.get('ELASTIC_SEARCH_CONFIG_ES7', [{}])

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -331,8 +331,8 @@ if (
    ENABLE_COURSE_DISCOVERY or
    ENABLE_TEAMS
    ):
-    # Use ElasticSearch as the search engine herein
-    SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+    # Default to ElasticSearch, but honor explicit SEARCH_ENGINE overrides from YAML.
+    SEARCH_ENGINE = _YAML_TOKENS.get('SEARCH_ENGINE', "search.elastic.ElasticSearchEngine")
 
 # TODO: Once we have successfully upgraded to ES7, switch this back to ELASTIC_SEARCH_CONFIG.
 ELASTIC_SEARCH_CONFIG = _YAML_TOKENS.get('ELASTIC_SEARCH_CONFIG_ES7', [{}])


### PR DESCRIPTION
## Summary

This change fixes a configuration precedence issue where the production settings always selected Elasticsearch, even when the stage configuration explicitly specified Meilisearch.

## Problem

The production settings hardcoded `SEARCH_ENGINE` to Elasticsearch whenever the search/index feature flags were enabled. As a result, the runtime configuration could end up in an inconsistent state:

```text
MEILISEARCH_ENABLED = True
MEILISEARCH_URL = <configured>
SEARCH_ENGINE = search.elastic.ElasticSearchEngine
```

## Changes

Updated both production settings modules to prioritize the `SEARCH_ENGINE` value from the YAML configuration, while retaining Elasticsearch as the default fallback.

### Modified files

- `production.py` (line 335) - LMS
- `production.py` (line 290) - CMS

### New Logic

```python
SEARCH_ENGINE = _YAML_TOKENS.get(
    "SEARCH_ENGINE",
    "search.elastic.ElasticSearchEngine",
)
```

## Result

- If `SEARCH_ENGINE` is explicitly defined in the stage YAML configuration, that value is used.
- If `SEARCH_ENGINE` is not defined, the application continues to default to Elasticsearch.

## Why this is safe

-  Maintains backward compatibility by keeping Elasticsearch as the default.
-  Only changes behavior when `SEARCH_ENGINE` is explicitly configured in YAML.
-  Does not modify Meilisearch feature flags or URL handling logic.
-  Existing deployments that do not override `SEARCH_ENGINE` remain unaffected.

Jira : https://2u-internal.atlassian.net/browse/GSRE-3887