### PR TITLE
fix: correct load more button visibility for discussion responses

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1685,6 +1685,7 @@ def get_comment_list(
             "response_limit": page_size,
             "reverse_order": reverse_order,
             "merge_question_type_responses": merge_question_type_responses,
+            "show_deleted": show_deleted,
         },
     )
     # Responses to discussion threads cannot be separated by endorsed, but
@@ -2317,17 +2318,11 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
                 response_comments = response["children"]
                 break
 
-        response_skip = page_size * (page - 1)
-        paged_response_comments = response_comments[
-            response_skip: (response_skip + page_size)
-        ]
-        if not paged_response_comments and page != 1:
-            raise PageNotFoundError("Page not found (No results on this page).")
-
+        # Filter deleted content from the FULL list first
         if not show_deleted:
-            paged_response_comments = [
+            response_comments = [
                 response
-                for response in paged_response_comments
+                for response in response_comments
                 if not response.get("is_deleted", False)
             ]
         else:
@@ -2336,13 +2331,30 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
                     "`show_deleted` can only be set by users with moderation roles."
                 )
 
-        # Apply muting filter if not including muted content
+        # Filter muted content from the FULL list
+        include_muted = request.GET.get("include_muted", False)
+        include_muted = include_muted in ["true", "True", True]
         if not include_muted:
-            paged_response_comments = filter_muted_content(
+            response_comments = filter_muted_content(
                 request.user,
                 context["course"].id,
-                paged_response_comments
+                response_comments
             )
+
+        # NOW calculate pagination based on FILTERED total
+        total_comments_count = len(response_comments)
+        num_pages = (
+            (total_comments_count + page_size - 1) // page_size
+            if total_comments_count else 1
+        )
+
+        # Then paginate the filtered list
+        response_skip = page_size * (page - 1)
+        paged_response_comments = response_comments[
+            response_skip: (response_skip + page_size)
+        ]
+        if not paged_response_comments and page != 1:
+            raise PageNotFoundError("Page not found (No results on this page).")
 
         results = _serialize_discussion_entities(
             request,
@@ -2352,11 +2364,6 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
             DiscussionEntity.comment,
         )
 
-        total_comments_count = len(response_comments)
-        num_pages = (
-            (total_comments_count + page_size - 1) // page_size
-            if total_comments_count else 1
-        )
         paginator = DiscussionAPIPagination(
             request, page, num_pages, total_comments_count
         )

--- a/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
@@ -4025,6 +4025,7 @@ class GetCommentListTest(
                 "with_responses": True,
                 "reverse_order": False,
                 "merge_question_type_responses": False,
+                "show_deleted": False,
             },
             "course_id": str(self.course.id),
         }

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -216,6 +216,7 @@ class Thread(models.Model):
             "merge_question_type_responses": kwargs.get(
                 "merge_question_type_responses", False
             ),
+            "show_deleted": kwargs.get("show_deleted"),
         }
         request_params = utils.clean_forum_params(request_params)
         course_id = kwargs.get("course_id")


### PR DESCRIPTION
## Summary

Fixes an issue where the **"Load more responses"** button remained visible even after all responses were loaded.

## Changes

- Updated the discussion responses API to return the correct pagination state.
- Hide the **"Load more responses"** button when no additional responses are available.

## Testing

- Verified the button is shown only when more responses exist.
- Verified it is hidden after all responses are loaded.

## Related PR
[edx/forum](https://github.com/edx/forum/pull/60)

## Ticket
[LP-933](https://2u-internal.atlassian.net/browse/LP-933)