### PR TITLE
fix: sanitize periods in HTML IDs for staff modals

### DIFF
--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -106,9 +106,9 @@ class TestXblockUtils(SharedModuleStoreTestCase):
 
     def test_sanitize_html_id(self):
         """
-        Verify that colons and dashes are replaced.
+        Verify that colons, dashes, and periods are replaced.
         """
-        dirty_string = 'I:have-un:allowed_characters'
+        dirty_string = 'I:have-un:allowed.characters'
         clean_string = sanitize_html_id(dirty_string)
 
         assert clean_string == 'I_have_un_allowed_characters'

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -255,9 +255,11 @@ def grade_histogram(block_id):
 
 def sanitize_html_id(html_id):
     """
-    Template uses element_id in js function names, so can't allow dashes and colons.
+    Template uses element_id in js function names, and as a raw (unescaped) jQuery/CSS
+    ID selector (e.g. leanModal's `$(anchor.attr('href'))`), so it can't contain
+    dashes, colons, or periods.
     """
-    sanitized_html_id = re.sub(r'[:-]', '_', html_id)
+    sanitized_html_id = re.sub(r'[:\-.]', '_', html_id)
     return sanitized_html_id
 
 


### PR DESCRIPTION
**Problem:** Staff debug info button does not work on EPFLx+drug-discovery (Introduction to Drug Discovery)

**Root cause**
Some older/imported XBlocks can have block IDs containing periods (.), for example question_1.4.100. These IDs are used to generate the HTML IDs for the staff tooling modals (Staff Debug Info, Submission History, and QA).

The staff tooling uses the generated IDs directly as jQuery/CSS selectors through LeanModal. Since periods are interpreted as CSS selector syntax rather than literal characters, the selector fails to locate the modal element. As a result, clicking Staff Debug Info dims the page but the modal never appears.

Newly created or duplicated XBlocks are not affected because they receive auto-generated alphanumeric IDs (UUIDs), which do not contain periods.

**Solution**
Extend sanitize_html_id() to replace periods (.) with underscores (_) in addition to the characters it already sanitizes (: and -).

This ensures that all HTML IDs generated for staff tooling are safe to use as unescaped jQuery/CSS selectors, allowing the Staff Debug Info, Submission History, and QA modals to open correctly for XBlocks regardless of how their block IDs were originally created.

**before fix:**

<img width="956" height="527" alt="image" src="https://github.com/user-attachments/assets/16dcceb1-3c52-450c-97ca-51f65d89ed59" />

**after fix:** 

<img width="956" height="527" alt="image" src="https://github.com/user-attachments/assets/d86634d8-839c-422e-bfb4-cdbef08a25b8" />



**jira_link:** https://2u-internal.atlassian.net/browse/LP-849