### PR TITLE
fix: include visible notes popup in iframe height calculation

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -127,10 +127,24 @@ ${HTML(fragment.foot_html())}
       var lastWidth = window.offsetWidth;
       var contentElement = document.getElementById('content');
 
+      function getExpandedContentHeight() {
+        var baseElement = contentElement || document.body;
+        var maxHeight = baseElement.offsetHeight;
+        // Notes popups live in .annotator-widget; .annotator-outer itself has zero size.
+        // Include visible popup bounds so iframe resize does not clip the notes modal.
+        var visiblePopup = document.querySelector('.annotator-outer:not(.annotator-hide) .annotator-widget, .annotator-adder:not(.annotator-hide)');
+        if (visiblePopup) {
+          var popupBottom = visiblePopup.getBoundingClientRect().bottom;
+          maxHeight = Math.max(baseElement.offsetHeight, Math.ceil(popupBottom));
+        }
+        console.log("getting reflected")
+        return maxHeight;
+      }
+
       function dispatchResizeMessage(event) {
         // Note: event is actually an Array of MutationRecord objects when fired from the MutationObserver
         var isLoadEvent = event.type === 'load';
-        var newHeight = contentElement.offsetHeight;
+        var newHeight = getExpandedContentHeight();
         var newWidth = contentElement.offsetWidth;
         if (!isLoadEvent && newWidth === lastWidth && newHeight === lastHeight) {
             // Monitor when any anchor tag is clicked, it is checked to make sure

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -137,7 +137,6 @@ ${HTML(fragment.foot_html())}
           var popupBottom = visiblePopup.getBoundingClientRect().bottom;
           maxHeight = Math.max(baseElement.offsetHeight, Math.ceil(popupBottom));
         }
-        console.log("getting reflected")
         return maxHeight;
       }
 


### PR DESCRIPTION
## Description

### Problem

The iframe height used by the Learning MFE is calculated based only on the main content height. Since the Notes popup (`.annotator-widget`) is absolutely positioned, it is not included in this calculation.

On units with little content, the iframe remains too short, causing the Notes modal to be clipped when opened.

### Solution

Update the chromeless resize logic to account for the visible annotator popup when calculating the iframe height.

If a visible Notes popup is present, its bottom boundary is included in the computed height so the parent page resizes the iframe appropriately.

### Testing

* Verified the iframe height increases when the Notes popup is opened.
* Verified the Notes modal is no longer clipped on short units.
* Verified existing iframe resize behavior remains unchanged when no Notes popup is present.

**jira-link-** https://2u-internal.atlassian.net/browse/LP-297
