### PR TITLE
fix: audit expiry banner not visible when masquerading as expired audit learner

### DIFF
--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -205,23 +205,23 @@ class OutlineTabView(RetrieveAPIView):
 
         course = get_course_or_403(request.user, 'load', course_key, check_if_enrolled=False)
 
-        user = request.user
+        masquerade_user = request.user
         if user_is_masquerading and masquerade_object.role == 'student':
             try:
                 User = get_user_model()
                 # If the masqueraded user does not exist, we will continue with request.user.
                 username = masquerade_object.user_name
-                user = User.objects.get(username=username)
+                masquerade_user = User.objects.get(username=username)
             except User.DoesNotExist:
                 pass
 
         course_overview = get_course_overview_or_404(course_key)
-        enrollment = CourseEnrollment.get_enrollment(user, course_key)
+        enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
         enrollment_mode = getattr(enrollment, 'mode', None)
         allow_anonymous = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key)
         allow_public = allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC
         allow_public_outline = allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE
-        allow_preview_of_verified_content = learner_can_preview_verified_content(course_key, user)
+        allow_preview_of_verified_content = learner_can_preview_verified_content(course_key, request.user)
 
         # User locale settings
         user_timezone_locale = user_timezone_locale_prefs(request)
@@ -260,22 +260,22 @@ class OutlineTabView(RetrieveAPIView):
         show_enrolled = is_enrolled or is_staff
         enable_proctored_exams = False
         if show_enrolled:
-            course_blocks = get_course_outline_block_tree(request, course_key_string, user)
-            date_blocks = get_course_date_blocks(course, user, request, num_assignments=1)
+            course_blocks = get_course_outline_block_tree(request, course_key_string, masquerade_user)
+            date_blocks = get_course_date_blocks(course, request.user, request, num_assignments=1)
             dates_widget['course_date_blocks'] = [block for block in date_blocks if not isinstance(block, TodaysDate)]
 
-            handouts_html = get_course_info_section(request, user, course, 'handouts')
+            handouts_html = get_course_info_section(request, request.user, course, 'handouts')
             welcome_message_html = get_current_update_for_user(request, course)
 
-            offer_data = generate_offer_data(user, course_overview)
-            access_expiration = get_access_expiration_data(user, course_overview)
-            cert_data = get_cert_data(user, course, enrollment.mode) if is_enrolled else None
+            offer_data = generate_offer_data(request.user, course_overview)
+            access_expiration = get_access_expiration_data(request.user, course_overview)
+            cert_data = get_cert_data(request.user, course, enrollment.mode) if is_enrolled else None
 
             enable_proctored_exams = course_overview.enable_proctored_exams
 
             if (is_enrolled and ENABLE_COURSE_GOALS.is_enabled(course_key)):
                 course_goals['weekly_learning_goal_enabled'] = True
-                selected_goal = get_course_goal(user, course_key)
+                selected_goal = get_course_goal(request.user, course_key)
                 if selected_goal:
                     course_goals['selected_goal'] = {
                         'days_per_week': selected_goal.days_per_week,
@@ -283,7 +283,7 @@ class OutlineTabView(RetrieveAPIView):
                     }
 
             try:
-                resume_block = get_key_to_last_completed_block(user, course.id)
+                resume_block = get_key_to_last_completed_block(request.user, course.id)
                 resume_course['has_visited_course'] = True
                 resume_path = reverse('jump_to', kwargs={
                     'course_id': course_key_string,
@@ -297,7 +297,7 @@ class OutlineTabView(RetrieveAPIView):
         elif allow_public_outline or allow_public or user_is_masquerading:
             course_blocks = get_course_outline_block_tree(request, course_key_string, None)
             if allow_public or user_is_masquerading:
-                handouts_html = get_course_info_section(request, user, course, 'handouts')
+                handouts_html = get_course_info_section(request, request.user, course, 'handouts')
 
         if not is_enrolled:
             if CourseMode.is_masters_only(course_key):
@@ -322,7 +322,7 @@ class OutlineTabView(RetrieveAPIView):
         # so this is a tiny first step in that migration.
         if course_blocks:
             user_course_outline = get_user_course_outline(
-                course_key, user, datetime.now(tz=timezone.utc),
+                course_key, masquerade_user, datetime.now(tz=timezone.utc),
                 preview_verified_content=allow_preview_of_verified_content
             )
             available_seq_ids = {str(usage_key) for usage_key in user_course_outline.sequences}
@@ -367,8 +367,8 @@ class OutlineTabView(RetrieveAPIView):
                             seq_data['is_preview'] = True
 
         user_has_passing_grade = False
-        if not user.is_anonymous:
-            user_grade = CourseGradeFactory().read(user, course)
+        if not request.user.is_anonymous:
+            user_grade = CourseGradeFactory().read(request.user, course)
             if user_grade:
                 user_has_passing_grade = user_grade.passed
 


### PR DESCRIPTION
## Problem
When a staff user masqueraded as a specific student with expired audit access, the audit expiry banner was not visible on the course home (outline) page.
The root cause was that setup_masquerade() already returns the correctly configured masqueraded user via request.user — with masquerade_settings and real_user attached. However, the outline view was re-fetching the user from the database via User.objects.get(username=...), which returned a fresh instance with no masquerade context.
This caused get_access_expiration_data() → is_masquerading_as_specific_student() to always return False, since masquerade_settings was missing on the re-fetched user, resulting in the audit expiry banner never appearing.
### Fix
Replaced all occurrences of the re-fetched user with request.user for user-specific operations (offer data, access expiration, cert data, course goals, resume block, grade calculation, enrollment)
Introduced masquerade_user (still fetched via User.objects.get()) only where strictly necessary — specifically for get_course_outline_block_tree and get_user_course_outline, which require the actual masqueraded user DB instance for content visibility logic
Enrollment is now fetched via request.user to ensure masquerade context is preserved

### Ticket : [LP-982](https://2u-internal.atlassian.net/browse/LP-982)
