### PR TITLE
fix: align retirement PII annotations with current runtime behavior

### DIFF
--- a/lms/djangoapps/survey/models.py
+++ b/lms/djangoapps/survey/models.py
@@ -171,7 +171,7 @@ class SurveyAnswer(TimeStampedModel):
 
     .. pii: These are free-form questions asked by course authors. Types below are current as of Feb 2019, new ones could be added. "other" PII currently includes "company", "job title", and "work experience".
     .. pii_types: name, location, other
-    .. pii_retirement: retained
+    .. pii_retirement: local_api
     """
     user = models.ForeignKey(User, db_index=True, on_delete=models.CASCADE)
     form = models.ForeignKey(SurveyForm, db_index=True, on_delete=models.CASCADE)

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -100,9 +100,9 @@ class IDVerificationAttempt(StatusModel):
     their identity through one of several methods that inherit from this Model,
     including PhotoVerification and SSOVerification.
 
-    .. pii: The User's name is stored in this and sub-models
+    .. pii: The User's name is stored in this and sub-models.
     .. pii_types: name
-    .. pii_retirement: retained
+    .. pii_retirement: local_api
     """
     STATUS = Choices('created', 'ready', 'submitted', 'must_retry', 'approved', 'denied')
     user = models.ForeignKey(User, db_index=True, on_delete=models.CASCADE)
@@ -303,7 +303,7 @@ class PhotoVerification(IDVerificationAttempt):
 
     .. pii: The User's name is stored in the parent model, this one stores links to face and photo ID images
     .. pii_types: name, image
-    .. pii_retirement: retained
+    .. pii_retirement: local_api
     """
     ######################## Fields Set During Creation ########################
     # See class docstring for description of status states
@@ -631,7 +631,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
 
     .. pii: The User's name is stored in the parent model, this one stores links to face and photo ID images
     .. pii_types: name, image
-    .. pii_retirement: retained
+    .. pii_retirement: local_api
     """
     # This is a base64.urlsafe_encode(rsa_encrypt(photo_id_aes_key), ss_pub_key)
     # So first we generate a random AES-256 key to encrypt our photo ID with.


### PR DESCRIPTION
## Summary
Updates pii_retirement annotations to match the current retirement implementation.

### Changes

1. changed `verify_student` verification annotations from retained to local_api where retirement already redacts or deletes data
2. changed `survey answer` annotation from retained to local_api

### Notes

1. left `certificate history` as retained because runtime still retains it by default

### Reference Ticket & Confluence Page

- https://2u-internal.atlassian.net/wiki/spaces/AT/pages/3899523193/Review+and+Validate+Retained+PII+Designations+in+edx-platform+User+Retirement
- https://2u-internal.atlassian.net/browse/BOMS-607
