### PR TITLE
feat: enable Student Notes by default in InheritanceMixin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,12 +23,13 @@ def create_edxnotes_oauth_client(request):
     Create edx-notes OAuth2 Application for tests that have DB access
     when ENABLE_EDXNOTES is enabled.
     """
-    from django.test import SimpleTestCase, TestCase as DjangoTestCase
+    from django.test import TransactionTestCase
 
-    # Only run for tests with DB access.
-    if request.cls:
-        if issubclass(request.cls, SimpleTestCase) and not issubclass(request.cls, DjangoTestCase):
-            return
+    # Only run for Django class-based tests with DB access.
+    if not request.cls:
+        return
+    if not issubclass(request.cls, TransactionTestCase):
+        return
 
     from django.conf import settings
 

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ Default unit test configuration and fixtures.
 from unittest import TestCase
 
 import pytest
+from django.conf import settings
 
 # Import hooks and fixture overrides from the cms package to
 # avoid duplicating the implementation
@@ -15,3 +16,23 @@ from cms.conftest import _django_clear_site_cache, pytest_configure  # pylint: d
 # When using self.assertEquals, diffs are truncated. We don't want that, always
 # show the whole diff.
 TestCase.maxDiff = None
+
+
+@pytest.fixture(autouse=True)
+def create_edxnotes_oauth_client(db):
+    """
+    Create edx-notes OAuth2 Application for all tests when
+    ENABLE_EDXNOTES is enabled and the setting is configured.
+    """
+    client_name = getattr(settings, 'EDXNOTES_CLIENT_NAME', None)
+    if not client_name:
+        return
+
+    if not getattr(settings, 'FEATURES', {}).get('ENABLE_EDXNOTES', False):
+        return
+
+    from oauth2_provider.models import Application
+    from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory
+
+    if not Application.objects.filter(name=client_name).exists():
+        ApplicationFactory(name=client_name)

--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,9 @@ def create_edxnotes_oauth_client(db):
     """
     Create edx-notes OAuth2 Application for all tests when
     ENABLE_EDXNOTES is enabled and the setting is configured.
+
+    Uses direct model creation to avoid creating an extra User
+    (which breaks tests that count users or look them up by unique fields).
     """
     client_name = getattr(settings, 'EDXNOTES_CLIENT_NAME', None)
     if not client_name:
@@ -32,7 +35,11 @@ def create_edxnotes_oauth_client(db):
         return
 
     from oauth2_provider.models import Application
-    from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory
 
     if not Application.objects.filter(name=client_name).exists():
-        ApplicationFactory(name=client_name)
+        Application.objects.create(
+            name=client_name,
+            user=None,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )

--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,6 @@ Default unit test configuration and fixtures.
 from unittest import TestCase
 
 import pytest
-from django.conf import settings
 
 # Import hooks and fixture overrides from the cms package to
 # avoid duplicating the implementation
@@ -19,14 +18,20 @@ TestCase.maxDiff = None
 
 
 @pytest.fixture(autouse=True)
-def create_edxnotes_oauth_client(db):
+def create_edxnotes_oauth_client(request):
     """
-    Create edx-notes OAuth2 Application for all tests when
-    ENABLE_EDXNOTES is enabled and the setting is configured.
+    Create edx-notes OAuth2 Application for tests that have DB access
+    when ENABLE_EDXNOTES is enabled.
+    """
+    from django.test import SimpleTestCase, TestCase as DjangoTestCase
 
-    Uses direct model creation to avoid creating an extra User
-    (which breaks tests that count users or look them up by unique fields).
-    """
+    # Only run for tests with DB access.
+    if request.cls:
+        if issubclass(request.cls, SimpleTestCase) and not issubclass(request.cls, DjangoTestCase):
+            return
+
+    from django.conf import settings
+
     client_name = getattr(settings, 'EDXNOTES_CLIENT_NAME', None)
     if not client_name:
         return

--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,10 @@ def create_edxnotes_oauth_client(request):
     if not issubclass(request.cls, TransactionTestCase):
         return
 
+    # Skip for edxnotes tests; they create their own Application.
+    if 'edxnotes' in request.node.module.__name__:
+        return
+
     from django.conf import settings
 
     client_name = getattr(settings, 'EDXNOTES_CLIENT_NAME', None)

--- a/openedx/core/djangoapps/course_apps/tests/test_notes_app.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_notes_app.py
@@ -19,6 +19,12 @@ class NotesCourseAppTestCase(TabBasedCourseAppTestMixin, ModuleStoreTestCase):
     tab_type = 'edxnotes'
     course_app_class = EdxNotesCourseApp
 
+    def test_app_disabled_by_default(self):
+        """
+        Override base mixin behavior: Notes is enabled by default.
+        """
+        assert self.course_app_class.is_enabled(self.course.id)
+
     def _assert_app_enabled(self, app_tab):
         assert app_tab.is_enabled(self.course, self.user)
 

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -210,7 +210,7 @@ class InheritanceMixin(XBlockMixin):
     edxnotes = Boolean(
         display_name=_("Enable Student Notes"),
         help=_("Enter true or false. If true, students can use the Student Notes feature."),
-        default=False,
+        default=True,
         scope=Scope.settings
     )
     edxnotes_visibility = Boolean(

--- a/xmodule/tests/test_split_test_block.py
+++ b/xmodule/tests/test_split_test_block.py
@@ -123,6 +123,7 @@ class SplitTestBlockTest(XModuleXmlImportTest, PartitionTestCase):
         self.split_test_block.runtime.modulestore = mocked_modulestore
 
 
+@patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
 @ddt.ddt
 class SplitTestBlockLMSTest(SplitTestBlockTest):
     """
@@ -186,6 +187,7 @@ class SplitTestBlockLMSTest(SplitTestBlockTest):
         assert len(children) == 2
 
 
+@patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
 class SplitTestBlockStudioTest(SplitTestBlockTest):
     """
     Unit tests for how split test interacts with Studio.

--- a/xmodule/tests/test_split_test_block.py
+++ b/xmodule/tests/test_split_test_block.py
@@ -123,7 +123,7 @@ class SplitTestBlockTest(XModuleXmlImportTest, PartitionTestCase):
         self.split_test_block.runtime.modulestore = mocked_modulestore
 
 
-@patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
+# @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
 @ddt.ddt
 class SplitTestBlockLMSTest(SplitTestBlockTest):
     """
@@ -187,7 +187,7 @@ class SplitTestBlockLMSTest(SplitTestBlockTest):
         assert len(children) == 2
 
 
-@patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
+# @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
 class SplitTestBlockStudioTest(SplitTestBlockTest):
     """
     Unit tests for how split test interacts with Studio.

--- a/xmodule/tests/test_split_test_block.py
+++ b/xmodule/tests/test_split_test_block.py
@@ -123,7 +123,7 @@ class SplitTestBlockTest(XModuleXmlImportTest, PartitionTestCase):
         self.split_test_block.runtime.modulestore = mocked_modulestore
 
 
-# @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
+@patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
 @ddt.ddt
 class SplitTestBlockLMSTest(SplitTestBlockTest):
     """
@@ -187,7 +187,7 @@ class SplitTestBlockLMSTest(SplitTestBlockTest):
         assert len(children) == 2
 
 
-# @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
+@patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
 class SplitTestBlockStudioTest(SplitTestBlockTest):
     """
     Unit tests for how split test interacts with Studio.


### PR DESCRIPTION
**Summary**

Enable the Student Notes feature by default by changing the default value of the edxnotes setting in InheritanceMixin from False to True.

**jira_link-** https://2u-internal.atlassian.net/browse/LP-952
