### PR TITLE
fix: hide unreleased content during learner masquerade

### DIFF
--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -9,6 +9,7 @@ from completion.models import BlockCompletion
 from completion.utilities import get_key_to_last_completed_block  # lint-amnesty, pylint: disable=wrong-import-order
 from django.conf import settings  # lint-amnesty, pylint: disable=wrong-import-order
 from django.core.cache import cache
+from django.contrib.auth.models import User  # lint-amnesty, pylint:
 from django.shortcuts import get_object_or_404  # lint-amnesty, pylint: disable=wrong-import-order
 from django.urls import reverse  # lint-amnesty, pylint: disable=wrong-import-order
 from django.utils.translation import gettext as _  # lint-amnesty, pylint: disable=wrong-import-order
@@ -189,30 +190,39 @@ class OutlineTabView(RetrieveAPIView):
     def get(self, request, *args, **kwargs):  # pylint: disable=too-many-statements
         course_key_string = kwargs.get('course_key_string')
         course_key = CourseKey.from_string(course_key_string)
-
+        user = request.user
         # Enable NR tracing for this view based on course
         monitoring_utils.set_custom_attribute('course_id', course_key_string)
-        monitoring_utils.set_custom_attribute('user_id', request.user.id)
-        monitoring_utils.set_custom_attribute('is_staff', request.user.is_staff)
+        monitoring_utils.set_custom_attribute('user_id', user.id)
+        monitoring_utils.set_custom_attribute('is_staff', user.is_staff)
 
-        course = get_course_or_403(request.user, 'load', course_key, check_if_enrolled=False)
+        course = get_course_or_403(user, 'load', course_key, check_if_enrolled=False)
 
-        masquerade_object, request.user = setup_masquerade(
+        masquerade_object, user = setup_masquerade(
             request,
             course_key,
-            staff_access=has_access(request.user, 'staff', course_key),
+            staff_access=has_access(user, 'staff', course_key),
             reset_masquerade_data=True,
         )
 
-        user_is_masquerading = is_masquerading(request.user, course_key, course_masquerade=masquerade_object)
+        user_is_masquerading = is_masquerading(user, course_key, course_masquerade=masquerade_object)
+
+        # Check if the user is masquerading as a student and get the masqueraded user object
+        if user_is_masquerading and masquerade_object.role == 'student':
+            try:
+                # If the masqueraded user does not exist, we will continue with the original user object.
+                username = masquerade_object.user_name or 'audit'
+                user = User.objects.get(username=username)
+            except User.DoesNotExist:
+                pass
 
         course_overview = get_course_overview_or_404(course_key)
-        enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
+        enrollment = CourseEnrollment.get_enrollment(user, course_key)
         enrollment_mode = getattr(enrollment, 'mode', None)
         allow_anonymous = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key)
         allow_public = allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC
         allow_public_outline = allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE
-        allow_preview_of_verified_content = learner_can_preview_verified_content(course_key, request.user)
+        allow_preview_of_verified_content = learner_can_preview_verified_content(course_key, user)
 
         # User locale settings
         user_timezone_locale = user_timezone_locale_prefs(request)
@@ -251,22 +261,22 @@ class OutlineTabView(RetrieveAPIView):
         show_enrolled = is_enrolled or is_staff
         enable_proctored_exams = False
         if show_enrolled:
-            course_blocks = get_course_outline_block_tree(request, course_key_string, request.user)
-            date_blocks = get_course_date_blocks(course, request.user, request, num_assignments=1)
+            course_blocks = get_course_outline_block_tree(request, course_key_string, user)
+            date_blocks = get_course_date_blocks(course, user, request, num_assignments=1)
             dates_widget['course_date_blocks'] = [block for block in date_blocks if not isinstance(block, TodaysDate)]
 
-            handouts_html = get_course_info_section(request, request.user, course, 'handouts')
+            handouts_html = get_course_info_section(request, user, course, 'handouts')
             welcome_message_html = get_current_update_for_user(request, course)
 
-            offer_data = generate_offer_data(request.user, course_overview)
-            access_expiration = get_access_expiration_data(request.user, course_overview)
-            cert_data = get_cert_data(request.user, course, enrollment.mode) if is_enrolled else None
+            offer_data = generate_offer_data(user, course_overview)
+            access_expiration = get_access_expiration_data(user, course_overview)
+            cert_data = get_cert_data(user, course, enrollment.mode) if is_enrolled else None
 
             enable_proctored_exams = course_overview.enable_proctored_exams
 
             if (is_enrolled and ENABLE_COURSE_GOALS.is_enabled(course_key)):
                 course_goals['weekly_learning_goal_enabled'] = True
-                selected_goal = get_course_goal(request.user, course_key)
+                selected_goal = get_course_goal(user, course_key)
                 if selected_goal:
                     course_goals['selected_goal'] = {
                         'days_per_week': selected_goal.days_per_week,
@@ -274,7 +284,7 @@ class OutlineTabView(RetrieveAPIView):
                     }
 
             try:
-                resume_block = get_key_to_last_completed_block(request.user, course.id)
+                resume_block = get_key_to_last_completed_block(user, course.id)
                 resume_course['has_visited_course'] = True
                 resume_path = reverse('jump_to', kwargs={
                     'course_id': course_key_string,
@@ -288,7 +298,7 @@ class OutlineTabView(RetrieveAPIView):
         elif allow_public_outline or allow_public or user_is_masquerading:
             course_blocks = get_course_outline_block_tree(request, course_key_string, None)
             if allow_public or user_is_masquerading:
-                handouts_html = get_course_info_section(request, request.user, course, 'handouts')
+                handouts_html = get_course_info_section(request, user, course, 'handouts')
 
         if not is_enrolled:
             if CourseMode.is_masters_only(course_key):
@@ -313,7 +323,7 @@ class OutlineTabView(RetrieveAPIView):
         # so this is a tiny first step in that migration.
         if course_blocks:
             user_course_outline = get_user_course_outline(
-                course_key, request.user, datetime.now(tz=timezone.utc),
+                course_key, user, datetime.now(tz=timezone.utc),
                 preview_verified_content=allow_preview_of_verified_content
             )
             available_seq_ids = {str(usage_key) for usage_key in user_course_outline.sequences}
@@ -358,8 +368,8 @@ class OutlineTabView(RetrieveAPIView):
                             seq_data['is_preview'] = True
 
         user_has_passing_grade = False
-        if not request.user.is_anonymous:
-            user_grade = CourseGradeFactory().read(request.user, course)
+        if not user.is_anonymous:
+            user_grade = CourseGradeFactory().read(user, course)
             if user_grade:
                 user_has_passing_grade = user_grade.passed
 

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -9,7 +9,7 @@ from completion.models import BlockCompletion
 from completion.utilities import get_key_to_last_completed_block  # lint-amnesty, pylint: disable=wrong-import-order
 from django.conf import settings  # lint-amnesty, pylint: disable=wrong-import-order
 from django.core.cache import cache
-from django.contrib.auth.models import User  # lint-amnesty, pylint:
+from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404  # lint-amnesty, pylint: disable=wrong-import-order
 from django.urls import reverse  # lint-amnesty, pylint: disable=wrong-import-order
 from django.utils.translation import gettext as _  # lint-amnesty, pylint: disable=wrong-import-order
@@ -195,10 +195,8 @@ class OutlineTabView(RetrieveAPIView):
         monitoring_utils.set_custom_attribute('course_id', course_key_string)
         monitoring_utils.set_custom_attribute('user_id', user.id)
         monitoring_utils.set_custom_attribute('is_staff', user.is_staff)
-
-        course = get_course_or_403(user, 'load', course_key, check_if_enrolled=False)
-
-        masquerade_object, user = setup_masquerade(
+        
+        masquerade_object, request.user = setup_masquerade(
             request,
             course_key,
             staff_access=has_access(user, 'staff', course_key),
@@ -210,12 +208,14 @@ class OutlineTabView(RetrieveAPIView):
         # Check if the user is masquerading as a student and get the masqueraded user object
         if user_is_masquerading and masquerade_object.role == 'student':
             try:
+                User = get_user_model()
                 # If the masqueraded user does not exist, we will continue with the original user object.
                 username = masquerade_object.user_name or 'audit'
                 user = User.objects.get(username=username)
             except User.DoesNotExist:
                 pass
 
+        course = get_course_or_403(user, 'load', course_key, check_if_enrolled=False)
         course_overview = get_course_overview_or_404(course_key)
         enrollment = CourseEnrollment.get_enrollment(user, course_key)
         enrollment_mode = getattr(enrollment, 'mode', None)

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -195,7 +195,6 @@ class OutlineTabView(RetrieveAPIView):
         monitoring_utils.set_custom_attribute('course_id', course_key_string)
         monitoring_utils.set_custom_attribute('user_id', user.id)
         monitoring_utils.set_custom_attribute('is_staff', user.is_staff)
-        
         masquerade_object, request.user = setup_masquerade(
             request,
             course_key,


### PR DESCRIPTION
**Summary**

Fix an issue where course staff using "View as Specific Learner" (learner masquerade) could see unreleased course content in the course outline.
The course outline was previously generated using the authenticated staff user, causing release-date and visibility checks to be evaluated with staff permissions instead of the masqueraded learner's permissions. This resulted in unreleased content appearing in the masqueraded view.
This change updates the course home API to consistently use the masqueraded learner throughout the request lifecycle, ensuring that the learner experience accurately reflects the selected user's permissions and content visibility.

**Root Cause**

Although the request was in learner masquerade mode, several course home APIs continued using the authenticated staff user when retrieving course data. Since staff users can access unreleased content, visibility checks were bypassed, causing discrepancies between the masqueraded view and the actual learner experience.

**Technical Details**

- Detect when the request is in student masquerade mode.
- Resolve the masqueraded learner from the masquerade context.
- Use the masqueraded learner instead of the authenticated staff user when retrieving learner-specific data.
- Fall back to the authenticated user if the masqueraded learner cannot be resolved.

**Testing**

  - Verified that unreleased sections are hidden while masquerading as a learner.
  - Confirmed that released content remains visible as expected.
  - Compared the masqueraded view with an actual learner account and verified identical content visibility.
  - Verified that non-masquerade behavior remains unchanged.
  - Ran the relevant unit and integration tests successfully.

**Expected Result**

The "View as Specific Learner" experience now accurately reflects what the selected learner can access, including proper enforcement of release-date restrictions and other learner-specific visibility rules.

Jira: https://2u-internal.atlassian.net/browse/LP-260