### PR TITLE
fix: handle exceptions when fetching library components during index rebuild

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -475,7 +475,12 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None, incremental=Fa
 
         def index_library(lib_key: LibraryLocatorV2) -> list:
             docs = []
-            for component in lib_api.get_library_components(lib_key):
+            try:
+                components = lib_api.get_library_components(lib_key)
+            except Exception as err:  # pylint: disable=broad-except
+                status_cb(f"Error fetching components for library {lib_key}, skipping: {err}")
+                return docs
+            for component in components:
                 try:
                     metadata = lib_api.LibraryXBlockMetadata.from_component(lib_key, component)
                     doc = {}


### PR DESCRIPTION
This pull request improves the robustness of the `rebuild_index` function in `openedx/core/djangoapps/content/search/api.py` by adding error handling when fetching library components. Now, if an error occurs while retrieving components for a library, the function logs the error and skips that library instead of failing.

Error handling improvements:

* Added a `try-except` block around the call to `lib_api.get_library_components(lib_key)` in the `index_library` function to catch any exceptions, log an error message via `status_cb`, and skip indexing that library if an error occurs.
**JIRA:** https://2u-internal.atlassian.net/browse/LP-806