### PR TITLE
fix: add LTI 1.3 UUID to profile CSV download

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2848,6 +2848,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         response = self.client.post(url, {})
         res_json = json.loads(response.content.decode('utf-8'))
         assert 'external_user_key' in res_json['feature_names']
+        assert 'lti_13_uuid' in res_json['feature_names']
         for student in self.students:
             student_json = [
                 x for x in res_json['students']

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2855,6 +2855,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
                 if x['username'] == student.username
             ][0]
             assert student_json['username'] == student.username
+            assert student_json['lti_13_uuid'] == ''
             if has_program_enrollments:
                 assert student_json['external_user_key'] == external_key_dict[student.username]
             else:

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1493,7 +1493,8 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
             query_features = [
                 'id', 'username', 'name', 'email', 'language', 'location',
                 'year_of_birth', 'gender', 'level_of_education', 'mailing_address',
-                'goals', 'enrollment_mode', 'last_login', 'date_joined', 'external_user_key'
+                'goals', 'enrollment_mode', 'last_login', 'date_joined', 'external_user_key',
+                'lti_13_uuid'
             ]
 
         # Provide human-friendly and translatable names for these features. These names
@@ -1515,6 +1516,7 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
             'last_login': _('Last Login'),
             'date_joined': _('Date Joined'),
             'external_user_key': _('External User Key'),
+            'lti_13_uuid': _('LTI 1.3 UUID'),
         }
 
         for field in settings.PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS:

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -87,7 +87,18 @@ def issued_certificates(course_key, features):
 
 
 def _get_external_id_dicts(students, include_program_enrollments, include_lti_13_uuid):
-    """Return (external_user_key_dict, lti_13_uuid_dict) for the given student queryset."""
+    """
+    Return (external_user_key_dict, lti_13_uuid_dict) for the given student queryset.
+
+    Arguments:
+        students: User queryset of enrolled students
+        include_program_enrollments (bool): whether to build the program enrollment key dict
+        include_lti_13_uuid (bool): whether to build the LTI 1.3 UUID dict
+
+    Returns:
+        tuple: (external_user_key_dict, lti_13_uuid_dict) where each dict maps user_id
+               to the corresponding external identifier string.
+    """
     external_user_key_dict = {}
     lti_13_uuid_dict = {}
     if include_program_enrollments and len(students) > 0:

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -26,6 +26,7 @@ from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.grades.api import context as grades_context
 from lms.djangoapps.program_enrollments.api import fetch_program_enrollments_by_students
 from lms.djangoapps.verify_student.services import IDVerificationService
+from openedx.core.djangoapps.external_user_ids.models import ExternalId, ExternalIdType
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import HTML, Text
 
@@ -38,6 +39,7 @@ PROFILE_FEATURES = ('name', 'language', 'location', 'year_of_birth', 'gender',
                     'level_of_education', 'mailing_address', 'goals', 'meta',
                     'city', 'country')
 PROGRAM_ENROLLMENT_FEATURES = ('external_user_key', )
+EXTERNAL_ID_FEATURES = ('lti_13_uuid', )
 ORDER_ITEM_FEATURES = ('list_price', 'unit_cost', 'status')
 ORDER_FEATURES = ('purchase_time',)
 
@@ -49,7 +51,7 @@ SALE_ORDER_FEATURES = ('id', 'company_name', 'company_contact_name', 'company_co
                        'bill_to_street2', 'bill_to_city', 'bill_to_state', 'bill_to_postalcode',
                        'bill_to_country', 'order_type', 'created')
 
-AVAILABLE_FEATURES = STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES
+AVAILABLE_FEATURES = STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES + EXTERNAL_ID_FEATURES
 COURSE_REGISTRATION_FEATURES = ('code', 'course_id', 'created_by', 'created_at', 'is_valid')
 COUPON_FEATURES = ('code', 'course_id', 'percentage_discount', 'description', 'expiration_date', 'is_active')
 CERTIFICATE_FEATURES = ('course_id', 'mode', 'status', 'grade', 'created_date', 'is_active', 'error_reason')
@@ -101,7 +103,9 @@ def enrolled_students_features(course_key, features):
     include_enrollment_mode = 'enrollment_mode' in features
     include_verification_status = 'verification_status' in features
     include_program_enrollments = 'external_user_key' in features
+    include_lti_13_uuid = 'lti_13_uuid' in features
     external_user_key_dict = {}
+    lti_13_uuid_dict = {}
 
     students = User.objects.filter(
         courseenrollment__course_id=course_key,
@@ -118,6 +122,16 @@ def enrolled_students_features(course_key, features):
         program_enrollments = fetch_program_enrollments_by_students(users=students, realized_only=True)
         for program_enrollment in program_enrollments:
             external_user_key_dict[program_enrollment.user_id] = program_enrollment.external_user_key
+
+    if include_lti_13_uuid and len(students) > 0:
+        lti_external_ids = ExternalId.objects.filter(
+            user__in=students,
+            external_id_type__name=ExternalIdType.LTI,
+        )
+        lti_13_uuid_dict = {
+            external_id.user_id: str(external_id.external_user_id)
+            for external_id in lti_external_ids
+        }
 
     def extract_attr(student, feature):
         """Evaluate a student attribute that is ready for JSON serialization"""
@@ -188,6 +202,9 @@ def enrolled_students_features(course_key, features):
         if include_program_enrollments:
             # extra external_user_key
             student_dict['external_user_key'] = external_user_key_dict.get(student.id, '')
+
+        if include_lti_13_uuid:
+            student_dict['lti_13_uuid'] = lti_13_uuid_dict.get(student.id, '')
 
         return student_dict
 

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -125,12 +125,12 @@ def enrolled_students_features(course_key, features):
 
     if include_lti_13_uuid and len(students) > 0:
         lti_external_ids = ExternalId.objects.filter(
-            user__in=students,
+            user_id__in=students.values_list('id', flat=True),
             external_id_type__name=ExternalIdType.LTI,
-        )
+        ).values_list('user_id', 'external_user_id')
         lti_13_uuid_dict = {
-            external_id.user_id: str(external_id.external_user_id)
-            for external_id in lti_external_ids
+            user_id: str(external_user_id)
+            for user_id, external_user_id in lti_external_ids
         }
 
     def extract_attr(student, feature):

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -86,6 +86,22 @@ def issued_certificates(course_key, features):
     return generated_certificates
 
 
+def _get_external_id_dicts(students, include_program_enrollments, include_lti_13_uuid):
+    """Return (external_user_key_dict, lti_13_uuid_dict) for the given student queryset."""
+    external_user_key_dict = {}
+    lti_13_uuid_dict = {}
+    if include_program_enrollments and len(students) > 0:
+        for enrollment in fetch_program_enrollments_by_students(users=students, realized_only=True):
+            external_user_key_dict[enrollment.user_id] = enrollment.external_user_key
+    if include_lti_13_uuid and len(students) > 0:
+        lti_external_ids = ExternalId.objects.filter(
+            user_id__in=students.values_list('id', flat=True),
+            external_id_type__name=ExternalIdType.LTI,
+        ).values_list('user_id', 'external_user_id')
+        lti_13_uuid_dict = {user_id: str(ext_id) for user_id, ext_id in lti_external_ids}
+    return external_user_key_dict, lti_13_uuid_dict
+
+
 def enrolled_students_features(course_key, features):
     """
     Return list of student features as dictionaries.
@@ -104,8 +120,6 @@ def enrolled_students_features(course_key, features):
     include_verification_status = 'verification_status' in features
     include_program_enrollments = 'external_user_key' in features
     include_lti_13_uuid = 'lti_13_uuid' in features
-    external_user_key_dict = {}
-    lti_13_uuid_dict = {}
 
     students = User.objects.filter(
         courseenrollment__course_id=course_key,
@@ -118,20 +132,9 @@ def enrolled_students_features(course_key, features):
     if include_team_column:
         students = students.prefetch_related('teams')
 
-    if include_program_enrollments and len(students) > 0:
-        program_enrollments = fetch_program_enrollments_by_students(users=students, realized_only=True)
-        for program_enrollment in program_enrollments:
-            external_user_key_dict[program_enrollment.user_id] = program_enrollment.external_user_key
-
-    if include_lti_13_uuid and len(students) > 0:
-        lti_external_ids = ExternalId.objects.filter(
-            user_id__in=students.values_list('id', flat=True),
-            external_id_type__name=ExternalIdType.LTI,
-        ).values_list('user_id', 'external_user_id')
-        lti_13_uuid_dict = {
-            user_id: str(external_user_id)
-            for user_id, external_user_id in lti_external_ids
-        }
+    external_user_key_dict, lti_13_uuid_dict = _get_external_id_dicts(
+        students, include_program_enrollments, include_lti_13_uuid
+    )
 
     def extract_attr(student, feature):
         """Evaluate a student attribute that is ready for JSON serialization"""

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -264,7 +264,8 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
             user=user_with_lti_uuid,
         )
 
-        userreports = enrolled_students_features(self.course_key, query_features)
+        with self.assertNumQueries(2):
+            userreports = enrolled_students_features(self.course_key, query_features)
 
         assert len(userreports) == 30
         for report in userreports:

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -12,6 +12,7 @@ from edx_proctoring.models import ProctoredExamStudentAttempt
 from opaque_keys.edx.locator import UsageKey
 from lms.djangoapps.instructor_analytics.basic import (  # lint-amnesty, pylint: disable=unused-import
     AVAILABLE_FEATURES,
+    EXTERNAL_ID_FEATURES,
     PROFILE_FEATURES,
     PROGRAM_ENROLLMENT_FEATURES,
     STUDENT_FEATURES,
@@ -23,6 +24,8 @@ from lms.djangoapps.instructor_analytics.basic import (  # lint-amnesty, pylint:
     list_problem_responses
 )
 from lms.djangoapps.program_enrollments.tests.factories import ProgramEnrollmentFactory
+from openedx.core.djangoapps.external_user_ids.models import ExternalIdType
+from openedx.core.djangoapps.external_user_ids.tests.factories import ExternalIdFactory
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
 from common.djangoapps.student.tests.factories import InstructorFactory
@@ -249,9 +252,35 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
             else:
                 assert '' == report['external_user_key']
 
+    def test_enrolled_student_features_lti_13_uuid(self):
+        query_features = ('username', 'lti_13_uuid')
+        id_type, _ = ExternalIdType.objects.get_or_create(
+            name=ExternalIdType.LTI,
+            defaults={'description': 'LTI'},
+        )
+        user_with_lti_uuid = self.users[0]
+        external_id = ExternalIdFactory.create(
+            external_id_type=id_type,
+            user=user_with_lti_uuid,
+        )
+
+        userreports = enrolled_students_features(self.course_key, query_features)
+
+        assert len(userreports) == 30
+        for report in userreports:
+            assert set(report.keys()) == set(query_features)
+            if report['username'] == user_with_lti_uuid.username:
+                assert report['lti_13_uuid'] == str(external_id.external_user_id)
+            else:
+                assert report['lti_13_uuid'] == ''
+
     def test_available_features(self):
-        assert len(AVAILABLE_FEATURES) == len(STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES)
-        assert set(AVAILABLE_FEATURES) == set(STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES)
+        assert len(AVAILABLE_FEATURES) == len(
+            STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES + EXTERNAL_ID_FEATURES
+        )
+        assert set(AVAILABLE_FEATURES) == set(
+            STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES + EXTERNAL_ID_FEATURES
+        )
 
     def test_list_may_enroll(self):
         may_enroll = list_may_enroll(self.course_key, ['email'])


### PR DESCRIPTION
## Description

Adds the LTI 1.3 UUID to the existing instructor Data Downloads profile CSV.

Berkeley requested the LTI 1.3 UUID to be included in the course-specific profile data download so they can map the UUID back to the learner identifiers already available in that report.

## Changes

- Adds `lti_13_uuid` as an available student profile report field.
- Includes `lti_13_uuid` in the default profile CSV download fields.
- Reads the value from `ExternalId.external_user_id` for rows where `ExternalIdType` is `lti`.
- Returns a blank value when a learner does not have an LTI external ID.
- Updates existing analytics/API tests to cover the new field.
