### PR TITLE
fix: Optimize vertical access scan for dynamic XBlocks

### DIFF
--- a/xmodule/tests/test_vertical.py
+++ b/xmodule/tests/test_vertical.py
@@ -308,10 +308,9 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
         """
         Tests block_has_access_error only checks selected children for dynamic blocks.
         """
-        selected_child = Mock()
+        selected_child = Mock(spec_set=['has_access_error', 'get_children'])
         selected_child.has_access_error = False
         selected_child.get_children.return_value = []
-
         dynamic_child = Mock()
         dynamic_child.has_access_error = False
         dynamic_child.has_dynamic_children.return_value = True

--- a/xmodule/tests/test_vertical.py
+++ b/xmodule/tests/test_vertical.py
@@ -304,6 +304,45 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
 
         assert should_block == has_access_error
 
+    def test_block_has_access_error_uses_selected_children_for_dynamic_blocks(self):
+        """
+        Tests block_has_access_error only checks selected children for dynamic blocks.
+        """
+        selected_child = Mock()
+        selected_child.has_access_error = False
+        selected_child.get_children.return_value = []
+
+        dynamic_child = Mock()
+        dynamic_child.has_access_error = False
+        dynamic_child.has_dynamic_children.return_value = True
+        dynamic_child.get_child_blocks.return_value = [selected_child]
+        dynamic_child.get_children.side_effect = AssertionError('Unselected children should not be inspected')
+
+        should_block = self.vertical.block_has_access_error(dynamic_child)
+
+        assert not should_block
+        dynamic_child.get_child_blocks.assert_called_once()
+        dynamic_child.get_children.assert_not_called()
+
+    def test_block_has_access_error_detects_selected_dynamic_child_access_error(self):
+        """
+        Tests block_has_access_error still detects access errors on selected dynamic children.
+        """
+        selected_child = Mock()
+        selected_child.has_access_error = True
+
+        dynamic_child = Mock()
+        dynamic_child.has_access_error = False
+        dynamic_child.has_dynamic_children.return_value = True
+        dynamic_child.get_child_blocks.return_value = [selected_child]
+        dynamic_child.get_children.side_effect = AssertionError('Unselected children should not be inspected')
+
+        should_block = self.vertical.block_has_access_error(dynamic_child)
+
+        assert should_block
+        dynamic_child.get_child_blocks.assert_called_once()
+        dynamic_child.get_children.assert_not_called()
+
     @ddt.unpack
     @ddt.data(
         (True, 0.9, True),

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -108,10 +108,8 @@ class VerticalBlock(
         child_context['child_of_vertical'] = True
         is_child_of_vertical = context.get('child_of_vertical', False)
 
-        # pylint: disable=no-member
         for child in child_blocks:
-            child_has_access_error = self.block_has_access_error(child)
-            if context.get('hide_access_error_blocks') and child_has_access_error:
+            if context.get('hide_access_error_blocks') and self.block_has_access_error(child):
                 continue
             child_block_context = copy(child_context)
             if child in list(child_blocks_to_complete_on_view):
@@ -189,8 +187,16 @@ class VerticalBlock(
         if has_access_error:
             return True
 
-        # Check child nodes if they exist (e.g. randomized library question aka LegacyLibraryContentBlock)
-        for child in block.get_children():
+        # Dynamic blocks, such as randomized library content, should only
+        # inspect the child blocks selected for the learner.
+        has_dynamic_children = getattr(block, 'has_dynamic_children', None)
+        get_child_blocks = getattr(block, 'get_child_blocks', None)
+        if callable(has_dynamic_children) and has_dynamic_children() and callable(get_child_blocks):
+            child_blocks = get_child_blocks()
+        else:
+            child_blocks = block.get_children()
+
+        for child in child_blocks:
             has_access_error = getattr(child, 'has_access_error', False)
             if has_access_error:
                 return True


### PR DESCRIPTION
## Summary

This PR optimizes the LMS unit render path for dynamic/randomized XBlocks when the Learning MFE requests access-error filtering with `recheck_access=1`.

For dynamic blocks such as item banks, library content, randomized blocks, or split tests, the vertical render access-error scan should inspect only the child blocks selected for the current learner. Previously, the recursive scan could use `get_children()`, which may include all possible children instead of only the selected/renderable children.

## Problem

In LP-284, the CyberFun graded assessment unit timed out for learner `kewinwong` while rendering the full LMS `/xblock/` response. Individual selected problem XBlocks loaded successfully, but the full parent unit render was slow enough to hit ingress/LMS timeout limits.

The investigation showed that the full unit render can involve learner-specific randomized content and access-error filtering from the Learning MFE path.

## Change

- Avoid calling `block_has_access_error()` unless `hide_access_error_blocks` is enabled.
- When recursively checking access errors for a dynamic child block:
  - use `get_child_blocks()` if the block reports `has_dynamic_children()`
  - otherwise continue using `get_children()`

This keeps the existing access-error hiding behavior while avoiding unnecessary scans of unselected dynamic/randomized children.