### PR TITLE
fix: reject duplicate children in xblock update endpoint (LP-960)

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -2097,6 +2097,129 @@ class TestEditItem(TestEditItemSetup):
         self.assertEqual(unit1_usage_key, children[2])
         self.assertEqual(unit2_usage_key, children[1])
 
+    def test_duplicate_children_error(self):
+        """
+        Submitting a children list that repeats an existing child returns 400
+        and leaves the block unchanged.
+        """
+        resp = self.client.ajax_post(
+            self.seq_update_url,
+            data={
+                "children": [
+                    str(self.problem_usage_key),
+                    str(self.problem_usage_key),
+                ]
+            },
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            resp.json(),
+            {"error": "Duplicate children are not allowed."},
+        )
+
+        # The sequential still has exactly one reference to the problem.
+        self.assertListEqual(
+            self.get_item_from_modulestore(self.seq_usage_key).children,
+            [self.problem_usage_key],
+        )
+
+    def test_duplicate_children_rejection_is_atomic(self):
+        """
+        A request combining duplicate children with other edits (fields) must
+        persist nothing at all. `data`/`fields` are applied to the in-memory
+        xblock BEFORE the children validation, so this proves the early
+        return discards them rather than saving a partial update.
+        """
+        original_display_name = self.get_item_from_modulestore(
+            self.seq_usage_key
+        ).display_name
+        resp = self.client.ajax_post(
+            self.seq_update_url,
+            data={
+                "children": [
+                    str(self.problem_usage_key),
+                    str(self.problem_usage_key),
+                ],
+                "fields": {"display_name": "Must not be saved"},
+            },
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            self.get_item_from_modulestore(self.seq_usage_key).display_name,
+            original_display_name,
+        )
+
+    def test_duplicate_children_does_not_reparent(self):
+        """
+        A rejected duplicate-children request must not mutate ANY structure —
+        in particular, a duplicated child that lives under another parent must
+        not be removed from that parent (the reparenting step must not run).
+        """
+        unit_1_key = self.response_usage_key(
+            self.create_xblock(
+                parent_usage_key=self.seq2_usage_key,
+                category="vertical",
+                display_name="unit 1",
+            )
+        )
+
+        # Try to move unit 1 into sequential 1, but with a duplicated entry.
+        resp = self.client.ajax_post(
+            self.seq_update_url,
+            data={
+                "children": [
+                    str(self.problem_usage_key),
+                    str(unit_1_key),
+                    str(unit_1_key),
+                ]
+            },
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            resp.json(),
+            {"error": "Duplicate children are not allowed."},
+        )
+
+        # Neither the target nor the old parent changed.
+        self.assertListEqual(
+            self.get_item_from_modulestore(self.seq_usage_key).children,
+            [self.problem_usage_key],
+        )
+        self.assertListEqual(
+            self.get_item_from_modulestore(self.seq2_usage_key).children,
+            [unit_1_key],
+        )
+
+    def test_unique_children_order_preserved(self):
+        """
+        A valid unique children list is accepted and stored in exactly the
+        submitted order.
+        """
+        unit_1_key = self.response_usage_key(
+            self.create_xblock(
+                parent_usage_key=self.seq_usage_key, category="vertical"
+            )
+        )
+        unit_2_key = self.response_usage_key(
+            self.create_xblock(
+                parent_usage_key=self.seq_usage_key, category="vertical"
+            )
+        )
+
+        submitted_order = [
+            str(unit_2_key),
+            str(self.problem_usage_key),
+            str(unit_1_key),
+        ]
+        resp = self.client.ajax_post(
+            self.seq_update_url, data={"children": submitted_order}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertListEqual(
+            self.get_item_from_modulestore(self.seq_usage_key).children,
+            [unit_2_key, self.problem_usage_key, unit_1_key],
+        )
+
     def test_move_parented_child(self):
         """
         Test moving a child from one Section to another

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -9,6 +9,7 @@ contentstore/views/block.py to this file, because the logic is reused in another
 Along with it, we moved the business logic of the other views in that file, since that is related.
 """
 import logging
+from collections import Counter
 from datetime import datetime
 from uuid import uuid4
 
@@ -366,6 +367,24 @@ def _save_xblock(
             children = []
             for child_string in children_strings:
                 children.append(usage_key_with_run(child_string))
+
+            # Reject duplicate children before any mutation below (reparenting
+            # writes to old parents), so a bad request leaves every structure
+            # untouched. Set-based checks further down cannot see duplicates.
+            if len(children) != len(set(children)):
+                counts = Counter(children)
+                duplicates = sorted(
+                    str(child) for child, count in counts.items() if count > 1
+                )
+                log.warning(
+                    "Rejected duplicate children submitted for %s: %s",
+                    xblock.location,
+                    ", ".join(duplicates),
+                )
+                return JsonResponse(
+                    {"error": "Duplicate children are not allowed."},
+                    400,
+                )
 
             # if new children have been added, remove them from their old parents
             new_children = set(children) - set(xblock.children)


### PR DESCRIPTION
Rejects duplicate children in the Studio xblock update endpoint (`_save_xblock`), returning HTTP 400 and leaving all course structures untouched when a submitted `children` list contains the same usage key more than once.

### Jira Ticket

[LP-960](https://2u-internal.atlassian.net/browse/LP-960)

## Problem

`_save_xblock` computes added/removed children with **set** operations (`set(children) - set(xblock.children)`), so duplicates in the submitted ordered list are invisible to every existing check, and the verbatim `xblock.children = children` assignment persists them. This let a production course end up with one sequential listed multiple times in a chapter's children, which then broke deletion (`list.remove()` only removes the first occurrence).

## Change

- A single validation in `_save_xblock`, added immediately after the submitted child strings are converted to usage keys and **before** the reparenting loop (which mutates old parents) and before `xblock.children` is assigned. Rejecting before any mutation is what guarantees the "no changes on failure" behaviour, since the surrounding `bulk_operations` context commits on early `return`.
- Returns `{"error": "Duplicate children are not allowed."}` with status 400, matching the existing error style in this handler. The duplicated keys go to a server-side `log.warning` for incident debugging rather than into the API response.

## Screenshot 

When the duplication happens it will show an error like this:

<img width="1503" height="817" alt="LP-960-duplicate-children-error" src="https://github.com/user-attachments/assets/27c68046-45e5-4a18-8195-35950c054039" />


## Tests

Four new tests in `TestEditItem`:
- `test_duplicate_children_error` — a repeated existing child returns 400 and the block is unchanged.
- `test_duplicate_children_rejection_is_atomic` — co-submitted `fields` edits are discarded, not partially saved.
- `test_duplicate_children_does_not_reparent` — a duplicated child owned by another parent is not removed from that parent.
- `test_unique_children_order_preserved` — valid unique lists are still accepted in exactly the submitted order.

All four pass; the full `TestEditItem` class (27 tests) passes; pylint is clean on both changed files.

## Out of scope

The `list.remove()` → filter fixes, modulestore/SplitMongo-level enforcement, and repair of existing corrupted data are tracked separately.
