### PR TITLE
fix: contract course asset URLs to /static/ before saving xblock data (LP-704)

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -1948,6 +1948,32 @@ class TestEditItem(TestEditItemSetup):
     Test xblock update.
     """
 
+    def test_data_saved_with_portable_static_urls(self):
+        """
+        Absolute asset URLs referencing this course's assets must be contracted
+        to the portable /static/ form before persisting, so re-runs and
+        export/import don't break them when an editor fails to contract.
+        """
+        asset_key = self.course.id.make_asset_key('asset', 'textlog.html')
+        self.client.ajax_post(
+            self.problem_update_url,
+            data={'data': f'<problem><jsinput html_file="/{asset_key}" gradefn="getGrade"/></problem>'},
+        )
+        problem = self.get_item_from_modulestore(self.problem_usage_key)
+        self.assertIn('html_file="/static/textlog.html"', problem.data)
+
+    def test_data_preserves_other_courses_asset_urls(self):
+        """
+        Asset URLs referencing another course's assets are not ours to rewrite.
+        """
+        foreign_url = '/asset-v1:OtherX+Other+1T2020+type@asset+block@textlog.html'
+        self.client.ajax_post(
+            self.problem_update_url,
+            data={'data': f'<problem><jsinput html_file="{foreign_url}" gradefn="getGrade"/></problem>'},
+        )
+        problem = self.get_item_from_modulestore(self.problem_usage_key)
+        self.assertIn(f'html_file="{foreign_url}"', problem.data)
+
     def test_delete_field(self):
         """
         Sending null in for a field 'deletes' it

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -42,7 +42,7 @@ from cms.lib.ai_aside_summary_config import AiAsideSummaryConfig
 from cms.lib.xblock.upstream_sync import BadUpstream, UpstreamLink
 from cms.lib.xblock.upstream_sync_block import sync_from_upstream_block
 from cms.lib.xblock.upstream_sync_container import sync_from_upstream_container
-from common.djangoapps.static_replace import replace_static_urls
+from common.djangoapps.static_replace import contract_static_urls, replace_static_urls
 from common.djangoapps.student.auth import (
     has_studio_read_access,
     has_studio_write_access,
@@ -353,6 +353,11 @@ def _save_xblock(
         old_content = xblock.get_explicitly_set_fields_by_scope(Scope.content)
 
         if data:
+            if isinstance(data, str):
+                # Editors receive `data` with /static/ URLs expanded (see get_block_info)
+                # and don't all contract them back on save; contract here so URLs pinned
+                # to this course are never persisted (they break on re-run/export/import).
+                data = contract_static_urls(data, xblock.location.course_key)
             # TODO Allow any scope.content fields not just "data" (exactly like the get below this)
             xblock.data = data
         else:

--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import uuid
 
 from django.conf import settings
 from django.contrib.staticfiles import finders
@@ -240,3 +241,51 @@ def replace_static_urls(
         return "".join([quote, url, quote])
 
     return process_static_urls(text, replace_static_url, data_dir=static_asset_path or data_directory)
+
+
+def contract_static_urls(text, course_id):
+    """
+    Reverse of `replace_static_urls` for a course's own assets: rewrite absolute
+    asset URLs referencing ``course_id``'s assets back to the portable
+    ``/static/<name>`` form.
+
+    Handles every form `StaticContent.get_canonicalized_asset_path` can emit:
+    relative (``/asset-v1:...@name`` or ``.../name``), versioned
+    (``/assets/courseware/v1/<digest>/asset-v1:...``), host-qualified
+    (``https://host/asset-v1:...``), and old-style ``/c4x/...`` paths.
+
+    URLs referencing other courses' assets, genuinely external URLs, and
+    already-portable ``/static/`` paths are left untouched.
+
+    text: The source text to do the substitution in
+    course_id: The course whose asset URLs should be made portable
+    """
+    if not course_id or not isinstance(text, str):
+        return text
+
+    # Serialize an asset key with a placeholder name, then split it into the
+    # course-specific prefix and the separator preceding the asset name.
+    placeholder = uuid.uuid4().hex
+    serialized = str(course_id.make_asset_key('asset', placeholder))
+    name_index = serialized.rfind(placeholder)
+    key_prefix, separator = serialized[:name_index - 1], serialized[name_index - 1]
+    # Modern keys serialize with '@' before the name, but canonicalized paths
+    # may separate the name with '/' instead; accept either.
+    separator_pattern = '[@/]' if separator == '@' else re.escape(separator)
+
+    asset_url_pattern = re.compile(
+        r"""(?P<quote>\\?['"])"""                          # the opening quotes
+        r"""(?:(?:https?:)?//[^'"/]+)?"""                  # optional scheme and host
+        r"""(?:/assets/courseware/(?:v\d+/)?[a-f0-9]{32})?"""  # optional versioned-asset prefix
+        r"""/?""" + re.escape(key_prefix) + separator_pattern +
+        r"""(?P<name>[^'"?]*)"""                           # the asset name
+        r"""(?P<query>\?[^'"]*)?"""                        # optional query string
+        r"""(?P=quote)"""                                  # the first matching closing quote
+    )
+
+    def contract(match):
+        quote = match.group('quote')
+        query = match.group('query') or ''
+        return f"{quote}/static/{match.group('name')}{query}{quote}"
+
+    return asset_url_pattern.sub(contract, text)

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -15,6 +15,7 @@ from web_fragments.fragment import Fragment
 
 from common.djangoapps.static_replace import (
     _url_replace_regex,
+    contract_static_urls,
     make_static_urls_absolute,
     process_static_urls,
     replace_course_urls,
@@ -60,6 +61,71 @@ def test_multi_replace():
         replace_static_urls(replace_static_urls(STATIC_SOURCE, DATA_DIRECTORY), DATA_DIRECTORY)
     assert replace_course_urls(course_source, COURSE_KEY) == \
         replace_course_urls(replace_course_urls(course_source, COURSE_KEY), COURSE_KEY)
+
+
+SPLIT_COURSE_KEY = CourseKey.from_string('course-v1:HarvardX+BDSG+2T2022')
+
+
+def test_contract_static_urls_jsinput_html_file():
+    text = '<jsinput html_file="/asset-v1:HarvardX+BDSG+2T2022+type@asset+block@textlog.html" gradefn="getGrade"/>'
+    expected = '<jsinput html_file="/static/textlog.html" gradefn="getGrade"/>'
+    assert contract_static_urls(text, SPLIT_COURSE_KEY) == expected
+
+
+def test_contract_static_urls_versioned_asset_path():
+    text = (
+        '<img src="/assets/courseware/v1/43761bc1cc13b218d267f790ed4313d1/'
+        'asset-v1:HarvardX+BDSG+2T2022+type@asset+block/image.jpg">'
+    )
+    expected = '<img src="/static/image.jpg">'
+    assert contract_static_urls(text, SPLIT_COURSE_KEY) == expected
+
+
+def test_contract_static_urls_versioned_asset_path_without_version_segment():
+    # VERSIONED_ASSETS_PATTERN treats the v1/ segment as optional
+    text = (
+        '<img src="/assets/courseware/43761bc1cc13b218d267f790ed4313d1/'
+        'asset-v1:HarvardX+BDSG+2T2022+type@asset+block/image.jpg">'
+    )
+    expected = '<img src="/static/image.jpg">'
+    assert contract_static_urls(text, SPLIT_COURSE_KEY) == expected
+
+
+def test_contract_static_urls_host_qualified():
+    text = '<a href="https://courses.edx.org/asset-v1:HarvardX+BDSG+2T2022+type@asset+block@syllabus.pdf">Syllabus</a>'
+    expected = '<a href="/static/syllabus.pdf">Syllabus</a>'
+    assert contract_static_urls(text, SPLIT_COURSE_KEY) == expected
+
+
+def test_contract_static_urls_preserves_query_string():
+    text = '<img src="/asset-v1:HarvardX+BDSG+2T2022+type@asset+block@pic.png?width=100">'
+    expected = '<img src="/static/pic.png?width=100">'
+    assert contract_static_urls(text, SPLIT_COURSE_KEY) == expected
+
+
+def test_contract_static_urls_leaves_foreign_course_urls():
+    """URLs pointing at a different course's assets are not this course's to rewrite."""
+    text = '<img src="/asset-v1:OtherX+Other+1T2020+type@asset+block@pic.png">'
+    assert contract_static_urls(text, SPLIT_COURSE_KEY) == text
+
+
+def test_contract_static_urls_leaves_external_and_portable_urls():
+    text = '<a href="https://example.com/asset.png">x</a> <img src="/static/already.png">'
+    assert contract_static_urls(text, SPLIT_COURSE_KEY) == text
+
+
+def test_contract_static_urls_old_style_course_key():
+    text = '<img src="/c4x/org/course/asset/foo.gif">'
+    expected = '<img src="/static/foo.gif">'
+    assert contract_static_urls(text, COURSE_KEY) == expected
+
+
+def test_contract_static_urls_non_string_passthrough():
+    assert contract_static_urls(None, SPLIT_COURSE_KEY) is None
+    assert contract_static_urls('', SPLIT_COURSE_KEY) == ''
+    data = {'key': 'value'}
+    assert contract_static_urls(data, SPLIT_COURSE_KEY) is data
+    assert contract_static_urls('text', None) == 'text'
 
 
 def test_process_url():


### PR DESCRIPTION
## Description

Fixes LP-704: Studio bakes course-pinned absolute asset URLs into stored xblock content, breaking JSInput problems and images after a course re-run or export/import.

### Jira Ticket

[LP-704](https://2u-internal.atlassian.net/browse/LP-704)

### Root cause

The authoring read/write round-trip is asymmetric:

- `get_block_info` runs `replace_static_urls`, expanding portable `/static/<name>` references into absolute `asset-v1:<Org>+<Course>+<Run>+...` URLs pinned to the current course (`cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py`).
- `_save_xblock` persists the POSTed `data` verbatim — nothing contracts those URLs back.

The client editor is the only safety net, and not every editor path contracts every attribute (e.g. the course-authoring MFE misses JSInput's `html_file`). Any save through a non-contracting path permanently bakes the current course's id into storage. After a re-run, those URLs still point at the *original* course: assets 404 for learners (or silently serve stale content from the old course while it happens to be public).

### The fix

- New `contract_static_urls(text, course_id)` in `common/djangoapps/static_replace/__init__.py` — the reverse of `replace_static_urls` for a course's own assets. It contracts all forms back to `/static/<name>`:
  - `…+type@asset+block@<name>` and `…+type@asset+block/<name>`
  - host-qualified (`https://host/asset-v1:…`) and protocol-relative
  - versioned (`/assets/courseware/v1/<digest>/asset-v1:…`)
  - legacy `/c4x/<org>/<course>/asset/<name>`
  - preserves query strings; leaves other courses' asset URLs and genuine external URLs untouched.
- `_save_xblock` now runs string `data` through `contract_static_urls` before persisting, so course-pinned URLs are never stored regardless of which editor performed the save.

`rewrite_nonportable_content_links` (`store_utilities.py`) was considered for reuse but never matches split-mongo course ids — its pattern is not `re.escape`d, so the `+` separators act as regex quantifiers. That is a separate pre-existing bug.

## Testing

- 8 new unit tests in `common/djangoapps/static_replace/test/test_static_replace.py` covering all URL forms, query-string preservation, foreign-course/external URLs left untouched, and non-string passthrough.
- 2 new integration tests in `cms/djangoapps/contentstore/views/tests/test_block.py`: saving data with a baked same-course URL stores `/static/<name>`; another course's asset URL is preserved verbatim.
- Verified end to end on devstack: a JSInput problem with a baked `html_file` URL heals on the next save, and re-saving portable content no longer bakes it.

### Screenshots
#### Before 

<img width="1635" height="794" alt="Screenshot 2026-07-08 at 1 38 19 PM" src="https://github.com/user-attachments/assets/4c412f3c-6a77-48b7-8db9-c04c2c942ab4" />


#### After the fix
<img width="1645" height="833" alt="Screenshot 2026-07-08 at 1 43 05 PM" src="https://github.com/user-attachments/assets/1e1faa9c-9f4f-4bf1-9d3f-df4dc914b5af" />


Companion frontend fix: https://github.com/edx/frontend-app-authoring/pull/106
