### PR TITLE
fix: run course access check before learner user substitution

### DIFF
--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -190,31 +190,31 @@ class OutlineTabView(RetrieveAPIView):
     def get(self, request, *args, **kwargs):  # pylint: disable=too-many-statements
         course_key_string = kwargs.get('course_key_string')
         course_key = CourseKey.from_string(course_key_string)
-        user = request.user
         # Enable NR tracing for this view based on course
         monitoring_utils.set_custom_attribute('course_id', course_key_string)
-        monitoring_utils.set_custom_attribute('user_id', user.id)
-        monitoring_utils.set_custom_attribute('is_staff', user.is_staff)
+        monitoring_utils.set_custom_attribute('user_id', request.user.id)
+        monitoring_utils.set_custom_attribute('is_staff', request.user.is_staff)
         masquerade_object, request.user = setup_masquerade(
             request,
             course_key,
-            staff_access=has_access(user, 'staff', course_key),
+            staff_access=has_access(request.user, 'staff', course_key),
             reset_masquerade_data=True,
         )
 
-        user_is_masquerading = is_masquerading(user, course_key, course_masquerade=masquerade_object)
+        user_is_masquerading = is_masquerading(request.user, course_key, course_masquerade=masquerade_object)
 
-        # Check if the user is masquerading as a student and get the masqueraded user object
+        course = get_course_or_403(request.user, 'load', course_key, check_if_enrolled=False)
+
+        user = request.user
         if user_is_masquerading and masquerade_object.role == 'student':
             try:
                 User = get_user_model()
-                # If the masqueraded user does not exist, we will continue with the original user object.
+                # If the masqueraded user does not exist, we will continue with request.user.
                 username = masquerade_object.user_name
                 user = User.objects.get(username=username)
             except User.DoesNotExist:
                 pass
 
-        course = get_course_or_403(user, 'load', course_key, check_if_enrolled=False)
         course_overview = get_course_overview_or_404(course_key)
         enrollment = CourseEnrollment.get_enrollment(user, course_key)
         enrollment_mode = getattr(enrollment, 'mode', None)


### PR DESCRIPTION
## Summary

Fixes a regression where staff using **"View as Specific Learner"** on a learner with expired audit access would encounter a generic **"An unexpected error occurred"** page instead of the expected course outline.

## Problem

When masquerading as a learner, the outline view replaces `request.user` (the staff user) with a fresh `User.objects.get()` instance of the masqueraded learner. This newly fetched user object does not include `masquerade_settings`, causing `check_course_expired` to lose the masquerade context and incorrectly return a **403 "Access expired"** response.

The frontend (`frontend-app-learning`) suppresses this 403 and relies on the metadata endpoint to determine access. Since the metadata endpoint evaluates access using the original staff user, it returns `hasAccess: true`. As a result, the frontend attempts to render the course outline with an empty outline model, leading to the generic error page.

## Root Cause

`get_course_or_403()` was executed **after** substituting `request.user` with the masqueraded learner. As a result, the access check was performed against a fresh learner object that lacked `masquerade_settings`, instead of the original `request.user`, where the masquerade context had already been established by `setup_masquerade`.

## Fix

Reordered the existing code so that `get_course_or_403()` executes **before** the learner substitution:

```python
# Access check runs first — request.user still has masquerade_settings
course = get_course_or_403(request.user, "load", course_key, ...)

# Replace the user only after access validation so downstream visibility
# checks continue to use the masqueraded learner's permissions.
if user_is_masquerading and masquerade_object.role == "student":
    user = User.objects.get(username=masquerade_object.user_name)
```
**Ticket:** [LP-982](https://2u-internal.atlassian.net/browse/LP-982)