### PR TITLE
chore: re-sync common_constraints.txt and recompile requirements

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -22,3 +22,9 @@ Django<6.0
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
+
+# 2026-07-06: Constrain social-auth-* packages to the latest version compatible with
+# edx-drf-extensions<=10.6.0. (Newer versions require a POST instead of a GET.)
+# Tracking issue: https://github.com/openedx/edx-drf-extensions/issues/561
+social-auth-app-django<6.0.0
+social-auth-core<5.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1120,12 +1120,14 @@ snowflake-connector-python==4.2.0
     # via enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
     #   edx-enterprise
 social-auth-core==4.7.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1940,6 +1940,7 @@ snowflake-connector-python==4.2.0
     #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1947,6 +1948,7 @@ social-auth-app-django==5.4.1
     #   edx-enterprise
 social-auth-core==4.7.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1371,12 +1371,14 @@ snowflake-connector-python==4.2.0
     #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   edx-enterprise
 social-auth-core==4.7.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1479,12 +1479,14 @@ snowflake-connector-python==4.2.0
     #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   edx-enterprise
 social-auth-core==4.7.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django


### PR DESCRIPTION
This is needed to fix the "Consistent Python dependencies" check in CI which would otherwise fail because it will try to update common_constraints.txt but then find that many "via" comments are outdated.

For now, this supersedes https://github.com/edx/edx-platform/pull/394 but I'm keeping that PR around for reference.

Also related:
* https://github.com/openedx/edx-lint/pull/552
* https://github.com/openedx/edx-lint/pull/555
* https://github.com/openedx/edx-lint/pull/556
