### PR TITLE
chore: update constraints to fix make upgrade/compile-requirements

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -22,3 +22,9 @@ Django<6.0
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
+
+# 2026-07-06: Constrain social-auth-* packages to the latest version compatible with
+# edx-drf-extensions<=10.6.0. (Newer versions require a POST instead of a GET.)
+# Tracking issue: https://github.com/openedx/edx-drf-extensions/issues/561
+social-auth-app-django>=5.4.1,<6.0.0
+social-auth-core>=4.9.1,<5.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -126,19 +126,38 @@ xmlsec==1.3.14
 # Pin this back to the previous version until that bug is fixed.
 django-debug-toolbar<6.0.0
 
-# Date 2025-10-07
-# Cryptography 46.0.0 conflicts with system dependencies needed for snowflake-connector-python
-# snowflake-connector-python comes as a dependency of edx-enterprise so it can not be directly pinned here.
-# See issue https://github.com/openedx/edx-platform/issues/37417 for details on this.
-# This can be unpinned once snowflake-connector-python==4.0.0 is available (contains the fix).
-# pact-python==3.0.0 also removes cffi dependency and is causing the upgrade build to fail
-# This should also be removed together with cryptography constraint.
-# Issue: https://github.com/openedx/edx-platform/issues/37435
-cryptography<46.0.0
-pact-python<3.0.0
+# Date 2026-03-02
+# setuptools 82.0.0 removed pkg_resources from its distribution, but fs (pyfilesystem2)
+# still uses pkg_resources for namespace package declarations. This constraint can be
+# removed once pyfilesystem2 drops its pkg_resources usage.
+# https://github.com/PyFilesystem/pyfilesystem2/issues/577
+# Issue for unpinning: https://github.com/openedx/openedx-platform/issues/38068
+setuptools<82
+
+# Date 2026-03-02
+# The latest version of pylint pins back astroid to an older version.
+# This holdback is not caught in the docs requirements file and since both the docs
+# and testing file are required in the development.in file, we fail to compile
+# development.txt because of conflicting dependencies.
+#
+# Holding astroid back until pylint releases a new version that works with the latest
+# version of astroid.
+# https://github.com/openedx/openedx-platform/issues/38066
+astroid==4.0.4
 
 # Date 2026-02-05
 # sphinx-autoapi==3.6.1 is incompatible with astroid==4.x under python 3.11. Since we (2U) currently
 # deploy edxapp to edx.org using python 3.11, we must pin sphinx-autoapi to avoid dependency
 # conflicts. Remove this constraint once we migrate to python 3.12.
 sphinx-autoapi<3.6.1
+
+# Date 2026-07-17
+# lti-consumer-xblock 11+ depends on the new SignalHandler.pre_item_delete introduced in
+# https://github.com/openedx/openedx-platform/pull/38289
+# but that new signal has not yet been backported to this 2U fork (edx/edx-platform).
+lti-consumer-xblock<11.0.0
+
+# Date 2026-07-17
+# pip 26.1 is incompatible with pip-tools <7.6.0: https://github.com/jazzband/pip-tools/issues/2379
+# Per the linked upstream issue, remove this pin once pip-tools 7.6.0 is released.
+pip<26.1

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -4,27 +4,27 @@
 #
 #    make upgrade
 #
-cffi==2.0.0
+cffi==2.1.0
     # via cryptography
 chem==2.0.0
     # via -r requirements/edx-sandbox/base.in
-click==8.3.0
+click==8.4.2
     # via nltk
 codejail-includes==2.0.0
     # via -r requirements/edx-sandbox/base.in
 contourpy==1.3.3
     # via matplotlib
-cryptography==45.0.7
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/edx-sandbox/base.in
+cryptography==49.0.0
+    # via -r requirements/edx-sandbox/base.in
 cycler==0.12.1
     # via matplotlib
-fonttools==4.60.1
-    # via matplotlib
-joblib==1.5.2
+defusedxml==0.7.1
     # via nltk
-kiwisolver==1.4.9
+fonttools==4.63.0
+    # via matplotlib
+joblib==1.5.3
+    # via nltk
+kiwisolver==1.5.0
     # via matplotlib
 lxml[html-clean]==5.3.2
     # via
@@ -32,19 +32,19 @@ lxml[html-clean]==5.3.2
     #   -r requirements/edx-sandbox/base.in
     #   lxml-html-clean
     #   openedx-calc
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via lxml
 markupsafe==3.0.3
     # via
     #   chem
     #   openedx-calc
-matplotlib==3.10.6
+matplotlib==3.11.0
     # via -r requirements/edx-sandbox/base.in
 mpmath==1.3.0
     # via sympy
-networkx==3.5
+networkx==3.6.1
     # via -r requirements/edx-sandbox/base.in
-nltk==3.9.2
+nltk==3.10.0
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
@@ -56,15 +56,15 @@ numpy==1.26.4
     #   matplotlib
     #   openedx-calc
     #   scipy
-openedx-calc==4.0.2
+openedx-calc==4.0.3
     # via -r requirements/edx-sandbox/base.in
-packaging==25.0
+packaging==26.2
     # via matplotlib
-pillow==11.3.0
+pillow==12.3.0
     # via matplotlib
-pycparser==2.23
+pycparser==3.0
     # via cffi
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
@@ -74,9 +74,9 @@ python-dateutil==2.9.0.post0
     # via matplotlib
 random2==1.0.2
     # via -r requirements/edx-sandbox/base.in
-regex==2025.9.18
+regex==2026.7.10
     # via nltk
-scipy==1.16.2
+scipy==1.17.1
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
@@ -86,5 +86,5 @@ sympy==1.14.0
     # via
     #   -r requirements/edx-sandbox/base.in
     #   openedx-calc
-tqdm==4.67.1
+tqdm==4.69.0
     # via nltk

--- a/requirements/edx/assets.txt
+++ b/requirements/edx/assets.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-click==8.3.0
+click==8.4.2
     # via -r requirements/edx/assets.in
 libsass==0.10.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.in
-nodeenv==1.9.1
+nodeenv==1.10.0
     # via -r requirements/edx/assets.in
 six==1.17.0
     # via libsass

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,9 +6,9 @@
 #
 acid-xblock==0.4.1
     # via -r requirements/edx/kernel.in
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.1
     # via geoip2
 aiosignal==1.4.0
     # via aiohttp
@@ -22,18 +22,18 @@ aniso8601==10.0.1
     #   tincan
 annotated-types==0.7.0
     # via pydantic
-anyio==4.11.0
+anyio==4.14.2
     # via httpx
 appdirs==1.4.4
     # via fs
-asgiref==3.10.0
+asgiref==3.12.1
     # via
     #   django
     #   django-cors-headers
     #   django-countries
 asn1crypto==1.5.1
     # via snowflake-connector-python
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   aiohttp
@@ -43,7 +43,7 @@ attrs==25.4.0
     #   openedx-events
     #   openedx-learning
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   -r requirements/edx/kernel.in
     #   enmerkar
@@ -52,13 +52,14 @@ backoff==1.10.0
     # via analytics-python
 bcrypt==5.0.0
     # via paramiko
-beautifulsoup4==4.14.2
+beautifulsoup4==4.15.0
     # via
     #   openedx-forum
     #   pynliner
-billiard==4.2.2
+    #   xblocks-contrib
+billiard==4.2.4
     # via celery
-bleach[css]==6.2.0
+bleach[css]==6.4.0
     # via
     #   edx-enterprise
     #   lti-consumer-xblock
@@ -68,14 +69,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/kernel.in
-boto3==1.40.46
+boto3==1.43.50
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.40.46
+botocore==1.43.50
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -83,15 +84,13 @@ botocore==1.40.46
     #   snowflake-connector-python
 bridgekeeper==0.9
     # via -r requirements/edx/kernel.in
-cachecontrol==0.14.3
+cachecontrol==0.14.4
     # via firebase-admin
-cachetools==6.2.0
-    # via
-    #   edxval
-    #   google-auth
-camel-converter[pydantic]==4.0.1
+cachetools==7.1.4
+    # via edxval
+camel-converter[pydantic]==5.1.0
     # via meilisearch
-celery==5.5.3
+celery==5.6.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
@@ -102,26 +101,30 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.10.5
+certifi==2026.6.17
     # via
     #   elasticsearch
     #   httpcore
     #   httpx
     #   requests
     #   snowflake-connector-python
-cffi==1.17.1
+cffi==2.1.0
     # via
     #   cryptography
     #   pynacl
-chardet==5.2.0
-    # via pysrt
-charset-normalizer==3.4.3
+chardet==7.4.3
+    # via
+    #   encutils
+    #   pysrt
+charset-normalizer==3.4.9
     # via
     #   requests
     #   snowflake-connector-python
 chem==2.0.0
-    # via -r requirements/edx/kernel.in
-click==8.3.0
+    # via
+    #   -r requirements/edx/kernel.in
+    #   xblocks-contrib
+click==8.4.2
     # via
     #   celery
     #   click-didyoumean
@@ -136,20 +139,20 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   edx-enterprise
     #   edx-toggles
 codejail-includes==2.0.0
     # via -r requirements/edx/kernel.in
-crowdsourcehinter-xblock==0.8
+crowdsourcehinter-xblock==1.0.1
     # via -r requirements/edx/bundled.in
-cryptography==45.0.7
+cryptography==49.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-fernet-fields-v2
     #   edx-enterprise
+    #   google-auth
     #   jwcrypto
     #   paramiko
     #   pgpy
@@ -157,16 +160,18 @@ cryptography==45.0.7
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.11.1
+cssutils==2.15.0
     # via pynliner
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/kernel.in
     #   djangorestframework-xml
+    #   nltk
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.28
+    #   xblocks-contrib
+django==4.2.30
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -240,10 +245,11 @@ django==4.2.28
     #   social-auth-app-django
     #   super-csv
     #   xblock-google-drive
+    #   xblocks-contrib
     #   xss-utils
-django-appconf==1.1.0
+django-appconf==1.2.0
     # via django-statici18n
-django-autocomplete-light==3.12.1
+django-autocomplete-light==4.0.3
     # via -r requirements/edx/kernel.in
 django-cache-memoize==0.2.1
     # via edx-enterprise
@@ -251,7 +257,7 @@ django-celery-results==2.6.0
     # via -r requirements/edx/kernel.in
 django-classy-tags==4.1.0
     # via django-sekizai
-django-config-models==2.9.0
+django-config-models==3.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -260,7 +266,7 @@ django-config-models==2.9.0
     #   lti-consumer-xblock
 django-cors-headers==4.9.0
     # via -r requirements/edx/kernel.in
-django-countries==7.6.1
+django-countries==9.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -287,7 +293,7 @@ django-ipware==7.0.1
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring
-django-js-asset==3.1.2
+django-js-asset==4.0.1
     # via django-mptt
 django-method-override==1.0.4
     # via -r requirements/edx/kernel.in
@@ -324,13 +330,13 @@ django-oauth-toolkit==1.7.1
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   enterprise-integrated-channels
-django-object-actions==5.0.0
+django-object-actions==5.1.2
     # via
     #   edx-enterprise
     #   enterprise-integrated-channels
 django-pipeline==4.1.0
     # via -r requirements/edx/kernel.in
-django-push-notifications==3.2.1
+django-push-notifications==3.3.0
     # via edx-ace
 django-ratelimit==4.1.0
     # via -r requirements/edx/kernel.in
@@ -338,9 +344,9 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
-django-ses==4.4.0
+django-ses==4.7.2
     # via -r requirements/edx/bundled.in
-django-simple-history==3.10.1
+django-simple-history==3.12.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -349,18 +355,17 @@ django-simple-history==3.10.1
     #   edx-proctoring
     #   enterprise-integrated-channels
     #   ora2
-django-statici18n==2.6.0
+django-statici18n==2.7.1
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-poll
-    #   xblocks-contrib
 django-storages==1.14.6
     # via
     #   -r requirements/edx/kernel.in
     #   edxval
-django-user-tasks==3.4.3
+django-user-tasks==4.0.0
     # via -r requirements/edx/kernel.in
 django-waffle==5.0.0
     # via
@@ -370,11 +375,11 @@ django-waffle==5.0.0
     #   edx-enterprise
     #   edx-proctoring
     #   edx-toggles
-django-webpack-loader==3.2.1
+django-webpack-loader==3.2.4
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/edx/kernel.in
     #   django-config-models
@@ -398,25 +403,25 @@ djangorestframework-xml==2.0.0
     # via edx-enterprise
 dnspython==2.8.0
     # via pymongo
-done-xblock==2.5.0
+done-xblock==3.0.0
     # via -r requirements/edx/bundled.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
-drf-spectacular==0.28.0
+drf-spectacular==0.30.0
     # via -r requirements/edx/kernel.in
-drf-yasg==1.21.11
+drf-yasg==1.21.15
     # via
     #   django-user-tasks
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via -r requirements/edx/kernel.in
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==3.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation
-edx-auth-backends==4.6.1
+edx-auth-backends==5.0.0
     # via -r requirements/edx/kernel.in
-edx-bulk-grades==1.2.0
+edx-bulk-grades==2.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   staff-graded-xblock
@@ -425,21 +430,23 @@ edx-ccx-keys==2.0.2
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   openedx-events
-edx-celeryutils==1.4.0
+edx-celeryutils==2.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation
     #   super-csv
-edx-codejail==4.0.0
-    # via -r requirements/edx/kernel.in
-edx-completion==4.9
+edx-codejail==4.1.0
+    # via
+    #   -r requirements/edx/kernel.in
+    #   xblocks-contrib
+edx-completion==5.0.0
     # via -r requirements/edx/kernel.in
 edx-django-release-util==1.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-submissions
     #   edxval
-edx-django-sites-extensions==5.1.0
+edx-django-sites-extensions==6.0.0
     # via -r requirements/edx/kernel.in
 edx-django-utils==8.0.1
     # via
@@ -460,6 +467,7 @@ edx-django-utils==8.0.1
     #   openedx-events
     #   ora2
     #   super-csv
+    #   xblocks-contrib
 edx-drf-extensions==10.6.0
     # via
     #   -r requirements/edx/kernel.in
@@ -481,16 +489,15 @@ edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/kernel.in
 edx-event-bus-redis==0.6.1
     # via -r requirements/edx/kernel.in
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via
     #   -r requirements/edx/bundled.in
     #   ora2
-    #   xblocks-contrib
-edx-milestones==1.1.0
+edx-milestones==2.0.0
     # via -r requirements/edx/kernel.in
 edx-name-affirmation==3.0.2
     # via -r requirements/edx/kernel.in
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==4.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-bulk-grades
@@ -508,33 +515,34 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==7.3.0
+edx-organizations==8.0.0
     # via -r requirements/edx/kernel.in
 edx-proctoring==5.2.0
     # via -r requirements/edx/kernel.in
-edx-rbac==2.1.0
+edx-rbac==3.0.0
     # via
     #   edx-enterprise
     #   enterprise-integrated-channels
-edx-rest-api-client==6.2.0
+edx-rest-api-client==7.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring
     #   enterprise-integrated-channels
-edx-search==4.3.0
+edx-search==5.0.2
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-forum
-edx-sga==0.26.0
+edx-sga==0.29.0
     # via -r requirements/edx/bundled.in
-edx-submissions==3.12.0
+edx-submissions==4.0.1
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
+    #   xblocks-contrib
 edx-tincan-py35==2.0.0
     # via enterprise-integrated-channels
-edx-toggles==5.4.1
+edx-toggles==6.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
@@ -547,35 +555,40 @@ edx-toggles==5.4.1
     #   edxval
     #   event-tracking
     #   ora2
-edx-when==3.0.0
+    #   xblocks-contrib
+edx-when==4.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
-edxval==3.1.0
-    # via -r requirements/edx/kernel.in
+edxval==5.0.1
+    # via
+    #   -r requirements/edx/kernel.in
+    #   xblocks-contrib
 elasticsearch==7.9.1
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   edx-search
     #   openedx-forum
+encutils==1.0.0
+    # via cssutils
 enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
 enterprise-integrated-channels==0.1.62
     # via -r requirements/edx/bundled.in
-event-tracking==3.3.0
+event-tracking==4.0.2
     # via
     #   -r requirements/edx/kernel.in
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-fastavro==1.12.0
+fastavro==1.12.2
     # via openedx-events
-filelock==3.19.1
+filelock==3.30.3
     # via snowflake-connector-python
-firebase-admin==7.1.0
+firebase-admin==7.5.0
     # via edx-ace
 frozenlist==1.8.0
     # via
@@ -587,73 +600,78 @@ fs==2.4.16
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
+    #   xblocks-contrib
 fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-pyfs
-geoip2==5.1.0
+geoip2==5.3.0
     # via -r requirements/edx/kernel.in
 glob2==0.7
     # via -r requirements/edx/kernel.in
-google-api-core[grpc]==2.25.2
+google-api-core[grpc]==2.32.0
     # via
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth==2.41.1
+google-auth==2.56.0
     # via
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-core==2.4.3
+google-cloud-core==2.6.0
     # via
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.21.0
+google-cloud-firestore==2.28.0
     # via firebase-admin
-google-cloud-storage==3.4.0
+google-cloud-storage==3.13.0
     # via firebase-admin
-google-crc32c==1.7.1
+google-crc32c==1.8.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.7.2
+google-resumable-media==2.10.0
     # via google-cloud-storage
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.75.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.75.1
+grpcio==1.82.1
     # via
     #   google-api-core
+    #   google-cloud-firestore
     #   grpcio-status
-grpcio-status==1.75.1
+grpcio-status==1.82.1
     # via google-api-core
-gunicorn==23.0.0
+gunicorn==26.0.0
     # via -r requirements/edx/kernel.in
 h11==0.16.0
     # via httpcore
 h2==4.3.0
     # via httpx
-help-tokens==3.2.0
+help-tokens==4.0.0
     # via -r requirements/edx/kernel.in
-hpack==4.1.0
+hpack==4.2.0
     # via h2
 html5lib==1.1
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
+    #   xblocks-contrib
 httpcore==1.0.9
     # via httpx
 httpx[http2]==0.28.1
-    # via firebase-admin
+    # via
+    #   firebase-admin
+    #   typesense
 hyperframe==6.1.0
     # via h2
-icalendar==6.3.1
+icalendar==7.2.0
     # via -r requirements/edx/kernel.in
-idna==3.10
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -661,13 +679,13 @@ idna==3.10
     #   requests
     #   snowflake-connector-python
     #   yarl
-importlib-metadata==8.7.0
+importlib-metadata==9.0.0
     # via -r requirements/edx/kernel.in
 inflection==0.5.1
     # via
     #   drf-spectacular
     #   drf-yasg
-invoke==2.2.0
+invoke==3.0.3
     # via paramiko
 ipaddress==1.0.23
     # via -r requirements/edx/kernel.in
@@ -675,11 +693,11 @@ isodate==0.7.2
     # via python3-saml
 jinja2==3.1.6
     # via code-annotations
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-joblib==1.5.2
+joblib==1.5.3
     # via nltk
 jsondiff==2.2.1
     # via edx-enterprise
@@ -693,28 +711,30 @@ jsonfield==3.2.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via
     #   drf-spectacular
     #   optimizely-sdk
 jsonschema-specifications==2025.9.1
     # via jsonschema
-jwcrypto==1.5.6
+jwcrypto==1.5.8
     # via
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.5.4
+kombu==5.6.2
     # via celery
 laboratory==1.0.2
     # via -r requirements/edx/kernel.in
-lazy==1.6
+lazy==2.0
     # via
     #   acid-xblock
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==9.14.2
-    # via -r requirements/edx/kernel.in
+lti-consumer-xblock==10.0.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/edx/kernel.in
 lxml[html-clean]==5.3.2
     # via
     #   -c requirements/constraints.txt
@@ -729,19 +749,19 @@ lxml[html-clean]==5.3.2
     #   ora2
     #   python3-saml
     #   xblock
+    #   xblocks-contrib
     #   xmlsec
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via lxml
 mailsnake==1.6.4
     # via -r requirements/edx/bundled.in
-mako==1.3.10
+mako==1.3.12
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock
     #   lti-consumer-xblock
     #   xblock
-    #   xblock-utils
-markdown==3.9
+markdown==3.10.2
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
@@ -754,37 +774,38 @@ markupsafe==3.0.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.8.2
+    #   xblocks-contrib
+maxminddb==3.1.1
     # via geoip2
-meilisearch==0.37.0
+meilisearch==0.42.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-search
-mongoengine==0.29.1
+mongoengine==0.29.3
     # via -r requirements/edx/kernel.in
 monotonic==1.6
     # via analytics-python
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via cssutils
 mpmath==1.3.0
     # via sympy
-msgpack==1.1.1
+msgpack==1.2.1
     # via cachecontrol
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-forum
-nh3==0.3.0
+nh3==0.3.6
     # via
     #   -r requirements/edx/kernel.in
     #   xblocks-contrib
-nltk==3.9.2
+nltk==3.10.0
     # via chem
-nodeenv==1.9.1
+nodeenv==1.10.0
     # via -r requirements/edx/kernel.in
 numpy==1.26.4
     # via
@@ -793,6 +814,7 @@ numpy==1.26.4
     #   openedx-calc
     #   scipy
     #   shapely
+    #   xblocks-contrib
 oauthlib==3.3.1
     # via
     #   -r requirements/edx/kernel.in
@@ -809,13 +831,12 @@ openedx-atlas==0.7.0
     #   edx-enterprise
     #   enterprise-integrated-channels
     #   openedx-forum
-openedx-calc==4.0.2
-    # via -r requirements/edx/kernel.in
-openedx-django-pyfs==3.8.0
+openedx-calc==4.0.3
     # via
-    #   lti-consumer-xblock
-    #   xblock
+    #   -r requirements/edx/kernel.in
     #   xblocks-contrib
+openedx-django-pyfs==4.0.0
+    # via xblock
 openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==3.1.2
@@ -829,29 +850,30 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.8
+openedx-forum==0.4.1
     # via -r requirements/edx/kernel.in
 openedx-learning==0.27.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
-optimizely-sdk==5.2.0
+optimizely-sdk==5.6.0
     # via -r requirements/edx/bundled.in
-ora2==6.17.2
+ora2==7.1.0
     # via -r requirements/edx/bundled.in
-packaging==25.0
+packaging==26.2
     # via
     #   drf-yasg
     #   gunicorn
     #   kombu
     #   snowflake-connector-python
-paramiko==4.0.0
+    #   wheel
+paramiko==5.0.0
     # via edx-enterprise
 path==16.11.0
     # via
@@ -859,6 +881,7 @@ path==16.11.0
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools
     #   path-py
+    #   xblocks-contrib
 path-py==12.5.0
     # via
     #   edx-enterprise
@@ -868,58 +891,57 @@ pgpy==0.6.0
     # via edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/kernel.in
-pillow==11.3.0
+pillow==12.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-platformdirs==4.4.0
+platformdirs==4.10.0
     # via snowflake-connector-python
 polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.52
     # via click-repl
-propcache==0.4.0
+propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
-proto-plus==1.26.1
+proto-plus==1.28.1
     # via
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.32.1
+protobuf==7.35.1
     # via
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.1.0
+psutil==7.2.2
     # via
     #   -r requirements/edx/kernel.in
     #   edx-django-utils
-pyasn1==0.6.1
+pyasn1==0.6.4
     # via
     #   pgpy
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycountry==24.6.1
+pycountry==26.2.16
     # via -r requirements/edx/kernel.in
-pycparser==2.23
+pycparser==3.0
     # via cffi
 pycryptodomex==3.23.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
     #   lti-consumer-xblock
-pydantic==2.11.10
+pydantic==2.13.4
     # via camel-converter
-pydantic-core==2.33.2
+pydantic-core==2.46.4
     # via pydantic
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
     # via
     #   -r requirements/edx/kernel.in
     #   drf-jwt
@@ -946,18 +968,19 @@ pymongo==4.4.0
     #   event-tracking
     #   mongoengine
     #   openedx-forum
-pynacl==1.6.0
+pynacl==1.6.2
     # via
     #   edx-django-utils
     #   paramiko
 pynliner==0.8.0
     # via -r requirements/edx/kernel.in
-pyopenssl==25.3.0
+pyopenssl==26.3.0
     # via snowflake-connector-python
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via
     #   chem
     #   openedx-calc
+    #   xblocks-contrib
 pyrsistent==0.20.0
     # via optimizely-sdk
 pysrt==1.1.2
@@ -981,7 +1004,7 @@ python-ipware==3.0.0
     # via django-ipware
 python-slugify==8.0.4
     # via code-annotations
-python-swiftclient==4.8.0
+python-swiftclient==4.10.0
     # via ora2
 python3-openid==3.2.0 ; python_version >= "3"
     # via
@@ -991,7 +1014,7 @@ python3-saml==1.16.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
-pytz==2025.2
+pytz==2026.2
     # via
     #   -r requirements/edx/kernel.in
     #   drf-yasg
@@ -1007,6 +1030,7 @@ pytz==2025.2
     #   snowflake-connector-python
     #   tincan
     #   xblock
+    #   xblocks-contrib
 pyuca==1.2
     # via -r requirements/edx/kernel.in
 pyyaml==6.0.3
@@ -1020,20 +1044,22 @@ pyyaml==6.0.3
     #   jsondiff
     #   xblock
 random2==1.0.2
-    # via -r requirements/edx/kernel.in
-recommender-xblock==3.1.0
+    # via
+    #   -r requirements/edx/kernel.in
+    #   xblocks-contrib
+recommender-xblock==5.0.0
     # via -r requirements/edx/bundled.in
-redis==6.4.0
+redis==8.0.1
     # via
     #   -r requirements/edx/kernel.in
     #   walrus
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.9.18
+regex==2026.7.10
     # via nltk
-requests==2.32.5
+requests==2.34.2
     # via
     #   analytics-python
     #   cachecontrol
@@ -1058,39 +1084,40 @@ requests==2.32.5
     #   snowflake-connector-python
     #   social-auth-core
     #   xblock-google-drive
+    #   xblocks-contrib
 requests-oauthlib==2.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   social-auth-core
-rpds-py==0.27.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via google-auth
 rules==3.5
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.14.0
+s3transfer==0.19.1
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
-scipy==1.16.2
+scipy==1.17.1
     # via chem
 semantic-version==2.10.0
     # via edx-drf-extensions
 shapely==2.1.2
-    # via -r requirements/edx/kernel.in
-simplejson==3.20.2
+    # via
+    #   -r requirements/edx/kernel.in
+    #   xblocks-contrib
+simplejson==4.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   sailthru-client
     #   super-csv
     #   xblock
-    #   xblock-utils
+    #   xblocks-contrib
 six==1.17.0
     # via
     #   -r requirements/edx/kernel.in
@@ -1114,22 +1141,22 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-sniffio==1.3.1
-    # via anyio
-snowflake-connector-python==4.2.0
+snowflake-connector-python==4.7.1
     # via enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
     #   edx-enterprise
-social-auth-core==4.7.0
+social-auth-core==4.9.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
     #   social-auth-app-django
-sorl-thumbnail==12.11.0
+sorl-thumbnail==13.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
@@ -1137,13 +1164,13 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   snowflake-connector-python
-soupsieve==2.8
+soupsieve==2.8.4
     # via beautifulsoup4
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-staff-graded-xblock==3.1.0
+staff-graded-xblock==4.0.1
     # via -r requirements/edx/bundled.in
-stevedore==5.5.0
+stevedore==5.9.0
     # via
     #   -r requirements/edx/kernel.in
     #   code-annotations
@@ -1151,32 +1178,38 @@ stevedore==5.5.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==4.1.0
+super-csv==5.0.0
     # via edx-bulk-grades
 sympy==1.14.0
     # via openedx-calc
-testfixtures==9.1.0
+testfixtures==12.3.0
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify
 tincan==1.0.0
     # via edx-enterprise
-tinycss2==1.4.0
+tinycss2==1.5.1
     # via bleach
-tomlkit==0.13.3
+tomlkit==0.15.1
     # via
     #   openedx-learning
     #   snowflake-connector-python
-tqdm==4.67.1
+tqdm==4.69.0
     # via nltk
-typing-extensions==4.15.0
+typesense==2.0.0
     # via
+    #   edx-search
+    #   openedx-forum
+typing-extensions==4.16.0
+    # via
+    #   aiohttp
     #   aiosignal
     #   anyio
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
     #   grpcio
+    #   icalendar
     #   jwcrypto
     #   pydantic
     #   pydantic-core
@@ -1184,13 +1217,17 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
+    #   testfixtures
+    #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-tzdata==2025.2
+tzdata==2026.3
     # via
     #   icalendar
     #   kombu
+tzlocal==5.4.4
+    # via celery
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/kernel.in
@@ -1202,7 +1239,7 @@ uritemplate==4.2.0
     # via
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   botocore
     #   elasticsearch
@@ -1212,34 +1249,34 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-voluptuous==0.15.2
+voluptuous==0.16.0
     # via ora2
-walrus==0.9.5
+walrus==0.9.8
     # via edx-event-bus-redis
-wcwidth==0.2.14
+wcwidth==0.8.2
     # via prompt-toolkit
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via
     #   -r requirements/edx/kernel.in
-    #   crowdsourcehinter-xblock
-    #   edx-sga
-    #   staff-graded-xblock
     #   xblock
-    #   xblock-utils
+    #   xblocks-contrib
 webencodings==0.5.1
     # via
     #   bleach
     #   html5lib
     #   tinycss2
-webob==1.8.9
+webob==1.8.10
     # via
     #   -r requirements/edx/kernel.in
     #   xblock
-wheel==0.45.1
+    #   xblocks-contrib
+wheel==0.47.0
     # via django-pipeline
-wrapt==1.17.3
-    # via -r requirements/edx/kernel.in
-xblock[django]==5.2.0
+wrapt==2.2.2
+    # via
+    #   -r requirements/edx/kernel.in
+    #   xblocks-contrib
+xblock[django]==6.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock
@@ -1253,29 +1290,25 @@ xblock[django]==5.2.0
     #   staff-graded-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-google-drive
-    #   xblock-utils
+    #   xblock-poll
     #   xblocks-contrib
 xblock-drag-and-drop-v2==5.0.3
     # via -r requirements/edx/bundled.in
 xblock-google-drive==0.8.1
     # via -r requirements/edx/bundled.in
-xblock-poll==1.15.1
+xblock-poll==1.16.1
     # via -r requirements/edx/bundled.in
-xblock-utils==4.0.0
-    # via
-    #   edx-sga
-    #   xblock-poll
-xblocks-contrib==0.6.0
+xblocks-contrib==0.13.1
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via
     #   -c requirements/constraints.txt
     #   python3-saml
-xss-utils==0.8.0
+xss-utils==1.0.0
     # via -r requirements/edx/kernel.in
-yarl==1.22.0
+yarl==1.24.2
     # via aiohttp
-zipp==3.23.0
+zipp==4.1.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-chardet==5.2.0
+chardet==7.4.3
     # via diff-cover
-coverage==7.10.7
+coverage==7.15.2
     # via -r requirements/edx/coverage.in
-diff-cover==9.7.1
+diff-cover==10.3.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.6
     # via diff-cover
@@ -16,5 +16,5 @@ markupsafe==3.0.3
     # via jinja2
 pluggy==1.6.0
     # via diff-cover
-pygments==2.19.2
+pygments==2.20.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -12,12 +12,12 @@ acid-xblock==0.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.7.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -51,18 +51,17 @@ annotated-types==0.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pydantic
-anyio==4.11.0
+anyio==4.14.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   httpx
-    #   starlette
 appdirs==1.4.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   fs
-asgiref==3.10.0
+asgiref==3.12.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -74,14 +73,15 @@ asn1crypto==1.5.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-astroid==4.0.3
+astroid==4.0.4
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pylint
     #   pylint-celery
     #   sphinx-autoapi
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -92,7 +92,7 @@ attrs==25.4.0
     #   openedx-events
     #   openedx-learning
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -110,19 +110,20 @@ bcrypt==5.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   paramiko
-beautifulsoup4==4.14.2
+beautifulsoup4==4.15.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-forum
     #   pydata-sphinx-theme
     #   pynliner
-billiard==4.2.2
+    #   xblocks-contrib
+billiard==4.2.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   celery
-bleach[css]==6.2.0
+bleach[css]==6.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -136,7 +137,7 @@ boto==2.49.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.40.46
+boto3==1.43.50
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -144,7 +145,7 @@ boto3==1.40.46
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.40.46
+botocore==1.43.50
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -155,28 +156,27 @@ bridgekeeper==0.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-build==1.3.0
+build==1.5.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachecontrol==0.14.3
+cachecontrol==0.14.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
-cachetools==6.2.0
+cachetools==7.1.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edxval
-    #   google-auth
     #   tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   meilisearch
-celery==5.5.3
+celery==5.6.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
@@ -188,7 +188,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.10.5
+certifi==2026.6.17
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -197,21 +197,21 @@ certifi==2025.10.5
     #   httpx
     #   requests
     #   snowflake-connector-python
-cffi==1.17.1
+cffi==2.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cryptography
-    #   pact-python
+    #   pact-python-ffi
     #   pynacl
-chardet==5.2.0
+chardet==7.4.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   diff-cover
+    #   encutils
     #   pysrt
-    #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -221,7 +221,8 @@ chem==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-click==8.3.0
+    #   xblocks-contrib
+click==8.4.2
     # via
     #   -r requirements/edx/assets.txt
     #   -r requirements/edx/development.in
@@ -238,9 +239,7 @@ click==8.3.0
     #   edx-lint
     #   import-linter
     #   nltk
-    #   pact-python
     #   pip-tools
-    #   uvicorn
 click-didyoumean==0.3.1
     # via
     #   -r requirements/edx/doc.txt
@@ -260,7 +259,7 @@ click-repl==0.3.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -275,21 +274,21 @@ colorama==0.4.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-coverage[toml]==7.10.7
+coverage[toml]==7.15.2
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
-crowdsourcehinter-xblock==0.8
+crowdsourcehinter-xblock==1.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-cryptography==45.0.7
+cryptography==49.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-fernet-fields-v2
     #   edx-enterprise
+    #   google-auth
     #   jwcrypto
     #   paramiko
     #   pgpy
@@ -297,18 +296,18 @@ cryptography==45.0.7
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssselect==1.3.0
+cssselect==1.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
-cssutils==2.11.1
+cssutils==2.15.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pynliner
 ddt==1.7.2
     # via -r requirements/edx/testing.txt
-deepmerge==2.0
+deepmerge==2.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinxcontrib-openapi
@@ -317,20 +316,22 @@ defusedxml==0.7.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   djangorestframework-xml
+    #   nltk
     #   ora2
     #   python3-openid
     #   social-auth-core
-diff-cover==9.7.1
+    #   xblocks-contrib
+diff-cover==10.3.0
     # via -r requirements/edx/testing.txt
-dill==0.4.0
+dill==0.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-distlib==0.4.0
+distlib==0.4.3
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==4.2.28
+django==4.2.30
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -408,13 +409,14 @@ django==4.2.28
     #   social-auth-app-django
     #   super-csv
     #   xblock-google-drive
+    #   xblocks-contrib
     #   xss-utils
-django-appconf==1.1.0
+django-appconf==1.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-statici18n
-django-autocomplete-light==3.12.1
+django-autocomplete-light==4.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -432,7 +434,7 @@ django-classy-tags==4.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-sekizai
-django-config-models==2.9.0
+django-config-models==3.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -444,7 +446,7 @@ django-cors-headers==4.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-countries==7.6.1
+django-countries==9.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -481,7 +483,7 @@ django-ipware==7.0.1
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-django-js-asset==3.1.2
+django-js-asset==4.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -531,7 +533,7 @@ django-oauth-toolkit==1.7.1
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-django-object-actions==5.0.0
+django-object-actions==5.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -541,7 +543,7 @@ django-pipeline==4.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-push-notifications==3.2.1
+django-push-notifications==3.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -555,11 +557,11 @@ django-sekizai==4.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-django-wiki
-django-ses==4.4.0
+django-ses==4.7.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-simple-history==3.10.1
+django-simple-history==3.12.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -569,27 +571,26 @@ django-simple-history==3.10.1
     #   edx-proctoring
     #   enterprise-integrated-channels
     #   ora2
-django-statici18n==2.6.0
+django-statici18n==2.7.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-poll
-    #   xblocks-contrib
 django-storages==1.14.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edxval
-django-stubs[compatible-mypy]==5.2.6
+django-stubs[compatible-mypy]==5.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/development.in
     #   djangorestframework-stubs
-django-stubs-ext==5.2.6
+django-stubs-ext==6.0.7
     # via django-stubs
-django-user-tasks==3.4.3
+django-user-tasks==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -602,12 +603,12 @@ django-waffle==5.0.0
     #   edx-enterprise
     #   edx-proctoring
     #   edx-toggles
-django-webpack-loader==3.2.1
+django-webpack-loader==3.2.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -628,7 +629,7 @@ djangorestframework==3.16.1
     #   openedx-learning
     #   ora2
     #   super-csv
-djangorestframework-stubs==3.16.4
+djangorestframework-stubs==3.16.9
     # via -r requirements/edx/development.in
 djangorestframework-xml==2.0.0
     # via
@@ -640,13 +641,13 @@ dnspython==2.8.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pymongo
-docutils==0.21.2
+docutils==0.22.4
     # via
     #   -r requirements/edx/doc.txt
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
-done-xblock==2.5.0
+done-xblock==3.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -655,11 +656,11 @@ drf-jwt==1.19.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
-drf-spectacular==0.28.0
+drf-spectacular==0.30.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-drf-yasg==1.21.11
+drf-yasg==1.21.15
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -669,16 +670,16 @@ edx-ace==1.15.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==3.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
-edx-auth-backends==4.6.1
+edx-auth-backends==5.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-bulk-grades==1.2.0
+edx-bulk-grades==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -689,17 +690,18 @@ edx-ccx-keys==2.0.2
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   openedx-events
-edx-celeryutils==1.4.0
+edx-celeryutils==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
     #   super-csv
-edx-codejail==4.0.0
+edx-codejail==4.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-completion==4.9
+    #   xblocks-contrib
+edx-completion==5.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -709,7 +711,7 @@ edx-django-release-util==1.5.0
     #   -r requirements/edx/testing.txt
     #   edx-submissions
     #   edxval
-edx-django-sites-extensions==5.1.0
+edx-django-sites-extensions==6.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -733,6 +735,7 @@ edx-django-utils==8.0.1
     #   openedx-events
     #   ora2
     #   super-csv
+    #   xblocks-contrib
 edx-drf-extensions==10.6.0
     # via
     #   -r requirements/edx/doc.txt
@@ -760,15 +763,14 @@ edx-event-bus-redis==0.6.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-    #   xblocks-contrib
-edx-lint==5.6.0
+edx-lint==6.1.0
     # via -r requirements/edx/testing.txt
-edx-milestones==1.1.0
+edx-milestones==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -776,7 +778,7 @@ edx-name-affirmation==3.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -795,7 +797,7 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==7.3.0
+edx-organizations==8.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -803,39 +805,40 @@ edx-proctoring==5.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-rbac==2.1.0
+edx-rbac==3.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-edx-rest-api-client==6.2.0
+edx-rest-api-client==7.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
     #   enterprise-integrated-channels
-edx-search==4.3.0
+edx-search==5.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-forum
-edx-sga==0.26.0
+edx-sga==0.29.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-submissions==3.12.0
+edx-submissions==4.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
+    #   xblocks-contrib
 edx-tincan-py35==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   enterprise-integrated-channels
-edx-toggles==5.4.1
+edx-toggles==6.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -849,15 +852,17 @@ edx-toggles==5.4.1
     #   edxval
     #   event-tracking
     #   ora2
-edx-when==3.0.0
+    #   xblocks-contrib
+edx-when==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-edxval==3.1.0
+edxval==5.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   xblocks-contrib
 elasticsearch==7.9.1
     # via
     #   -c requirements/common_constraints.txt
@@ -866,6 +871,11 @@ elasticsearch==7.9.1
     #   -r requirements/edx/testing.txt
     #   edx-search
     #   openedx-forum
+encutils==1.0.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   cssutils
 enmerkar==0.7.1
     # via
     #   -r requirements/edx/doc.txt
@@ -879,40 +889,37 @@ enterprise-integrated-channels==0.1.62
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-event-tracking==3.3.0
+event-tracking==4.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-execnet==2.1.1
+execnet==2.1.2
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-xdist
 factory-boy==3.3.3
     # via -r requirements/edx/testing.txt
-faker==37.8.0
+faker==40.31.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.118.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   pact-python
-fastavro==1.12.0
+fastavro==1.12.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.30.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   python-discovery
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==7.1.0
+firebase-admin==7.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -932,12 +939,13 @@ fs==2.4.16
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
+    #   xblocks-contrib
 fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-django-pyfs
-geoip2==5.1.0
+geoip2==5.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -945,13 +953,13 @@ gitdb==4.0.12
     # via
     #   -r requirements/edx/doc.txt
     #   gitpython
-gitpython==3.1.45
+gitpython==3.1.52
     # via -r requirements/edx/doc.txt
 glob2==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-google-api-core[grpc]==2.25.2
+google-api-core[grpc]==2.32.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -959,7 +967,7 @@ google-api-core[grpc]==2.25.2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth==2.41.1
+google-auth==2.56.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -967,55 +975,56 @@ google-auth==2.41.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-core==2.4.3
+google-cloud-core==2.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.21.0
+google-cloud-firestore==2.28.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
-google-cloud-storage==3.4.0
+google-cloud-storage==3.13.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
-google-crc32c==1.7.1
+google-crc32c==1.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.7.2
+google-resumable-media==2.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-cloud-storage
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.75.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grimp==3.11
+grimp==3.15
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
-grpcio==1.75.1
+grpcio==1.82.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
+    #   google-cloud-firestore
     #   grpcio-status
-grpcio-status==1.75.1
+grpcio-status==1.82.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
-gunicorn==23.0.0
+gunicorn==26.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1024,17 +1033,16 @@ h11==0.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   httpcore
-    #   uvicorn
 h2==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   httpx
-help-tokens==3.2.0
+help-tokens==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-hpack==4.1.0
+hpack==4.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1044,6 +1052,7 @@ html5lib==1.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
+    #   xblocks-contrib
 httpcore==1.0.9
     # via
     #   -r requirements/edx/doc.txt
@@ -1056,16 +1065,17 @@ httpx[http2]==0.28.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
+    #   typesense
 hyperframe==6.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   h2
-icalendar==6.3.1
+icalendar==7.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-idna==3.10
+idna==3.18
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1075,13 +1085,13 @@ idna==3.10
     #   requests
     #   snowflake-connector-python
     #   yarl
-imagesize==1.4.1
+imagesize==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-import-linter==2.5
+import-linter==2.13
     # via -r requirements/edx/testing.txt
-importlib-metadata==8.7.0
+importlib-metadata==9.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1091,11 +1101,11 @@ inflection==0.5.1
     #   -r requirements/edx/testing.txt
     #   drf-spectacular
     #   drf-yasg
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest
-invoke==2.2.0
+invoke==3.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1109,7 +1119,7 @@ isodate==0.7.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml
-isort==6.1.0
+isort==8.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -1121,13 +1131,13 @@ jinja2==3.1.6
     #   diff-cover
     #   sphinx
     #   sphinx-autoapi
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   boto3
     #   botocore
-joblib==1.5.2
+joblib==1.5.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1148,7 +1158,7 @@ jsonfield==3.2.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1160,13 +1170,13 @@ jsonschema-specifications==2025.9.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jsonschema
-jwcrypto==1.5.6
+jwcrypto==1.5.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1175,7 +1185,7 @@ laboratory==1.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-lazy==1.6
+lazy==2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1183,12 +1193,15 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
+librt==0.13.0
+    # via mypy
 libsass==0.10.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.txt
-lti-consumer-xblock==9.14.2
+lti-consumer-xblock==10.0.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 lxml[html-clean]==5.3.2
@@ -1207,8 +1220,9 @@ lxml[html-clean]==5.3.2
     #   pyquery
     #   python3-saml
     #   xblock
+    #   xblocks-contrib
     #   xmlsec
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1217,21 +1231,24 @@ mailsnake==1.6.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-mako==1.3.10
+mako==1.3.12
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   acid-xblock
     #   lti-consumer-xblock
     #   xblock
-    #   xblock-utils
-markdown==3.9
+markdown==3.10.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
+markdown-it-py==4.2.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   rich
 markupsafe==3.0.3
     # via
     #   -r requirements/edx/doc.txt
@@ -1241,7 +1258,8 @@ markupsafe==3.0.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.8.2
+    #   xblocks-contrib
+maxminddb==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1250,18 +1268,22 @@ mccabe==0.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-meilisearch==0.37.0
+mdurl==0.1.2
+    # via
+    #   -r requirements/edx/testing.txt
+    #   markdown-it-py
+meilisearch==0.42.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-search
-mistune==3.1.4
+mistune==3.3.3
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx-mdinclude
 mock==5.2.0
     # via -r requirements/edx/testing.txt
-mongoengine==0.29.1
+mongoengine==0.29.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1270,7 +1292,7 @@ monotonic==1.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1280,39 +1302,39 @@ mpmath==1.3.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   sympy
-msgpack==1.1.1
+msgpack==1.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cachecontrol
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.18.2
+mypy==1.19.1
     # via
     #   -r requirements/edx/development.in
     #   django-stubs
 mypy-extensions==1.1.0
     # via mypy
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-forum
-nh3==0.3.0
+nh3==0.3.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblocks-contrib
-nltk==3.9.2
+nltk==3.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   chem
-nodeenv==1.9.1
+nodeenv==1.10.0
     # via
     #   -r requirements/edx/assets.txt
     #   -r requirements/edx/doc.txt
@@ -1326,6 +1348,7 @@ numpy==1.26.4
     #   openedx-calc
     #   scipy
     #   shapely
+    #   xblocks-contrib
 oauthlib==3.3.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1346,17 +1369,16 @@ openedx-atlas==0.7.0
     #   edx-enterprise
     #   enterprise-integrated-channels
     #   openedx-forum
-openedx-calc==4.0.2
+openedx-calc==4.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-django-pyfs==3.8.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   lti-consumer-xblock
-    #   xblock
     #   xblocks-contrib
+openedx-django-pyfs==4.0.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   xblock
 openedx-django-require==3.0.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1375,14 +1397,14 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.8
+openedx-forum==0.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1391,15 +1413,15 @@ openedx-learning==0.27.1
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-optimizely-sdk==5.2.0
+optimizely-sdk==5.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.17.2
+ora2==7.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-packaging==25.0
+packaging==26.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1408,17 +1430,19 @@ packaging==25.0
     #   drf-yasg
     #   gunicorn
     #   kombu
-    #   pydata-sphinx-theme
     #   pyproject-api
     #   pytest
     #   snowflake-connector-python
     #   sphinx
     #   tox
-pact-python==2.3.3
+    #   wheel
+pact-python==3.4.0
+    # via -r requirements/edx/testing.txt
+pact-python-ffi==0.5.4.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/testing.txt
-paramiko==4.0.0
+    #   pact-python
+paramiko==5.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1430,6 +1454,7 @@ path==16.11.0
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
     #   path-py
+    #   xblocks-contrib
 path-py==12.5.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1437,7 +1462,7 @@ path-py==12.5.0
     #   edx-enterprise
     #   ora2
     #   staff-graded-xblock
-pathspec==0.12.1
+pathspec==1.1.1
     # via mypy
 pgpy==0.6.0
     # via
@@ -1452,20 +1477,21 @@ piexif==1.1.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pillow==11.3.0
+pillow==12.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-pip-tools==7.5.1
+pip-tools==7.5.3
     # via -r requirements/pip-tools.txt
-platformdirs==4.4.0
+platformdirs==4.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pylint
+    #   python-discovery
     #   snowflake-connector-python
     #   tox
     #   virtualenv
@@ -1486,19 +1512,19 @@ prompt-toolkit==3.0.52
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   click-repl
-propcache==0.4.0
+propcache==0.5.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-proto-plus==1.26.1
+proto-plus==1.28.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.32.1
+protobuf==7.35.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1507,22 +1533,20 @@ protobuf==6.32.1
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.1.0
+psutil==7.2.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
-    #   pact-python
     #   pytest-xdist
 py==1.11.0
     # via -r requirements/edx/testing.txt
-pyasn1==0.6.1
+pyasn1==0.6.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pgpy
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -r requirements/edx/doc.txt
@@ -1532,11 +1556,11 @@ pycodestyle==2.8.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/testing.txt
-pycountry==24.6.1
+pycountry==26.2.16
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pycparser==2.23
+pycparser==3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1547,31 +1571,31 @@ pycryptodomex==3.23.0
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
     #   lti-consumer-xblock
-pydantic==2.11.10
+pydantic==2.13.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   camel-converter
-    #   fastapi
-pydantic-core==2.33.2
+pydantic-core==2.46.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pydantic
-pydata-sphinx-theme==0.15.4
+pydata-sphinx-theme==0.16.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx-book-theme
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   accessible-pygments
     #   diff-cover
     #   pydata-sphinx-theme
+    #   rich
     #   sphinx
     #   sphinx-mdinclude
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1590,7 +1614,7 @@ pylatexenc==2.10
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==4.0.4
+pylint==4.0.6
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1602,7 +1626,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
-pylint-django==2.7.0
+pylint-django==2.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1630,7 +1654,7 @@ pymongo==4.4.0
     #   event-tracking
     #   mongoengine
     #   openedx-forum
-pynacl==1.6.0
+pynacl==1.6.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1640,18 +1664,19 @@ pynliner==0.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pyopenssl==25.3.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   chem
     #   openedx-calc
-pyproject-api==1.9.1
+    #   xblocks-contrib
+pyproject-api==1.10.1
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -1685,9 +1710,9 @@ pytest==8.2.0
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.txt
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/edx/testing.txt
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/edx/testing.txt
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.txt
@@ -1695,7 +1720,7 @@ pytest-metadata==3.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-json-report
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==3.8.0
     # via -r requirements/edx/testing.txt
@@ -1714,6 +1739,11 @@ python-dateutil==2.9.0.post0
     #   olxcleaner
     #   ora2
     #   xblock
+python-discovery==1.4.4
+    # via
+    #   -r requirements/edx/testing.txt
+    #   tox
+    #   virtualenv
 python-ipware==3.0.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1724,7 +1754,7 @@ python-slugify==8.0.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   code-annotations
-python-swiftclient==4.8.0
+python-swiftclient==4.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1739,7 +1769,7 @@ python3-saml==1.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-pytz==2025.2
+pytz==2026.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1756,11 +1786,12 @@ pytz==2025.2
     #   snowflake-connector-python
     #   tincan
     #   xblock
+    #   xblocks-contrib
 pyuca==1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pywatchman==3.0.0
+pywatchman==4.0.0
     # via -r requirements/edx/development.in
 pyyaml==6.0.3
     # via
@@ -1779,34 +1810,34 @@ random2==1.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-recommender-xblock==3.1.0
+    #   xblocks-contrib
+recommender-xblock==5.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-redis==6.4.0
+redis==8.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   walrus
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.9.18
+regex==2026.7.10
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   nltk
-requests==2.32.5
+requests==2.34.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit
-    #   djangorestframework-stubs
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise
@@ -1819,7 +1850,6 @@ requests==2.32.5
     #   meilisearch
     #   openedx-forum
     #   optimizely-sdk
-    #   pact-python
     #   pylti1p3
     #   python-swiftclient
     #   requests-oauthlib
@@ -1829,26 +1859,26 @@ requests==2.32.5
     #   social-auth-core
     #   sphinx
     #   xblock-google-drive
+    #   xblocks-contrib
 requests-oauthlib==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   social-auth-core
-roman-numerals-py==3.1.0
+rich==15.0.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   import-linter
+roman-numerals==4.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-rpds-py==0.27.1
+rpds-py==2026.6.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   google-auth
 rules==3.5
     # via
     #   -r requirements/edx/doc.txt
@@ -1856,7 +1886,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.14.0
+s3transfer==0.19.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1866,7 +1896,7 @@ sailthru-client==2.2.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-ace
-scipy==1.16.2
+scipy==1.17.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1880,14 +1910,15 @@ shapely==2.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-simplejson==3.20.2
+    #   xblocks-contrib
+simplejson==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   sailthru-client
     #   super-csv
     #   xblock
-    #   xblock-utils
+    #   xblocks-contrib
 singledispatch==4.1.2
     # via -r requirements/edx/testing.txt
 six==1.17.0
@@ -1910,9 +1941,7 @@ six==1.17.0
     #   fs-s3fs
     #   html5lib
     #   libsass
-    #   pact-python
     #   python-dateutil
-    #   sphinxcontrib-httpdomain
 slumber==0.7.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1920,38 +1949,35 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-smmap==5.0.2
+smmap==5.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   gitdb
-sniffio==1.3.1
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   anyio
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==4.2.0
+snowflake-connector-python==4.7.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
     #   edx-enterprise
-social-auth-core==4.7.0
+social-auth-core==4.9.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sorl-thumbnail==12.11.0
+sorl-thumbnail==13.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1961,12 +1987,12 @@ sortedcontainers==2.4.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-soupsieve==2.8
+soupsieve==2.8.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==8.2.3
+sphinx==9.0.4
     # via
     #   -r requirements/edx/doc.txt
     #   pydata-sphinx-theme
@@ -1982,15 +2008,15 @@ sphinx-autoapi==3.6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
-sphinx-book-theme==1.1.4
+sphinx-book-theme==1.2.0
     # via -r requirements/edx/doc.txt
-sphinx-design==0.6.1
+sphinx-design==0.7.0
     # via -r requirements/edx/doc.txt
 sphinx-mdinclude==0.6.2
     # via
     #   -r requirements/edx/doc.txt
     #   sphinxcontrib-openapi
-sphinx-reredirects==1.0.0
+sphinx-reredirects==1.1.0
     # via -r requirements/edx/doc.txt
 sphinxcontrib-applehelp==2.0.0
     # via
@@ -2004,7 +2030,7 @@ sphinxcontrib-htmlhelp==2.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-sphinxcontrib-httpdomain==1.8.1
+sphinxcontrib-httpdomain==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinxcontrib-openapi
@@ -2012,7 +2038,7 @@ sphinxcontrib-jsmath==1.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-sphinxcontrib-openapi[markdown]==0.8.4
+sphinxcontrib-openapi[markdown]==0.9.0
     # via -r requirements/edx/doc.txt
 sphinxcontrib-qthelp==2.0.0
     # via
@@ -2024,21 +2050,17 @@ sphinxcontrib-serializinghtml==2.0.0
     #   sphinx
 sphinxext-rediraffe==0.3.0
     # via -r requirements/edx/doc.txt
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django
     #   django-debug-toolbar
-staff-graded-xblock==3.1.0
+staff-graded-xblock==4.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-starlette==0.48.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   fastapi
-stevedore==5.5.0
+stevedore==5.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2047,7 +2069,7 @@ stevedore==5.5.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==4.1.0
+super-csv==5.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2057,7 +2079,7 @@ sympy==1.14.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-calc
-testfixtures==9.1.0
+testfixtures==12.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2072,35 +2094,45 @@ tincan==1.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-tinycss2==1.4.0
+tinycss2==1.5.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   bleach
-tomlkit==0.13.3
+tomli-w==1.2.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   tox
+tomlkit==0.15.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   edx-lint
     #   openedx-learning
     #   pylint
     #   snowflake-connector-python
-tox==4.30.3
+tox==4.56.4
     # via -r requirements/edx/testing.txt
-tqdm==4.67.1
+tqdm==4.69.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   nltk
-types-pyyaml==6.0.12.20250915
+types-pyyaml==6.0.12.20260518
     # via
     #   django-stubs
     #   djangorestframework-stubs
-types-requests==2.32.4.20250913
-    # via djangorestframework-stubs
-typing-extensions==4.15.0
+typesense==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   edx-search
+    #   openedx-forum
+typing-extensions==4.16.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   aiohttp
     #   aiosignal
     #   anyio
     #   beautifulsoup4
@@ -2109,12 +2141,12 @@ typing-extensions==4.15.0
     #   django-stubs-ext
     #   djangorestframework-stubs
     #   edx-opaque-keys
-    #   fastapi
-    #   grimp
     #   grpcio
+    #   icalendar
     #   import-linter
     #   jwcrypto
     #   mypy
+    #   pact-python
     #   pydantic
     #   pydantic-core
     #   pydata-sphinx-theme
@@ -2122,20 +2154,25 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
-    #   starlette
+    #   testfixtures
+    #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pydantic
-tzdata==2025.2
+tzdata==2026.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   faker
     #   icalendar
     #   kombu
+tzlocal==5.4.4
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   celery
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/doc.txt
@@ -2154,18 +2191,13 @@ uritemplate==4.2.0
     #   -r requirements/edx/testing.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   botocore
     #   elasticsearch
     #   requests
-    #   types-requests
-uvicorn==0.37.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   pact-python
 vine==5.1.0
     # via
     #   -r requirements/edx/doc.txt
@@ -2173,38 +2205,35 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==21.6.1
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-voluptuous==0.15.2
+voluptuous==0.16.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-vulture==2.14
+vulture==2.16
     # via -r requirements/edx/development.in
-walrus==0.9.5
+walrus==0.9.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-redis
 watchdog==6.0.0
     # via -r requirements/edx/development.in
-wcwidth==0.2.14
+wcwidth==0.8.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   prompt-toolkit
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   crowdsourcehinter-xblock
-    #   edx-sga
-    #   staff-graded-xblock
     #   xblock
-    #   xblock-utils
+    #   xblocks-contrib
 webencodings==0.5.1
     # via
     #   -r requirements/edx/doc.txt
@@ -2212,23 +2241,25 @@ webencodings==0.5.1
     #   bleach
     #   html5lib
     #   tinycss2
-webob==1.8.9
+webob==1.8.10
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblock
-wheel==0.45.1
+    #   xblocks-contrib
+wheel==0.47.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   -r requirements/pip-tools.txt
     #   django-pipeline
     #   pip-tools
-wrapt==1.17.3
+wrapt==2.2.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblock[django]==5.2.0
+    #   xblocks-contrib
+xblock[django]==6.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2243,7 +2274,7 @@ xblock[django]==5.2.0
     #   staff-graded-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-google-drive
-    #   xblock-utils
+    #   xblock-poll
     #   xblocks-contrib
 xblock-drag-and-drop-v2==5.0.3
     # via
@@ -2253,17 +2284,11 @@ xblock-google-drive==0.8.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblock-poll==1.15.1
+xblock-poll==1.16.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblock-utils==4.0.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   edx-sga
-    #   xblock-poll
-xblocks-contrib==0.6.0
+xblocks-contrib==0.13.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2273,17 +2298,17 @@ xmlsec==1.3.14
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml
-xss-utils==0.8.0
+xss-utils==1.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-yarl==1.22.0
+yarl==1.24.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   pact-python
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -8,11 +8,11 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 acid-xblock==0.4.1
     # via -r requirements/edx/base.txt
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.7.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.1
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -37,7 +37,7 @@ annotated-types==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-anyio==4.11.0
+anyio==4.14.2
     # via
     #   -r requirements/edx/base.txt
     #   httpx
@@ -45,7 +45,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-asgiref==3.10.0
+asgiref==3.12.1
     # via
     #   -r requirements/edx/base.txt
     #   django
@@ -55,9 +55,11 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==4.0.3
-    # via sphinx-autoapi
-attrs==25.4.0
+astroid==4.0.4
+    # via
+    #   -c requirements/constraints.txt
+    #   sphinx-autoapi
+attrs==26.1.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -67,7 +69,7 @@ attrs==25.4.0
     #   openedx-events
     #   openedx-learning
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar
@@ -82,17 +84,18 @@ bcrypt==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   paramiko
-beautifulsoup4==4.14.2
+beautifulsoup4==4.15.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
     #   pydata-sphinx-theme
     #   pynliner
-billiard==4.2.2
+    #   xblocks-contrib
+billiard==4.2.4
     # via
     #   -r requirements/edx/base.txt
     #   celery
-bleach[css]==6.2.0
+bleach[css]==6.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -103,14 +106,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.40.46
+boto3==1.43.50
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.40.46
+botocore==1.43.50
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -118,20 +121,19 @@ botocore==1.40.46
     #   snowflake-connector-python
 bridgekeeper==0.9
     # via -r requirements/edx/base.txt
-cachecontrol==0.14.3
+cachecontrol==0.14.4
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-cachetools==6.2.0
+cachetools==7.1.4
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-    #   google-auth
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
-celery==5.5.3
+celery==5.6.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
@@ -142,7 +144,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.10.5
+certifi==2026.6.17
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -150,23 +152,26 @@ certifi==2025.10.5
     #   httpx
     #   requests
     #   snowflake-connector-python
-cffi==1.17.1
+cffi==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
+chardet==7.4.3
     # via
     #   -r requirements/edx/base.txt
+    #   encutils
     #   pysrt
-charset-normalizer==3.4.3
+charset-normalizer==3.4.9
     # via
     #   -r requirements/edx/base.txt
     #   requests
     #   snowflake-connector-python
 chem==2.0.0
-    # via -r requirements/edx/base.txt
-click==8.3.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+click==8.4.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -188,7 +193,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/doc.in
@@ -196,14 +201,14 @@ code-annotations==2.3.0
     #   edx-toggles
 codejail-includes==2.0.0
     # via -r requirements/edx/base.txt
-crowdsourcehinter-xblock==0.8
+crowdsourcehinter-xblock==1.0.1
     # via -r requirements/edx/base.txt
-cryptography==45.0.7
+cryptography==49.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-fernet-fields-v2
     #   edx-enterprise
+    #   google-auth
     #   jwcrypto
     #   paramiko
     #   pgpy
@@ -211,20 +216,22 @@ cryptography==45.0.7
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.11.1
+cssutils==2.15.0
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
-deepmerge==2.0
+deepmerge==2.1.0
     # via sphinxcontrib-openapi
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/base.txt
     #   djangorestframework-xml
+    #   nltk
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.28
+    #   xblocks-contrib
+django==4.2.30
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -298,12 +305,13 @@ django==4.2.28
     #   social-auth-app-django
     #   super-csv
     #   xblock-google-drive
+    #   xblocks-contrib
     #   xss-utils
-django-appconf==1.1.0
+django-appconf==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
-django-autocomplete-light==3.12.1
+django-autocomplete-light==4.0.3
     # via -r requirements/edx/base.txt
 django-cache-memoize==0.2.1
     # via
@@ -315,7 +323,7 @@ django-classy-tags==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   django-sekizai
-django-config-models==2.9.0
+django-config-models==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -324,7 +332,7 @@ django-config-models==2.9.0
     #   lti-consumer-xblock
 django-cors-headers==4.9.0
     # via -r requirements/edx/base.txt
-django-countries==7.6.1
+django-countries==9.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -352,7 +360,7 @@ django-ipware==7.0.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-django-js-asset==3.1.2
+django-js-asset==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   django-mptt
@@ -393,14 +401,14 @@ django-oauth-toolkit==1.7.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-django-object-actions==5.0.0
+django-object-actions==5.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
 django-pipeline==4.1.0
     # via -r requirements/edx/base.txt
-django-push-notifications==3.2.1
+django-push-notifications==3.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -410,9 +418,9 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
-django-ses==4.4.0
+django-ses==4.7.2
     # via -r requirements/edx/base.txt
-django-simple-history==3.10.1
+django-simple-history==3.12.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -421,18 +429,17 @@ django-simple-history==3.10.1
     #   edx-proctoring
     #   enterprise-integrated-channels
     #   ora2
-django-statici18n==2.6.0
+django-statici18n==2.7.1
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-poll
-    #   xblocks-contrib
 django-storages==1.14.6
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-django-user-tasks==3.4.3
+django-user-tasks==4.0.0
     # via -r requirements/edx/base.txt
 django-waffle==5.0.0
     # via
@@ -442,11 +449,11 @@ django-waffle==5.0.0
     #   edx-enterprise
     #   edx-proctoring
     #   edx-toggles
-django-webpack-loader==3.2.1
+django-webpack-loader==3.2.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -474,33 +481,33 @@ dnspython==2.8.0
     # via
     #   -r requirements/edx/base.txt
     #   pymongo
-docutils==0.21.2
+docutils==0.22.4
     # via
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
-done-xblock==2.5.0
+done-xblock==3.0.0
     # via -r requirements/edx/base.txt
 drf-jwt==1.19.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-drf-spectacular==0.28.0
+drf-spectacular==0.30.0
     # via -r requirements/edx/base.txt
-drf-yasg==1.21.11
+drf-yasg==1.21.15
     # via
     #   -r requirements/edx/base.txt
     #   django-user-tasks
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via -r requirements/edx/base.txt
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
-edx-auth-backends==4.6.1
+edx-auth-backends==5.0.0
     # via -r requirements/edx/base.txt
-edx-bulk-grades==1.2.0
+edx-bulk-grades==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   staff-graded-xblock
@@ -509,21 +516,23 @@ edx-ccx-keys==2.0.2
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   openedx-events
-edx-celeryutils==1.4.0
+edx-celeryutils==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   super-csv
-edx-codejail==4.0.0
-    # via -r requirements/edx/base.txt
-edx-completion==4.9
+edx-codejail==4.1.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+edx-completion==5.0.0
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-submissions
     #   edxval
-edx-django-sites-extensions==5.1.0
+edx-django-sites-extensions==6.0.0
     # via -r requirements/edx/base.txt
 edx-django-utils==8.0.1
     # via
@@ -544,6 +553,7 @@ edx-django-utils==8.0.1
     #   openedx-events
     #   ora2
     #   super-csv
+    #   xblocks-contrib
 edx-drf-extensions==10.6.0
     # via
     #   -r requirements/edx/base.txt
@@ -565,16 +575,15 @@ edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.6.1
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-    #   xblocks-contrib
-edx-milestones==1.1.0
+edx-milestones==2.0.0
     # via -r requirements/edx/base.txt
 edx-name-affirmation==3.0.2
     # via -r requirements/edx/base.txt
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades
@@ -592,36 +601,37 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==7.3.0
+edx-organizations==8.0.0
     # via -r requirements/edx/base.txt
 edx-proctoring==5.2.0
     # via -r requirements/edx/base.txt
-edx-rbac==2.1.0
+edx-rbac==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-edx-rest-api-client==6.2.0
+edx-rest-api-client==7.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
     #   enterprise-integrated-channels
-edx-search==4.3.0
+edx-search==5.0.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-edx-sga==0.26.0
+edx-sga==0.29.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.12.0
+edx-submissions==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
+    #   xblocks-contrib
 edx-tincan-py35==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   enterprise-integrated-channels
-edx-toggles==5.4.1
+edx-toggles==6.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
@@ -634,12 +644,15 @@ edx-toggles==5.4.1
     #   edxval
     #   event-tracking
     #   ora2
-edx-when==3.0.0
+    #   xblocks-contrib
+edx-when==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==3.1.0
-    # via -r requirements/edx/base.txt
+edxval==5.0.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
 elasticsearch==7.9.1
     # via
     #   -c requirements/common_constraints.txt
@@ -647,6 +660,10 @@ elasticsearch==7.9.1
     #   -r requirements/edx/base.txt
     #   edx-search
     #   openedx-forum
+encutils==1.0.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   cssutils
 enmerkar==0.7.1
     # via
     #   -r requirements/edx/base.txt
@@ -655,21 +672,21 @@ enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
 enterprise-integrated-channels==0.1.62
     # via -r requirements/edx/base.txt
-event-tracking==3.3.0
+event-tracking==4.0.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-fastavro==1.12.0
+fastavro==1.12.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.30.3
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-firebase-admin==7.1.0
+firebase-admin==7.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -684,69 +701,71 @@ fs==2.4.16
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
+    #   xblocks-contrib
 fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-pyfs
-geoip2==5.1.0
+geoip2==5.3.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.45
+gitpython==3.1.52
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.25.2
+google-api-core[grpc]==2.32.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth==2.41.1
+google-auth==2.56.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-core==2.4.3
+google-cloud-core==2.6.0
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.21.0
+google-cloud-firestore==2.28.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-google-cloud-storage==3.4.0
+google-cloud-storage==3.13.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-google-crc32c==1.7.1
+google-crc32c==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.7.2
+google-resumable-media==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-storage
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.75.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.75.1
+grpcio==1.82.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
+    #   google-cloud-firestore
     #   grpcio-status
-grpcio-status==1.75.1
+grpcio-status==1.82.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
-gunicorn==23.0.0
+gunicorn==26.0.0
     # via -r requirements/edx/base.txt
 h11==0.16.0
     # via
@@ -756,9 +775,9 @@ h2==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   httpx
-help-tokens==3.2.0
+help-tokens==4.0.0
     # via -r requirements/edx/base.txt
-hpack==4.1.0
+hpack==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   h2
@@ -766,6 +785,7 @@ html5lib==1.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
+    #   xblocks-contrib
 httpcore==1.0.9
     # via
     #   -r requirements/edx/base.txt
@@ -774,13 +794,14 @@ httpx[http2]==0.28.1
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
+    #   typesense
 hyperframe==6.1.0
     # via
     #   -r requirements/edx/base.txt
     #   h2
-icalendar==6.3.1
+icalendar==7.2.0
     # via -r requirements/edx/base.txt
-idna==3.10
+idna==3.18
     # via
     #   -r requirements/edx/base.txt
     #   anyio
@@ -789,16 +810,16 @@ idna==3.10
     #   requests
     #   snowflake-connector-python
     #   yarl
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
-importlib-metadata==8.7.0
+importlib-metadata==9.0.0
     # via -r requirements/edx/base.txt
 inflection==0.5.1
     # via
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   drf-yasg
-invoke==2.2.0
+invoke==3.0.3
     # via
     #   -r requirements/edx/base.txt
     #   paramiko
@@ -814,12 +835,12 @@ jinja2==3.1.6
     #   code-annotations
     #   sphinx
     #   sphinx-autoapi
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   boto3
     #   botocore
-joblib==1.5.2
+joblib==1.5.3
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -837,7 +858,7 @@ jsonfield==3.2.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-spectacular
@@ -847,26 +868,28 @@ jsonschema-specifications==2025.9.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
-jwcrypto==1.5.6
+jwcrypto==1.5.8
     # via
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
 laboratory==1.0.2
     # via -r requirements/edx/base.txt
-lazy==1.6
+lazy==2.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==9.14.2
-    # via -r requirements/edx/base.txt
+lti-consumer-xblock==10.0.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
     # via
     #   -c requirements/constraints.txt
@@ -881,21 +904,21 @@ lxml[html-clean]==5.3.2
     #   ora2
     #   python3-saml
     #   xblock
+    #   xblocks-contrib
     #   xmlsec
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via
     #   -r requirements/edx/base.txt
     #   lxml
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.3.10
+mako==1.3.12
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   lti-consumer-xblock
     #   xblock
-    #   xblock-utils
-markdown==3.9
+markdown==3.10.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -909,23 +932,24 @@ markupsafe==3.0.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.8.2
+    #   xblocks-contrib
+maxminddb==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
-meilisearch==0.37.0
+meilisearch==0.42.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-search
-mistune==3.1.4
+mistune==3.3.3
     # via sphinx-mdinclude
-mongoengine==0.29.1
+mongoengine==0.29.3
     # via -r requirements/edx/base.txt
 monotonic==1.6
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/edx/base.txt
     #   cssutils
@@ -933,28 +957,28 @@ mpmath==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   sympy
-msgpack==1.1.1
+msgpack==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   cachecontrol
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-nh3==0.3.0
+nh3==0.3.6
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-nltk==3.9.2
+nltk==3.10.0
     # via
     #   -r requirements/edx/base.txt
     #   chem
-nodeenv==1.9.1
+nodeenv==1.10.0
     # via -r requirements/edx/base.txt
 numpy==1.26.4
     # via
@@ -964,6 +988,7 @@ numpy==1.26.4
     #   openedx-calc
     #   scipy
     #   shapely
+    #   xblocks-contrib
 oauthlib==3.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -980,14 +1005,14 @@ openedx-atlas==0.7.0
     #   edx-enterprise
     #   enterprise-integrated-channels
     #   openedx-forum
-openedx-calc==4.0.2
-    # via -r requirements/edx/base.txt
-openedx-django-pyfs==3.8.0
+openedx-calc==4.0.3
     # via
     #   -r requirements/edx/base.txt
-    #   lti-consumer-xblock
-    #   xblock
     #   xblocks-contrib
+openedx-django-pyfs==4.0.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblock
 openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.2
@@ -1001,32 +1026,32 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.8
+openedx-forum==0.4.1
     # via -r requirements/edx/base.txt
 openedx-learning==0.27.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
-optimizely-sdk==5.2.0
+optimizely-sdk==5.6.0
     # via -r requirements/edx/base.txt
-ora2==6.17.2
+ora2==7.1.0
     # via -r requirements/edx/base.txt
-packaging==25.0
+packaging==26.2
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
     #   gunicorn
     #   kombu
-    #   pydata-sphinx-theme
     #   snowflake-connector-python
     #   sphinx
-paramiko==4.0.0
+    #   wheel
+paramiko==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1036,6 +1061,7 @@ path==16.11.0
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   path-py
+    #   xblocks-contrib
 path-py==12.5.0
     # via
     #   -r requirements/edx/base.txt
@@ -1050,13 +1076,13 @@ picobox==4.0.0
     # via sphinxcontrib-openapi
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==11.3.0
+pillow==12.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-platformdirs==4.4.0
+platformdirs==4.10.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -1068,17 +1094,17 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-propcache==0.4.0
+propcache==0.5.2
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-proto-plus==1.26.1
+proto-plus==1.28.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.32.1
+protobuf==7.35.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -1086,23 +1112,22 @@ protobuf==6.32.1
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.1.0
+psutil==7.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
-pyasn1==0.6.1
+pyasn1==0.6.4
     # via
     #   -r requirements/edx/base.txt
     #   pgpy
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -r requirements/edx/base.txt
     #   google-auth
-pycountry==24.6.1
+pycountry==26.2.16
     # via -r requirements/edx/base.txt
-pycparser==2.23
+pycparser==3.0
     # via
     #   -r requirements/edx/base.txt
     #   cffi
@@ -1111,23 +1136,23 @@ pycryptodomex==3.23.0
     #   -r requirements/edx/base.txt
     #   edx-proctoring
     #   lti-consumer-xblock
-pydantic==2.11.10
+pydantic==2.13.4
     # via
     #   -r requirements/edx/base.txt
     #   camel-converter
-pydantic-core==2.33.2
+pydantic-core==2.46.4
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-pydata-sphinx-theme==0.15.4
+pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   accessible-pygments
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-jwt
@@ -1156,22 +1181,23 @@ pymongo==4.4.0
     #   event-tracking
     #   mongoengine
     #   openedx-forum
-pynacl==1.6.0
+pynacl==1.6.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
     #   paramiko
 pynliner==0.8.0
     # via -r requirements/edx/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc
+    #   xblocks-contrib
 pyrsistent==0.20.0
     # via
     #   -r requirements/edx/base.txt
@@ -1201,7 +1227,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
-python-swiftclient==4.8.0
+python-swiftclient==4.10.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -1213,7 +1239,7 @@ python3-saml==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-pytz==2025.2
+pytz==2026.2
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1229,6 +1255,7 @@ pytz==2025.2
     #   snowflake-connector-python
     #   tincan
     #   xblock
+    #   xblocks-contrib
 pyuca==1.2
     # via -r requirements/edx/base.txt
 pyyaml==6.0.3
@@ -1244,23 +1271,25 @@ pyyaml==6.0.3
     #   sphinxcontrib-openapi
     #   xblock
 random2==1.0.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+recommender-xblock==5.0.0
     # via -r requirements/edx/base.txt
-recommender-xblock==3.1.0
-    # via -r requirements/edx/base.txt
-redis==6.4.0
+redis==8.0.1
     # via
     #   -r requirements/edx/base.txt
     #   walrus
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.9.18
+regex==2026.7.10
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-requests==2.32.5
+requests==2.34.2
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
@@ -1287,28 +1316,25 @@ requests==2.32.5
     #   social-auth-core
     #   sphinx
     #   xblock-google-drive
+    #   xblocks-contrib
 requests-oauthlib==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
-rpds-py==0.27.1
+rpds-py==2026.6.3
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via
-    #   -r requirements/edx/base.txt
-    #   google-auth
 rules==3.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.14.0
+s3transfer==0.19.1
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1316,7 +1342,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.16.2
+scipy==1.17.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1325,14 +1351,16 @@ semantic-version==2.10.0
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
 shapely==2.1.2
-    # via -r requirements/edx/base.txt
-simplejson==3.20.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+simplejson==4.1.1
     # via
     #   -r requirements/edx/base.txt
     #   sailthru-client
     #   super-csv
     #   xblock
-    #   xblock-utils
+    #   xblocks-contrib
 six==1.17.0
     # via
     #   -r requirements/edx/base.txt
@@ -1350,37 +1378,34 @@ six==1.17.0
     #   fs-s3fs
     #   html5lib
     #   python-dateutil
-    #   sphinxcontrib-httpdomain
 slumber==0.7.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-smmap==5.0.2
+smmap==5.0.3
     # via gitdb
-sniffio==1.3.1
-    # via
-    #   -r requirements/edx/base.txt
-    #   anyio
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
     # via sphinx
-snowflake-connector-python==4.2.0
+snowflake-connector-python==4.7.1
     # via
     #   -r requirements/edx/base.txt
     #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   edx-enterprise
-social-auth-core==4.7.0
+social-auth-core==4.9.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sorl-thumbnail==12.11.0
+sorl-thumbnail==13.0.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -1388,11 +1413,11 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-soupsieve==2.8
+soupsieve==2.8.4
     # via
     #   -r requirements/edx/base.txt
     #   beautifulsoup4
-sphinx==8.2.3
+sphinx==9.0.4
     # via
     #   -r requirements/edx/doc.in
     #   pydata-sphinx-theme
@@ -1408,13 +1433,13 @@ sphinx-autoapi==3.6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.in
-sphinx-book-theme==1.1.4
+sphinx-book-theme==1.2.0
     # via -r requirements/edx/doc.in
-sphinx-design==0.6.1
+sphinx-design==0.7.0
     # via -r requirements/edx/doc.in
 sphinx-mdinclude==0.6.2
     # via sphinxcontrib-openapi
-sphinx-reredirects==1.0.0
+sphinx-reredirects==1.1.0
     # via -r requirements/edx/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -1422,11 +1447,11 @@ sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
-sphinxcontrib-httpdomain==1.8.1
+sphinxcontrib-httpdomain==2.0.0
     # via sphinxcontrib-openapi
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-openapi[markdown]==0.8.4
+sphinxcontrib-openapi[markdown]==0.9.0
     # via -r requirements/edx/doc.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
@@ -1434,13 +1459,13 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxext-rediraffe==0.3.0
     # via -r requirements/edx/doc.in
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/edx/base.txt
     #   django
-staff-graded-xblock==3.1.0
+staff-graded-xblock==4.0.1
     # via -r requirements/edx/base.txt
-stevedore==5.5.0
+stevedore==5.9.0
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -1448,7 +1473,7 @@ stevedore==5.5.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==4.1.0
+super-csv==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades
@@ -1456,7 +1481,7 @@ sympy==1.14.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-testfixtures==9.1.0
+testfixtures==12.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1468,28 +1493,35 @@ tincan==1.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-tinycss2==1.4.0
+tinycss2==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   bleach
-tomlkit==0.13.3
+tomlkit==0.15.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-learning
     #   snowflake-connector-python
-tqdm==4.67.1
+tqdm==4.69.0
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-typing-extensions==4.15.0
+typesense==2.0.0
     # via
     #   -r requirements/edx/base.txt
+    #   edx-search
+    #   openedx-forum
+typing-extensions==4.16.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   aiohttp
     #   aiosignal
     #   anyio
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
     #   grpcio
+    #   icalendar
     #   jwcrypto
     #   pydantic
     #   pydantic-core
@@ -1498,16 +1530,22 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
+    #   testfixtures
+    #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-tzdata==2025.2
+tzdata==2026.3
     # via
     #   -r requirements/edx/base.txt
     #   icalendar
     #   kombu
+tzlocal==5.4.4
+    # via
+    #   -r requirements/edx/base.txt
+    #   celery
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.txt
@@ -1520,7 +1558,7 @@ uritemplate==4.2.0
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   -r requirements/edx/base.txt
     #   botocore
@@ -1532,43 +1570,43 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-voluptuous==0.15.2
+voluptuous==0.16.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-walrus==0.9.5
+walrus==0.9.8
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
-wcwidth==0.2.14
+wcwidth==0.8.2
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via
     #   -r requirements/edx/base.txt
-    #   crowdsourcehinter-xblock
-    #   edx-sga
-    #   staff-graded-xblock
     #   xblock
-    #   xblock-utils
+    #   xblocks-contrib
 webencodings==0.5.1
     # via
     #   -r requirements/edx/base.txt
     #   bleach
     #   html5lib
     #   tinycss2
-webob==1.8.9
+webob==1.8.10
     # via
     #   -r requirements/edx/base.txt
     #   xblock
-wheel==0.45.1
+    #   xblocks-contrib
+wheel==0.47.0
     # via
     #   -r requirements/edx/base.txt
     #   django-pipeline
-wrapt==1.17.3
-    # via -r requirements/edx/base.txt
-xblock[django]==5.2.0
+wrapt==2.2.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+xblock[django]==6.1.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -1582,33 +1620,28 @@ xblock[django]==5.2.0
     #   staff-graded-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-google-drive
-    #   xblock-utils
+    #   xblock-poll
     #   xblocks-contrib
 xblock-drag-and-drop-v2==5.0.3
     # via -r requirements/edx/base.txt
 xblock-google-drive==0.8.1
     # via -r requirements/edx/base.txt
-xblock-poll==1.15.1
+xblock-poll==1.16.1
     # via -r requirements/edx/base.txt
-xblock-utils==4.0.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-sga
-    #   xblock-poll
-xblocks-contrib==0.6.0
+xblocks-contrib==0.13.1
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
-xss-utils==0.8.0
+xss-utils==1.0.0
     # via -r requirements/edx/base.txt
-yarl==1.22.0
+yarl==1.24.2
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -6,13 +6,13 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==4.11.0
+anyio==4.14.2
     # via
     #   httpx
     #   mcp
     #   sse-starlette
     #   starlette
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   glom
     #   jsonschema
@@ -23,33 +23,35 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-bracex==2.6
+bracex==3.0
     # via wcmatch
-certifi==2025.10.5
+certifi==2026.6.17
     # via
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.4.3
+cffi==2.1.0
+    # via cryptography
+charset-normalizer==3.4.9
     # via requests
 click==8.1.8
     # via
     #   click-option-group
     #   semgrep
     #   uvicorn
-click-option-group==0.5.8
+click-option-group==0.5.9
     # via semgrep
 colorama==0.4.6
     # via semgrep
-defusedxml==0.7.1
-    # via semgrep
+cryptography==49.0.0
+    # via pyjwt
 exceptiongroup==1.2.2
     # via semgrep
-face==24.0.0
+face==26.0.1
     # via glom
-glom==22.1.0
+glom==25.12.0
     # via semgrep
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.75.0
     # via opentelemetry-exporter-otlp-proto-http
 h11==0.16.0
     # via
@@ -59,24 +61,24 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via mcp
-httpx-sse==0.4.1
+httpx-sse==0.4.3
     # via mcp
-idna==3.10
+idna==3.18
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-metadata==8.7.0
+importlib-metadata==8.7.1
     # via opentelemetry-api
-jsonschema==4.20.0
+jsonschema==4.25.1
     # via
     #   mcp
     #   semgrep
 jsonschema-specifications==2025.9.1
     # via jsonschema
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
-mcp==1.12.2
+mcp==1.23.3
     # via semgrep
 mdurl==0.1.2
     # via markdown-it-py
@@ -85,6 +87,7 @@ opentelemetry-api==1.37.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   semgrep
@@ -93,8 +96,12 @@ opentelemetry-exporter-otlp-proto-common==1.37.0
 opentelemetry-exporter-otlp-proto-http==1.37.0
     # via semgrep
 opentelemetry-instrumentation==0.58b0
-    # via opentelemetry-instrumentation-requests
+    # via
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-requests==0.58b0
+    # via semgrep
+opentelemetry-instrumentation-threading==0.58b0
     # via semgrep
 opentelemetry-proto==1.37.0
     # via
@@ -111,63 +118,70 @@ opentelemetry-semantic-conventions==0.58b0
     #   opentelemetry-sdk
 opentelemetry-util-http==0.58b0
     # via opentelemetry-instrumentation-requests
-packaging==25.0
+packaging==26.2
     # via
     #   opentelemetry-instrumentation
     #   semgrep
-peewee==3.18.2
+peewee==3.19.0
     # via semgrep
-protobuf==6.32.1
+protobuf==6.33.6
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-pydantic==2.11.10
+pycparser==3.0
+    # via cffi
+pydantic==2.13.4
     # via
     #   mcp
     #   pydantic-settings
-pydantic-core==2.33.2
+pydantic-core==2.46.4
     # via pydantic
-pydantic-settings==2.11.0
+pydantic-settings==2.14.2
     # via mcp
-pygments==2.19.2
+pygments==2.20.0
     # via rich
-python-dotenv==1.1.1
+pyjwt[crypto]==2.13.0
+    # via
+    #   mcp
+    #   semgrep
+python-dotenv==1.2.2
     # via pydantic-settings
-python-multipart==0.0.20
+python-multipart==0.0.32
     # via mcp
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.5
+requests==2.34.2
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   semgrep
-rich==13.5.3
+rich==15.0.0
     # via semgrep
-rpds-py==0.27.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.18.15
+ruamel-yaml==0.19.1
     # via semgrep
-ruamel-yaml-clib==0.2.12
-    # via
-    #   ruamel-yaml
-    #   semgrep
-semgrep==1.139.0
+ruamel-yaml-clib==0.2.15
+    # via semgrep
+semantic-version==2.10.0
+    # via semgrep
+semgrep==1.170.0
     # via -r requirements/edx/semgrep.in
-sniffio==1.3.1
-    # via anyio
-sse-starlette==3.0.2
+sse-starlette==3.4.5
     # via mcp
-starlette==0.48.0
-    # via mcp
-tomli==2.0.2
+starlette==1.3.1
+    # via
+    #   mcp
+    #   sse-starlette
+tomli==2.4.1
     # via semgrep
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   anyio
+    #   mcp
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
@@ -180,17 +194,20 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via
+    #   mcp
     #   pydantic
     #   pydantic-settings
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   semgrep
-uvicorn==0.37.0
+uvicorn==0.51.0
     # via mcp
 wcmatch==8.5.2
     # via semgrep
 wrapt==1.17.3
-    # via opentelemetry-instrumentation
-zipp==3.23.0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-threading
+zipp==4.1.0
     # via importlib-metadata

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,11 +6,11 @@
 #
 acid-xblock==0.4.1
     # via -r requirements/edx/base.txt
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.7.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.1
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -33,16 +33,15 @@ annotated-types==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-anyio==4.11.0
+anyio==4.14.2
     # via
     #   -r requirements/edx/base.txt
     #   httpx
-    #   starlette
 appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-asgiref==3.10.0
+asgiref==3.12.1
     # via
     #   -r requirements/edx/base.txt
     #   django
@@ -52,11 +51,12 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==4.0.3
+astroid==4.0.4
     # via
+    #   -c requirements/constraints.txt
     #   pylint
     #   pylint-celery
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -66,7 +66,7 @@ attrs==25.4.0
     #   openedx-events
     #   openedx-learning
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar
@@ -79,17 +79,18 @@ bcrypt==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   paramiko
-beautifulsoup4==4.14.2
+beautifulsoup4==4.15.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
     #   openedx-forum
     #   pynliner
-billiard==4.2.2
+    #   xblocks-contrib
+billiard==4.2.4
     # via
     #   -r requirements/edx/base.txt
     #   celery
-bleach[css]==6.2.0
+bleach[css]==6.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -100,14 +101,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.40.46
+boto3==1.43.50
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.40.46
+botocore==1.43.50
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -115,21 +116,20 @@ botocore==1.40.46
     #   snowflake-connector-python
 bridgekeeper==0.9
     # via -r requirements/edx/base.txt
-cachecontrol==0.14.3
+cachecontrol==0.14.4
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-cachetools==6.2.0
+cachetools==7.1.4
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-    #   google-auth
     #   tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
-celery==5.5.3
+celery==5.6.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
@@ -140,7 +140,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.10.5
+certifi==2026.6.17
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -148,27 +148,29 @@ certifi==2025.10.5
     #   httpx
     #   requests
     #   snowflake-connector-python
-cffi==1.17.1
+cffi==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   cryptography
-    #   pact-python
+    #   pact-python-ffi
     #   pynacl
-chardet==5.2.0
+chardet==7.4.3
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
     #   diff-cover
+    #   encutils
     #   pysrt
-    #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.9
     # via
     #   -r requirements/edx/base.txt
     #   requests
     #   snowflake-connector-python
 chem==2.0.0
-    # via -r requirements/edx/base.txt
-click==8.3.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+click==8.4.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -181,8 +183,6 @@ click==8.3.0
     #   edx-lint
     #   import-linter
     #   nltk
-    #   pact-python
-    #   uvicorn
 click-didyoumean==0.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -197,7 +197,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -208,18 +208,18 @@ codejail-includes==2.0.0
     # via -r requirements/edx/base.txt
 colorama==0.4.6
     # via tox
-coverage[toml]==7.10.7
+coverage[toml]==7.15.2
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
-crowdsourcehinter-xblock==0.8
+crowdsourcehinter-xblock==1.0.1
     # via -r requirements/edx/base.txt
-cryptography==45.0.7
+cryptography==49.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-fernet-fields-v2
     #   edx-enterprise
+    #   google-auth
     #   jwcrypto
     #   paramiko
     #   pgpy
@@ -227,11 +227,11 @@ cryptography==45.0.7
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssselect==1.3.0
+cssselect==1.4.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
-cssutils==2.11.1
+cssutils==2.15.0
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
@@ -241,16 +241,18 @@ defusedxml==0.7.1
     # via
     #   -r requirements/edx/base.txt
     #   djangorestframework-xml
+    #   nltk
     #   ora2
     #   python3-openid
     #   social-auth-core
-diff-cover==9.7.1
+    #   xblocks-contrib
+diff-cover==10.3.0
     # via -r requirements/edx/coverage.txt
-dill==0.4.0
+dill==0.4.1
     # via pylint
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
-django==4.2.28
+django==4.2.30
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -324,12 +326,13 @@ django==4.2.28
     #   social-auth-app-django
     #   super-csv
     #   xblock-google-drive
+    #   xblocks-contrib
     #   xss-utils
-django-appconf==1.1.0
+django-appconf==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
-django-autocomplete-light==3.12.1
+django-autocomplete-light==4.0.3
     # via -r requirements/edx/base.txt
 django-cache-memoize==0.2.1
     # via
@@ -341,7 +344,7 @@ django-classy-tags==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   django-sekizai
-django-config-models==2.9.0
+django-config-models==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -350,7 +353,7 @@ django-config-models==2.9.0
     #   lti-consumer-xblock
 django-cors-headers==4.9.0
     # via -r requirements/edx/base.txt
-django-countries==7.6.1
+django-countries==9.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -378,7 +381,7 @@ django-ipware==7.0.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-django-js-asset==3.1.2
+django-js-asset==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   django-mptt
@@ -419,14 +422,14 @@ django-oauth-toolkit==1.7.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-django-object-actions==5.0.0
+django-object-actions==5.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
 django-pipeline==4.1.0
     # via -r requirements/edx/base.txt
-django-push-notifications==3.2.1
+django-push-notifications==3.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -436,9 +439,9 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
-django-ses==4.4.0
+django-ses==4.7.2
     # via -r requirements/edx/base.txt
-django-simple-history==3.10.1
+django-simple-history==3.12.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -447,18 +450,17 @@ django-simple-history==3.10.1
     #   edx-proctoring
     #   enterprise-integrated-channels
     #   ora2
-django-statici18n==2.6.0
+django-statici18n==2.7.1
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-poll
-    #   xblocks-contrib
 django-storages==1.14.6
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-django-user-tasks==3.4.3
+django-user-tasks==4.0.0
     # via -r requirements/edx/base.txt
 django-waffle==5.0.0
     # via
@@ -468,11 +470,11 @@ django-waffle==5.0.0
     #   edx-enterprise
     #   edx-proctoring
     #   edx-toggles
-django-webpack-loader==3.2.1
+django-webpack-loader==3.2.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -500,28 +502,28 @@ dnspython==2.8.0
     # via
     #   -r requirements/edx/base.txt
     #   pymongo
-done-xblock==2.5.0
+done-xblock==3.0.0
     # via -r requirements/edx/base.txt
 drf-jwt==1.19.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-drf-spectacular==0.28.0
+drf-spectacular==0.30.0
     # via -r requirements/edx/base.txt
-drf-yasg==1.21.11
+drf-yasg==1.21.15
     # via
     #   -r requirements/edx/base.txt
     #   django-user-tasks
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via -r requirements/edx/base.txt
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
-edx-auth-backends==4.6.1
+edx-auth-backends==5.0.0
     # via -r requirements/edx/base.txt
-edx-bulk-grades==1.2.0
+edx-bulk-grades==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   staff-graded-xblock
@@ -530,21 +532,23 @@ edx-ccx-keys==2.0.2
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   openedx-events
-edx-celeryutils==1.4.0
+edx-celeryutils==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   super-csv
-edx-codejail==4.0.0
-    # via -r requirements/edx/base.txt
-edx-completion==4.9
+edx-codejail==4.1.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+edx-completion==5.0.0
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-submissions
     #   edxval
-edx-django-sites-extensions==5.1.0
+edx-django-sites-extensions==6.0.0
     # via -r requirements/edx/base.txt
 edx-django-utils==8.0.1
     # via
@@ -565,6 +569,7 @@ edx-django-utils==8.0.1
     #   openedx-events
     #   ora2
     #   super-csv
+    #   xblocks-contrib
 edx-drf-extensions==10.6.0
     # via
     #   -r requirements/edx/base.txt
@@ -586,18 +591,17 @@ edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.6.1
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-    #   xblocks-contrib
-edx-lint==5.6.0
+edx-lint==6.1.0
     # via -r requirements/edx/testing.in
-edx-milestones==1.1.0
+edx-milestones==2.0.0
     # via -r requirements/edx/base.txt
 edx-name-affirmation==3.0.2
     # via -r requirements/edx/base.txt
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades
@@ -615,36 +619,37 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==7.3.0
+edx-organizations==8.0.0
     # via -r requirements/edx/base.txt
 edx-proctoring==5.2.0
     # via -r requirements/edx/base.txt
-edx-rbac==2.1.0
+edx-rbac==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-edx-rest-api-client==6.2.0
+edx-rest-api-client==7.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
     #   enterprise-integrated-channels
-edx-search==4.3.0
+edx-search==5.0.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-edx-sga==0.26.0
+edx-sga==0.29.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.12.0
+edx-submissions==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
+    #   xblocks-contrib
 edx-tincan-py35==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   enterprise-integrated-channels
-edx-toggles==5.4.1
+edx-toggles==6.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
@@ -657,12 +662,15 @@ edx-toggles==5.4.1
     #   edxval
     #   event-tracking
     #   ora2
-edx-when==3.0.0
+    #   xblocks-contrib
+edx-when==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==3.1.0
-    # via -r requirements/edx/base.txt
+edxval==5.0.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
 elasticsearch==7.9.1
     # via
     #   -c requirements/common_constraints.txt
@@ -670,6 +678,10 @@ elasticsearch==7.9.1
     #   -r requirements/edx/base.txt
     #   edx-search
     #   openedx-forum
+encutils==1.0.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   cssutils
 enmerkar==0.7.1
     # via
     #   -r requirements/edx/base.txt
@@ -678,31 +690,30 @@ enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
 enterprise-integrated-channels==0.1.62
     # via -r requirements/edx/base.txt
-event-tracking==3.3.0
+event-tracking==4.0.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-execnet==2.1.1
+execnet==2.1.2
     # via pytest-xdist
 factory-boy==3.3.3
     # via -r requirements/edx/testing.in
-faker==37.8.0
+faker==40.31.0
     # via factory-boy
-fastapi==0.118.0
-    # via pact-python
-fastavro==1.12.0
+fastavro==1.12.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.30.3
     # via
     #   -r requirements/edx/base.txt
+    #   python-discovery
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==7.1.0
+firebase-admin==7.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -719,80 +730,81 @@ fs==2.4.16
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
+    #   xblocks-contrib
 fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-pyfs
-geoip2==5.1.0
+geoip2==5.3.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.25.2
+google-api-core[grpc]==2.32.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth==2.41.1
+google-auth==2.56.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-core==2.4.3
+google-cloud-core==2.6.0
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.21.0
+google-cloud-firestore==2.28.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-google-cloud-storage==3.4.0
+google-cloud-storage==3.13.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-google-crc32c==1.7.1
+google-crc32c==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.7.2
+google-resumable-media==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-storage
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.75.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grimp==3.11
+grimp==3.15
     # via import-linter
-grpcio==1.75.1
+grpcio==1.82.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
+    #   google-cloud-firestore
     #   grpcio-status
-grpcio-status==1.75.1
+grpcio-status==1.82.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
-gunicorn==23.0.0
+gunicorn==26.0.0
     # via -r requirements/edx/base.txt
 h11==0.16.0
     # via
     #   -r requirements/edx/base.txt
     #   httpcore
-    #   uvicorn
 h2==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   httpx
-help-tokens==3.2.0
+help-tokens==4.0.0
     # via -r requirements/edx/base.txt
-hpack==4.1.0
+hpack==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   h2
@@ -800,6 +812,7 @@ html5lib==1.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
+    #   xblocks-contrib
 httpcore==1.0.9
     # via
     #   -r requirements/edx/base.txt
@@ -810,13 +823,14 @@ httpx[http2]==0.28.1
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
+    #   typesense
 hyperframe==6.1.0
     # via
     #   -r requirements/edx/base.txt
     #   h2
-icalendar==6.3.1
+icalendar==7.2.0
     # via -r requirements/edx/base.txt
-idna==3.10
+idna==3.18
     # via
     #   -r requirements/edx/base.txt
     #   anyio
@@ -825,18 +839,18 @@ idna==3.10
     #   requests
     #   snowflake-connector-python
     #   yarl
-import-linter==2.5
+import-linter==2.13
     # via -r requirements/edx/testing.in
-importlib-metadata==8.7.0
+importlib-metadata==9.0.0
     # via -r requirements/edx/base.txt
 inflection==0.5.1
     # via
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   drf-yasg
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
-invoke==2.2.0
+invoke==3.0.3
     # via
     #   -r requirements/edx/base.txt
     #   paramiko
@@ -846,7 +860,7 @@ isodate==0.7.2
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
-isort==6.1.0
+isort==8.0.1
     # via
     #   -r requirements/edx/testing.in
     #   pylint
@@ -856,12 +870,12 @@ jinja2==3.1.6
     #   -r requirements/edx/coverage.txt
     #   code-annotations
     #   diff-cover
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   boto3
     #   botocore
-joblib==1.5.2
+joblib==1.5.3
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -879,7 +893,7 @@ jsonfield==3.2.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-spectacular
@@ -888,26 +902,28 @@ jsonschema-specifications==2025.9.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
-jwcrypto==1.5.6
+jwcrypto==1.5.8
     # via
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
 laboratory==1.0.2
     # via -r requirements/edx/base.txt
-lazy==1.6
+lazy==2.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==9.14.2
-    # via -r requirements/edx/base.txt
+lti-consumer-xblock==10.0.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
     # via
     #   -c requirements/constraints.txt
@@ -923,26 +939,28 @@ lxml[html-clean]==5.3.2
     #   pyquery
     #   python3-saml
     #   xblock
+    #   xblocks-contrib
     #   xmlsec
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via
     #   -r requirements/edx/base.txt
     #   lxml
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.3.10
+mako==1.3.12
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   lti-consumer-xblock
     #   xblock
-    #   xblock-utils
-markdown==3.9
+markdown==3.10.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
+markdown-it-py==4.2.0
+    # via rich
 markupsafe==3.0.3
     # via
     #   -r requirements/edx/base.txt
@@ -952,25 +970,28 @@ markupsafe==3.0.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.8.2
+    #   xblocks-contrib
+maxminddb==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
 mccabe==0.7.0
     # via pylint
-meilisearch==0.37.0
+mdurl==0.1.2
+    # via markdown-it-py
+meilisearch==0.42.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-search
 mock==5.2.0
     # via -r requirements/edx/testing.in
-mongoengine==0.29.1
+mongoengine==0.29.3
     # via -r requirements/edx/base.txt
 monotonic==1.6
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/edx/base.txt
     #   cssutils
@@ -978,28 +999,28 @@ mpmath==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   sympy
-msgpack==1.1.1
+msgpack==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   cachecontrol
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-nh3==0.3.0
+nh3==0.3.6
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-nltk==3.9.2
+nltk==3.10.0
     # via
     #   -r requirements/edx/base.txt
     #   chem
-nodeenv==1.9.1
+nodeenv==1.10.0
     # via -r requirements/edx/base.txt
 numpy==1.26.4
     # via
@@ -1009,6 +1030,7 @@ numpy==1.26.4
     #   openedx-calc
     #   scipy
     #   shapely
+    #   xblocks-contrib
 oauthlib==3.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -1025,14 +1047,14 @@ openedx-atlas==0.7.0
     #   edx-enterprise
     #   enterprise-integrated-channels
     #   openedx-forum
-openedx-calc==4.0.2
-    # via -r requirements/edx/base.txt
-openedx-django-pyfs==3.8.0
+openedx-calc==4.0.3
     # via
     #   -r requirements/edx/base.txt
-    #   lti-consumer-xblock
-    #   xblock
     #   xblocks-contrib
+openedx-django-pyfs==4.0.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblock
 openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.2
@@ -1046,23 +1068,23 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.8
+openedx-forum==0.4.1
     # via -r requirements/edx/base.txt
 openedx-learning==0.27.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
-optimizely-sdk==5.2.0
+optimizely-sdk==5.6.0
     # via -r requirements/edx/base.txt
-ora2==6.17.2
+ora2==7.1.0
     # via -r requirements/edx/base.txt
-packaging==25.0
+packaging==26.2
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1072,11 +1094,12 @@ packaging==25.0
     #   pytest
     #   snowflake-connector-python
     #   tox
-pact-python==2.3.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/edx/testing.in
-paramiko==4.0.0
+    #   wheel
+pact-python==3.4.0
+    # via -r requirements/edx/testing.in
+pact-python-ffi==0.5.4.1
+    # via pact-python
+paramiko==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1086,6 +1109,7 @@ path==16.11.0
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   path-py
+    #   xblocks-contrib
 path-py==12.5.0
     # via
     #   -r requirements/edx/base.txt
@@ -1098,16 +1122,17 @@ pgpy==0.6.0
     #   edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==11.3.0
+pillow==12.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-platformdirs==4.4.0
+platformdirs==4.10.0
     # via
     #   -r requirements/edx/base.txt
     #   pylint
+    #   python-discovery
     #   snowflake-connector-python
     #   tox
     #   virtualenv
@@ -1127,17 +1152,17 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-propcache==0.4.0
+propcache==0.5.2
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-proto-plus==1.26.1
+proto-plus==1.28.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.32.1
+protobuf==7.35.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -1145,20 +1170,18 @@ protobuf==6.32.1
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.1.0
+psutil==7.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
-    #   pact-python
     #   pytest-xdist
 py==1.11.0
     # via -r requirements/edx/testing.in
-pyasn1==0.6.1
+pyasn1==0.6.4
     # via
     #   -r requirements/edx/base.txt
     #   pgpy
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -r requirements/edx/base.txt
@@ -1167,9 +1190,9 @@ pycodestyle==2.8.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/testing.in
-pycountry==24.6.1
+pycountry==26.2.16
     # via -r requirements/edx/base.txt
-pycparser==2.23
+pycparser==3.0
     # via
     #   -r requirements/edx/base.txt
     #   cffi
@@ -1178,20 +1201,20 @@ pycryptodomex==3.23.0
     #   -r requirements/edx/base.txt
     #   edx-proctoring
     #   lti-consumer-xblock
-pydantic==2.11.10
+pydantic==2.13.4
     # via
     #   -r requirements/edx/base.txt
     #   camel-converter
-    #   fastapi
-pydantic-core==2.33.2
+pydantic-core==2.46.4
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -r requirements/edx/coverage.txt
     #   diff-cover
-pyjwt[crypto]==2.10.1
+    #   rich
+pyjwt[crypto]==2.13.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-jwt
@@ -1208,7 +1231,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==4.0.4
+pylint==4.0.6
     # via
     #   edx-lint
     #   pylint-celery
@@ -1217,7 +1240,7 @@ pylint==4.0.4
     #   pylint-pytest
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.7.0
+pylint-django==2.8.0
     # via edx-lint
 pylint-plugin-utils==0.9.0
     # via
@@ -1237,23 +1260,24 @@ pymongo==4.4.0
     #   event-tracking
     #   mongoengine
     #   openedx-forum
-pynacl==1.6.0
+pynacl==1.6.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
     #   paramiko
 pynliner==0.8.0
     # via -r requirements/edx/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc
-pyproject-api==1.9.1
+    #   xblocks-contrib
+pyproject-api==1.10.1
     # via tox
 pyquery==2.0.1
     # via -r requirements/edx/testing.in
@@ -1278,9 +1302,9 @@ pytest==8.2.0
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.in
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/edx/testing.in
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/edx/testing.in
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.in
@@ -1288,7 +1312,7 @@ pytest-metadata==3.1.1
     # via
     #   -r requirements/edx/testing.in
     #   pytest-json-report
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r requirements/edx/testing.in
 pytest-xdist[psutil]==3.8.0
     # via -r requirements/edx/testing.in
@@ -1306,6 +1330,10 @@ python-dateutil==2.9.0.post0
     #   olxcleaner
     #   ora2
     #   xblock
+python-discovery==1.4.4
+    # via
+    #   tox
+    #   virtualenv
 python-ipware==3.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -1314,7 +1342,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
-python-swiftclient==4.8.0
+python-swiftclient==4.10.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -1326,7 +1354,7 @@ python3-saml==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-pytz==2025.2
+pytz==2026.2
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1342,6 +1370,7 @@ pytz==2025.2
     #   snowflake-connector-python
     #   tincan
     #   xblock
+    #   xblocks-contrib
 pyuca==1.2
     # via -r requirements/edx/base.txt
 pyyaml==6.0.3
@@ -1355,23 +1384,25 @@ pyyaml==6.0.3
     #   jsondiff
     #   xblock
 random2==1.0.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+recommender-xblock==5.0.0
     # via -r requirements/edx/base.txt
-recommender-xblock==3.1.0
-    # via -r requirements/edx/base.txt
-redis==6.4.0
+redis==8.0.1
     # via
     #   -r requirements/edx/base.txt
     #   walrus
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.9.18
+regex==2026.7.10
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-requests==2.32.5
+requests==2.34.2
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
@@ -1389,7 +1420,6 @@ requests==2.32.5
     #   meilisearch
     #   openedx-forum
     #   optimizely-sdk
-    #   pact-python
     #   pylti1p3
     #   python-swiftclient
     #   requests-oauthlib
@@ -1398,26 +1428,25 @@ requests==2.32.5
     #   snowflake-connector-python
     #   social-auth-core
     #   xblock-google-drive
+    #   xblocks-contrib
 requests-oauthlib==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-rpds-py==0.27.1
+rich==15.0.0
+    # via import-linter
+rpds-py==2026.6.3
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via
-    #   -r requirements/edx/base.txt
-    #   google-auth
 rules==3.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.14.0
+s3transfer==0.19.1
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1425,7 +1454,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.16.2
+scipy==1.17.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1434,14 +1463,16 @@ semantic-version==2.10.0
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
 shapely==2.1.2
-    # via -r requirements/edx/base.txt
-simplejson==3.20.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+simplejson==4.1.1
     # via
     #   -r requirements/edx/base.txt
     #   sailthru-client
     #   super-csv
     #   xblock
-    #   xblock-utils
+    #   xblocks-contrib
 singledispatch==4.1.2
     # via -r requirements/edx/testing.in
 six==1.17.0
@@ -1461,7 +1492,6 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   html5lib
-    #   pact-python
     #   python-dateutil
 slumber==0.7.1
     # via
@@ -1469,26 +1499,24 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-sniffio==1.3.1
-    # via
-    #   -r requirements/edx/base.txt
-    #   anyio
-snowflake-connector-python==4.2.0
+snowflake-connector-python==4.7.1
     # via
     #   -r requirements/edx/base.txt
     #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   edx-enterprise
-social-auth-core==4.7.0
+social-auth-core==4.9.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sorl-thumbnail==12.11.0
+sorl-thumbnail==13.0.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -1496,19 +1524,17 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-soupsieve==2.8
+soupsieve==2.8.4
     # via
     #   -r requirements/edx/base.txt
     #   beautifulsoup4
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/edx/base.txt
     #   django
-staff-graded-xblock==3.1.0
+staff-graded-xblock==4.0.1
     # via -r requirements/edx/base.txt
-starlette==0.48.0
-    # via fastapi
-stevedore==5.5.0
+stevedore==5.9.0
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -1516,7 +1542,7 @@ stevedore==5.5.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==4.1.0
+super-csv==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades
@@ -1524,7 +1550,7 @@ sympy==1.14.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-testfixtures==9.1.0
+testfixtures==12.3.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -1537,53 +1563,66 @@ tincan==1.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-tinycss2==1.4.0
+tinycss2==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   bleach
-tomlkit==0.13.3
+tomli-w==1.2.0
+    # via tox
+tomlkit==0.15.1
     # via
     #   -r requirements/edx/base.txt
+    #   edx-lint
     #   openedx-learning
     #   pylint
     #   snowflake-connector-python
-tox==4.30.3
+tox==4.56.4
     # via -r requirements/edx/testing.in
-tqdm==4.67.1
+tqdm==4.69.0
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-typing-extensions==4.15.0
+typesense==2.0.0
     # via
     #   -r requirements/edx/base.txt
+    #   edx-search
+    #   openedx-forum
+typing-extensions==4.16.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   aiohttp
     #   aiosignal
     #   anyio
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
-    #   fastapi
-    #   grimp
     #   grpcio
+    #   icalendar
     #   import-linter
     #   jwcrypto
+    #   pact-python
     #   pydantic
     #   pydantic-core
     #   pylti1p3
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
-    #   starlette
+    #   testfixtures
+    #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-tzdata==2025.2
+tzdata==2026.3
     # via
     #   -r requirements/edx/base.txt
-    #   faker
     #   icalendar
     #   kombu
+tzlocal==5.4.4
+    # via
+    #   -r requirements/edx/base.txt
+    #   celery
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.txt
@@ -1598,59 +1637,57 @@ uritemplate==4.2.0
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   -r requirements/edx/base.txt
     #   botocore
     #   elasticsearch
     #   requests
-uvicorn==0.37.0
-    # via pact-python
 vine==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==21.6.1
     # via tox
-voluptuous==0.15.2
+voluptuous==0.16.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-walrus==0.9.5
+walrus==0.9.8
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
-wcwidth==0.2.14
+wcwidth==0.8.2
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via
     #   -r requirements/edx/base.txt
-    #   crowdsourcehinter-xblock
-    #   edx-sga
-    #   staff-graded-xblock
     #   xblock
-    #   xblock-utils
+    #   xblocks-contrib
 webencodings==0.5.1
     # via
     #   -r requirements/edx/base.txt
     #   bleach
     #   html5lib
     #   tinycss2
-webob==1.8.9
+webob==1.8.10
     # via
     #   -r requirements/edx/base.txt
     #   xblock
-wheel==0.45.1
+    #   xblocks-contrib
+wheel==0.47.0
     # via
     #   -r requirements/edx/base.txt
     #   django-pipeline
-wrapt==1.17.3
-    # via -r requirements/edx/base.txt
-xblock[django]==5.2.0
+wrapt==2.2.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   xblocks-contrib
+xblock[django]==6.1.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -1664,34 +1701,29 @@ xblock[django]==5.2.0
     #   staff-graded-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-google-drive
-    #   xblock-utils
+    #   xblock-poll
     #   xblocks-contrib
 xblock-drag-and-drop-v2==5.0.3
     # via -r requirements/edx/base.txt
 xblock-google-drive==0.8.1
     # via -r requirements/edx/base.txt
-xblock-poll==1.15.1
+xblock-poll==1.16.1
     # via -r requirements/edx/base.txt
-xblock-utils==4.0.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-sga
-    #   xblock-poll
-xblocks-contrib==0.6.0
+xblocks-contrib==0.13.1
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
-xss-utils==0.8.0
+xss-utils==1.0.0
     # via -r requirements/edx/base.txt
-yarl==1.22.0
+yarl==1.24.2
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   pact-python
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,19 +4,21 @@
 #
 #    make upgrade
 #
-build==1.3.0
+build==1.5.0
     # via pip-tools
-click==8.3.0
+click==8.4.2
     # via pip-tools
-packaging==25.0
-    # via build
-pip-tools==7.5.1
+packaging==26.2
+    # via
+    #   build
+    #   wheel
+pip-tools==7.5.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.45.1
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,17 @@
 #
 #    make upgrade
 #
-wheel==0.45.1
+packaging==26.2
+    # via wheel
+wheel==0.47.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.2
-    # via -r requirements/pip.in
-setuptools==80.9.0
-    # via -r requirements/pip.in
+pip==26.0.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/pip.in
+setuptools==81.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/pip.in

--- a/scripts/structures_pruning/requirements/base.txt
+++ b/scripts/structures_pruning/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-click==8.3.0
+click==8.4.2
     # via
     #   -r scripts/structures_pruning/requirements/base.in
     #   click-log
@@ -12,14 +12,14 @@ click-log==0.4.0
     # via -r scripts/structures_pruning/requirements/base.in
 dnspython==2.8.0
     # via pymongo
-edx-opaque-keys==3.0.0
+edx-opaque-keys==4.0.0
     # via -r scripts/structures_pruning/requirements/base.in
 pymongo==4.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r scripts/structures_pruning/requirements/base.in
     #   edx-opaque-keys
-stevedore==5.5.0
+stevedore==5.9.0
     # via edx-opaque-keys
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via edx-opaque-keys

--- a/scripts/structures_pruning/requirements/testing.txt
+++ b/scripts/structures_pruning/requirements/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-click==8.3.0
+click==8.4.2
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   click-log
@@ -16,27 +16,27 @@ dnspython==2.8.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   pymongo
-edx-opaque-keys==3.0.0
+edx-opaque-keys==4.0.0
     # via -r scripts/structures_pruning/requirements/base.txt
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
-packaging==25.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pymongo==4.4.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys
-pytest==8.4.2
+pytest==9.1.1
     # via -r scripts/structures_pruning/requirements/testing.in
-stevedore==5.5.0
+stevedore==5.9.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -4,37 +4,35 @@
 #
 #    make upgrade
 #
-asgiref==3.10.0
+asgiref==3.12.1
     # via django
-attrs==25.4.0
+attrs==26.1.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
-boto3==1.40.46
+boto3==1.43.51
     # via -r scripts/user_retirement/requirements/base.in
-botocore==1.40.46
+botocore==1.43.51
     # via
     #   boto3
     #   s3transfer
-cachetools==6.2.0
-    # via google-auth
-certifi==2025.10.5
+certifi==2026.6.17
     # via requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.3
+charset-normalizer==3.4.9
     # via requests
-click==8.3.0
+click==8.4.2
     # via
     #   -r scripts/user_retirement/requirements/base.in
     #   edx-django-utils
-cryptography==45.0.7
+cryptography==49.0.0
     # via
-    #   -c requirements/constraints.txt
+    #   google-auth
     #   pyjwt
-django==4.2.28
+django==4.2.30
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -47,32 +45,32 @@ django-waffle==5.0.0
     # via edx-django-utils
 edx-django-utils==8.0.1
     # via edx-rest-api-client
-edx-rest-api-client==6.2.0
+edx-rest-api-client==7.0.0
     # via -r scripts/user_retirement/requirements/base.in
-google-api-core==2.25.2
+google-api-core==2.32.0
     # via google-api-python-client
-google-api-python-client==2.184.0
+google-api-python-client==2.198.0
     # via -r scripts/user_retirement/requirements/base.in
-google-auth==2.41.1
+google-auth==2.56.0
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
-google-auth-httplib2==0.2.0
+google-auth-httplib2==0.4.0
     # via google-api-python-client
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.75.0
     # via google-api-core
-httplib2==0.31.0
+httplib2==0.32.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.10
+idna==3.18
     # via requests
 isodate==0.7.2
     # via zeep
-jenkinsapi==0.3.16
+jenkinsapi==0.3.23
     # via -r scripts/user_retirement/requirements/base.in
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
@@ -80,44 +78,40 @@ lxml==5.3.2
     # via
     #   -c requirements/constraints.txt
     #   zeep
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via simple-salesforce
-platformdirs==4.4.0
+platformdirs==4.10.0
     # via zeep
-proto-plus==1.26.1
+proto-plus==1.28.1
     # via google-api-core
-protobuf==6.32.1
+protobuf==7.35.1
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   proto-plus
-psutil==7.1.0
+psutil==7.2.2
     # via edx-django-utils
-pyasn1==0.6.1
-    # via
-    #   pyasn1-modules
-    #   rsa
+pyasn1==0.6.4
+    # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
-pycparser==2.23
+pycparser==3.0
     # via cffi
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
     # via
     #   edx-rest-api-client
     #   simple-salesforce
-pynacl==1.6.0
+pynacl==1.6.2
     # via edx-django-utils
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via httplib2
 python-dateutil==2.9.0.post0
     # via botocore
-pytz==2025.2
-    # via
-    #   jenkinsapi
-    #   zeep
+pytz==2026.2
+    # via jenkinsapi
 pyyaml==6.0.3
     # via -r scripts/user_retirement/requirements/base.in
-requests==2.32.5
+requests==2.34.2
     # via
     #   -r scripts/user_retirement/requirements/base.in
     #   edx-rest-api-client
@@ -127,33 +121,31 @@ requests==2.32.5
     #   requests-toolbelt
     #   simple-salesforce
     #   zeep
-requests-file==2.1.0
+requests-file==3.0.1
     # via zeep
 requests-toolbelt==1.0.0
     # via zeep
-rsa==4.9.1
-    # via google-auth
-s3transfer==0.14.0
+s3transfer==0.19.1
     # via boto3
-simple-salesforce==1.12.9
+simple-salesforce==1.12.10
     # via -r scripts/user_retirement/requirements/base.in
-simplejson==3.20.2
+simplejson==4.1.1
     # via -r scripts/user_retirement/requirements/base.in
 six==1.17.0
     # via python-dateutil
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.5.0
+stevedore==5.9.0
     # via edx-django-utils
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via simple-salesforce
 unicodecsv==0.14.1
     # via -r scripts/user_retirement/requirements/base.in
 uritemplate==4.2.0
     # via google-api-python-client
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   botocore
     #   requests
-zeep==4.3.2
+zeep==4.3.3
     # via simple-salesforce

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -4,55 +4,52 @@
 #
 #    make upgrade
 #
-asgiref==3.10.0
+asgiref==3.12.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.txt
-boto3==1.40.46
+boto3==1.43.51
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-botocore==1.40.46
+botocore==1.43.51
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
     #   moto
     #   s3transfer
-cachetools==6.2.0
-    # via
-    #   -r scripts/user_retirement/requirements/base.txt
-    #   google-auth
-certifi==2025.10.5
+certifi==2026.6.17
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.3
+charset-normalizer==3.4.9
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests
-click==8.3.0
+click==8.4.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-cryptography==45.0.7
+cryptography==49.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
+    #   google-auth
     #   moto
     #   pyjwt
 ddt==1.7.2
     # via -r scripts/user_retirement/requirements/testing.in
-django==4.2.28
+django==4.2.30
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django-crum
@@ -70,48 +67,46 @@ edx-django-utils==8.0.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
-edx-rest-api-client==6.2.0
+edx-rest-api-client==7.0.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-api-core==2.25.2
+google-api-core==2.32.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.184.0
+google-api-python-client==2.198.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-auth==2.41.1
+google-auth==2.56.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
-google-auth-httplib2==0.2.0
+google-auth-httplib2==0.4.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.75.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
-httplib2==0.31.0
+httplib2==0.32.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.10
+idna==3.18
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
 isodate==0.7.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-jenkinsapi==0.3.16
+jenkinsapi==0.3.23
     # via -r scripts/user_retirement/requirements/base.txt
-jinja2==3.1.6
-    # via moto
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -121,84 +116,79 @@ lxml==5.3.2
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
 markupsafe==3.0.3
-    # via
-    #   jinja2
-    #   werkzeug
+    # via werkzeug
 mock==5.2.0
     # via -r scripts/user_retirement/requirements/testing.in
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce
-moto==5.1.14
+moto==5.2.2
     # via -r scripts/user_retirement/requirements/testing.in
-packaging==25.0
+packaging==26.2
     # via pytest
-platformdirs==4.4.0
+platformdirs==4.10.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
 pluggy==1.6.0
     # via pytest
-proto-plus==1.26.1
+proto-plus==1.28.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
-protobuf==6.32.1
+protobuf==7.35.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
     #   googleapis-common-protos
     #   proto-plus
-psutil==7.1.0
+psutil==7.2.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-pyasn1==0.6.1
+pyasn1==0.6.4
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-pycparser==2.23
+pycparser==3.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   cffi
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
     #   simple-salesforce
-pynacl==1.6.0
+pynacl==1.6.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   httplib2
-pytest==8.4.2
+pytest==9.1.1
     # via -r scripts/user_retirement/requirements/testing.in
 python-dateutil==2.9.0.post0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   botocore
-    #   moto
-pytz==2025.2
+pytz==2026.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   jenkinsapi
-    #   zeep
 pyyaml==6.0.3
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   responses
-requests==2.32.5
+requests==2.34.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
@@ -211,7 +201,7 @@ requests==2.32.5
     #   responses
     #   simple-salesforce
     #   zeep
-requests-file==2.1.0
+requests-file==3.0.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
@@ -221,35 +211,31 @@ requests-toolbelt==1.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-responses==0.25.8
+responses==0.26.2
     # via
     #   -r scripts/user_retirement/requirements/testing.in
     #   moto
-rsa==4.9.1
-    # via
-    #   -r scripts/user_retirement/requirements/base.txt
-    #   google-auth
-s3transfer==0.14.0
+s3transfer==0.19.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
-simple-salesforce==1.12.9
+simple-salesforce==1.12.10
     # via -r scripts/user_retirement/requirements/base.txt
-simplejson==3.20.2
+simplejson==4.1.1
     # via -r scripts/user_retirement/requirements/base.txt
 six==1.17.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   python-dateutil
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
-stevedore==5.5.0
+stevedore==5.9.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce
@@ -259,18 +245,18 @@ uritemplate==4.2.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   -r scripts/user_retirement/requirements/testing.in
     #   botocore
     #   requests
     #   responses
-werkzeug==3.1.3
+werkzeug==3.1.8
     # via moto
-xmltodict==1.0.2
+xmltodict==1.0.4
     # via moto
-zeep==4.3.2
+zeep==4.3.3
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-certifi==2025.10.5
+certifi==2026.6.17
     # via requests
-charset-normalizer==3.4.3
+charset-normalizer==3.4.9
     # via requests
-idna==3.10
+idna==3.18
     # via requests
-requests==2.32.5
+requests==2.34.2
     # via -r scripts/xblock/requirements.in
-urllib3==2.5.0
+urllib3==2.7.0
     # via requests


### PR DESCRIPTION
Backport several constraints.txt changes from upstream openedx/openedx-platform to this 2U fork (edx/edx-platform).

* Remove `cryptography` and `pact-python` pins.
  - backport of https://github.com/openedx/openedx-platform/pull/38465
* Add `astroid` pin.
  - backport of https://github.com/openedx/openedx-platform/pull/38067

Additional changes:

* Added `pip` pin because the newest version of pip is incompatible with pip-tools.
* Added lti-consumer-xblock pin because 11+ depends on the new SignalHandler.pre_item_delete introduced in https://github.com/openedx/openedx-platform/pull/38289 but that new signal has not yet been backported to this 2U fork (edx/edx-platform).

Then also I ran `make upgrade`. That updated common_constraints.txt to pull in the new `social-auth-*` pins.

`make compile-requirements` now runs cleanly under python 3.11.