### PR TITLE
feat: enable edxnotes by default and add OAuth client fixture for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -29,8 +29,6 @@ def create_edxnotes_oauth_client(request):
     if not request.cls:
         return
 
-   
-
     if not issubclass(request.cls, TransactionTestCase):
         return
 
@@ -38,16 +36,12 @@ def create_edxnotes_oauth_client(request):
     if request.node.module.__name__.startswith('lms.djangoapps.edxnotes.'):
         return
 
-
-
     client_name = getattr(settings, 'EDXNOTES_CLIENT_NAME', None)
     if not client_name:
         return
 
     if not getattr(settings, 'FEATURES', {}).get('ENABLE_EDXNOTES', False):
         return
-
- 
 
     Application.objects.get_or_create(
         name=client_name,

--- a/conftest.py
+++ b/conftest.py
@@ -10,8 +10,50 @@ import pytest
 # avoid duplicating the implementation
 
 from cms.conftest import _django_clear_site_cache, pytest_configure  # pylint: disable=unused-import
-
+from django.test import TransactionTestCase
+from django.conf import settings
+from oauth2_provider.models import Application
 
 # When using self.assertEquals, diffs are truncated. We don't want that, always
 # show the whole diff.
 TestCase.maxDiff = None
+
+
+@pytest.fixture(autouse=True)
+def create_edxnotes_oauth_client(request):
+    """
+    Create edx-notes OAuth2 Application for tests that have DB access
+    when ENABLE_EDXNOTES is enabled.
+    """
+    # Only run for Django class-based tests with DB access.
+    if not request.cls:
+        return
+
+   
+
+    if not issubclass(request.cls, TransactionTestCase):
+        return
+
+    # Skip for edxnotes app tests; they create their own Application.
+    if request.node.module.__name__.startswith('lms.djangoapps.edxnotes.'):
+        return
+
+
+
+    client_name = getattr(settings, 'EDXNOTES_CLIENT_NAME', None)
+    if not client_name:
+        return
+
+    if not getattr(settings, 'FEATURES', {}).get('ENABLE_EDXNOTES', False):
+        return
+
+ 
+
+    Application.objects.get_or_create(
+        name=client_name,
+        defaults={
+            'user': None,
+            'client_type': Application.CLIENT_CONFIDENTIAL,
+            'authorization_grant_type': Application.GRANT_CLIENT_CREDENTIALS,
+        },
+    )

--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -59,12 +59,12 @@ def edxnotes(cls):
                 token_url = get_token_url(course.id)
                 endpoint = get_public_endpoint()
             except ImproperlyConfigured:
-                if not getattr(get_html, "_edxnotes_oauth_missing_logged", False):
+                if not getattr(get_html, "edxnotes_oauth_missing_logged", False):
                     log.warning(
                         "EdxNotes OAuth2 client not configured; falling back to original HTML.",
                         exc_info=True,
                     )
-                    get_html._edxnotes_oauth_missing_logged = True
+                    get_html.edxnotes_oauth_missing_logged = True
                 return original_content
 
             return render_to_string("edxnotes_wrapper.html", {

--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -58,11 +58,13 @@ def edxnotes(cls):
                 token = get_edxnotes_id_token(user)
                 token_url = get_token_url(course.id)
                 endpoint = get_public_endpoint()
-            except ImproperlyConfigured as e:
-                log.warning(
-                    "EdxNotes OAuth2 client not configured, falling back to original HTML. Error: %s",
-                    str(e)
-                )
+            except ImproperlyConfigured:
+                if not getattr(get_html, "_edxnotes_oauth_missing_logged", False):
+                    log.warning(
+                        "EdxNotes OAuth2 client not configured; falling back to original HTML.",
+                        exc_info=True,
+                    )
+                    get_html._edxnotes_oauth_missing_logged = True
                 return original_content
 
             return render_to_string("edxnotes_wrapper.html", {

--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -4,11 +4,15 @@ Decorators related to edXNotes.
 
 
 import json
+import logging
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from xblock.exceptions import NoSuchServiceError
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
+
+log = logging.getLogger(__name__)
 
 
 def edxnotes(cls):
@@ -49,8 +53,20 @@ def edxnotes(cls):
         if is_studio or not is_feature_enabled(course, user):
             return original_get_html(self, *args, **kwargs)
         else:
+            original_content = original_get_html(self, *args, **kwargs)
+            try:
+                token = get_edxnotes_id_token(user)
+                token_url = get_token_url(course.id)
+                endpoint = get_public_endpoint()
+            except ImproperlyConfigured as e:
+                log.warning(
+                    "EdxNotes OAuth2 client not configured, falling back to original HTML. Error: %s",
+                    str(e)
+                )
+                return original_content
+
             return render_to_string("edxnotes_wrapper.html", {
-                "content": original_get_html(self, *args, **kwargs),
+                "content": original_content,
                 "uid": generate_uid(),
                 "edxnotes_visibility": json.dumps(
                     getattr(self, 'edxnotes_visibility', course.edxnotes_visibility)
@@ -59,9 +75,9 @@ def edxnotes(cls):
                     # Use camelCase to name keys.
                     "usageId": self.scope_ids.usage_id,
                     "courseId": course.id,
-                    "token": get_edxnotes_id_token(user),
-                    "tokenUrl": get_token_url(course.id),
-                    "endpoint": get_public_endpoint(),
+                    "token": token,
+                    "tokenUrl": token_url,
+                    "endpoint": endpoint,
                     "debug": settings.DEBUG,
                     "eventStringLimit": settings.TRACK_MAX_EVENT / 6,
                 },

--- a/openedx/core/djangoapps/course_apps/tests/test_notes_app.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_notes_app.py
@@ -19,6 +19,12 @@ class NotesCourseAppTestCase(TabBasedCourseAppTestMixin, ModuleStoreTestCase):
     tab_type = 'edxnotes'
     course_app_class = EdxNotesCourseApp
 
+    def test_app_disabled_by_default(self):
+        """
+        Override base mixin behavior: Notes is enabled by default.
+        """
+        assert self.course_app_class.is_enabled(self.course.id)
+
     def _assert_app_enabled(self, app_tab):
         assert app_tab.is_enabled(self.course, self.user)
 

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -210,7 +210,7 @@ class InheritanceMixin(XBlockMixin):
     edxnotes = Boolean(
         display_name=_("Enable Student Notes"),
         help=_("Enter true or false. If true, students can use the Student Notes feature."),
-        default=False,
+        default=True,
         scope=Scope.settings
     )
     edxnotes_visibility = Boolean(

--- a/xmodule/tests/test_split_test_block.py
+++ b/xmodule/tests/test_split_test_block.py
@@ -123,6 +123,7 @@ class SplitTestBlockTest(XModuleXmlImportTest, PartitionTestCase):
         self.split_test_block.runtime.modulestore = mocked_modulestore
 
 
+@patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
 @ddt.ddt
 class SplitTestBlockLMSTest(SplitTestBlockTest):
     """
@@ -186,6 +187,7 @@ class SplitTestBlockLMSTest(SplitTestBlockTest):
         assert len(children) == 2
 
 
+@patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
 class SplitTestBlockStudioTest(SplitTestBlockTest):
     """
     Unit tests for how split test interacts with Studio.


### PR DESCRIPTION
**PR Description
Summary**
Enables the Student Notes feature by default for all courses by changing InheritanceMixin.edxnotes default from False to True, so courses no longer require manual opt-in via Advanced Settings when the platform-level ENABLE_EDXNOTES flag is on.

Jira: LP-952: turn Notes on by default](https://2u-internal.atlassian.net/browse/LP-952)
