### PR TITLE
fix: limit repeated HLS fragment load retries

### DIFF
--- a/xmodule/js/spec/video/video_player_spec.js
+++ b/xmodule/js/spec/video/video_player_spec.js
@@ -980,6 +980,40 @@
                         expect(state.videoPlayer.player.hls).toBeDefined();
                     });
 
+                    it('limits fatal network retries for the same fragment', function() {
+                        var i,
+                            player = state.videoPlayer.player,
+                            makeFatalNetworkError = function(url) {
+                                return {
+                                    fatal: true,
+                                    type: Hls.ErrorTypes.NETWORK_ERROR,
+                                    details: 'fragLoadError',
+                                    frag: {
+                                        url: url
+                                    }
+                                };
+                            };
+
+                        spyOn(player.hls, 'startLoad');
+                        spyOn(console, 'error');
+                        spyOn(console, 'warn');
+                        player.hls.stopLoad = jasmine.createSpy('stopLoad');
+
+                        for (i = 0; i < 4; i++) {
+                            player.onError(null, makeFatalNetworkError('/base/fixtures/hls/hls_0_4.ts'));
+                        }
+
+                        expect(player.hls.startLoad.calls.count()).toEqual(3);
+                        expect(console.error.calls.count()).toEqual(3);
+                        expect(console.warn.calls.count()).toEqual(1);
+                        expect(player.hls.stopLoad).toHaveBeenCalled();
+
+                        player.onError(null, makeFatalNetworkError('/base/fixtures/hls/hls_0_5.ts'));
+
+                        expect(player.hls.startLoad.calls.count()).toEqual(4);
+                        expect(console.error.calls.count()).toEqual(4);
+                    });
+
                     describe('on safari', function() {
                         beforeEach(function() {
                             spyOn(Hls, 'isSupported').and.returnValue(false);

--- a/xmodule/js/src/video/02_html5_hls_video.js
+++ b/xmodule/js/src/video/02_html5_hls_video.js
@@ -9,7 +9,8 @@
 
     define('video/02_html5_hls_video.js', ['underscore', 'video/02_html5_video.js', 'hls'],
         function(_, HTML5Video, Hls) {
-            var HLSVideo = {};
+            var HLSVideo = {},
+                MAX_HLS_NETWORK_ERROR_RETRIES = 3;
 
             HLSVideo.Player = (function() {
             /**
@@ -22,6 +23,7 @@
                     var self = this;
 
                     this.config = config;
+                    this.hlsNetworkErrorRetries = {};
 
                     // do common initialization independent of player type
                     this.init(el, config);
@@ -104,6 +106,13 @@
                     this.config.events.onReady(null);
                 };
 
+                Player.prototype.getHlsNetworkErrorKey = function(data) {
+                    if (data.frag && data.frag.url) {
+                        return data.frag.url;
+                    }
+                    return data.details;
+                };
+
                 /**
              * Handler for HLS video errors. This only takes care of fatal erros, non-fatal errors
              * are automatically handled by hls.js
@@ -112,14 +121,31 @@
              * @param {Object} data  Contains the information regarding error occurred.
              */
                 Player.prototype.onError = function(event, data) {
+                    var errorKey,
+                        retryCount;
+
                     if (data.fatal) {
                         switch (data.type) {
                         case Hls.ErrorTypes.NETWORK_ERROR:
-                            console.error(
-                                '[HLS Video]: Fatal network error encountered, try to recover. Details: %s',
-                                data.details
-                            );
-                            this.hls.startLoad();
+                            errorKey = this.getHlsNetworkErrorKey(data);
+                            retryCount = this.hlsNetworkErrorRetries[errorKey] || 0;
+                            if (retryCount < MAX_HLS_NETWORK_ERROR_RETRIES) {
+                                this.hlsNetworkErrorRetries[errorKey] = retryCount + 1;
+                                console.error(
+                                    '[HLS Video]: Fatal network error encountered, try to recover. Details: %s',
+                                    data.details
+                                );
+                                this.hls.startLoad();
+                            } else if (retryCount === MAX_HLS_NETWORK_ERROR_RETRIES) {
+                                this.hlsNetworkErrorRetries[errorKey] = retryCount + 1;
+                                console.warn(
+                                    '[HLS Video]: Stopped retrying repeated fatal network error. Details: %s',
+                                    data.details
+                                );
+                                if (this.hls.stopLoad) {
+                                    this.hls.stopLoad();
+                                }
+                            }
                             break;
                         case Hls.ErrorTypes.MEDIA_ERROR:
                             console.error(

--- a/xmodule/js/src/video/02_html5_hls_video.js
+++ b/xmodule/js/src/video/02_html5_hls_video.js
@@ -23,7 +23,7 @@
                     var self = this;
 
                     this.config = config;
-                    this.hlsNetworkErrorRetries = {};
+                    this.hlsNetworkErrorRetries = Object.create(null);
 
                     // do common initialization independent of player type
                     this.init(el, config);
@@ -142,7 +142,7 @@
                                     '[HLS Video]: Stopped retrying repeated fatal network error. Details: %s',
                                     data.details
                                 );
-                                if (this.hls.stopLoad) {
+                                if (typeof this.hls.stopLoad === 'function') {
                                     this.hls.stopLoad();
                                 }
                             }


### PR DESCRIPTION
## Description

Limits repeated retry/logging loops for fatal HLS network errors when the same fragment keeps failing.

Datadog showed repeated `[HLS Video]: Fatal network error encountered... fragLoadError` events caused by final/trailing HLS `.ts` fragments returning 403. In affected sessions, the same fragment was retried hundreds/thousands of times, creating noisy frontend error reporting even when playback could complete.

This change keeps the existing recovery behavior for transient HLS network errors, but caps retries per failed fragment URL.

## Changes

- Track fatal HLS network retries per fragment URL.
- Allow the first 3 retries to continue using existing `console.error` + `hls.startLoad()` behavior.
- Stop retrying the same fragment after the retry limit and call `hls.stopLoad()` if available.
- Add focused spec coverage for retry limiting.
- Leave media error handling, Safari native HLS, player selection, MP4 fallback, and Datadog filtering unchanged.
