### PR TITLE
fix: Fix logout iframe load handler script error

### DIFF
--- a/lms/static/js/jquery.allLoaded.js
+++ b/lms/static/js/jquery.allLoaded.js
@@ -19,15 +19,12 @@
             var $elems = this;
             var waiting = this.length;
 
-            var handler = function () {
+            return $elems.one('load', function () {
                 --waiting;
                 if (!waiting) {
                     fn.call(window);
                 }
-                this.unbind(handler);
-            };
-
-            return $elems.load(handler);
+            });
         }
     });
 })(jQuery);


### PR DESCRIPTION
Fixes repeated `Uncaught "Script error."` events captured by Datadog on the `/logout` page.

The logout page waits for hidden logout iframes to load before redirecting. The helper in `jquery.allLoaded.js` was calling `this.unbind(handler)` inside a jQuery load callback, but `this` is the raw iframe DOM element, not a jQuery object. That can throw during iframe load handling and surface in RUM as a masked `Script error`.

This change replaces the manual load/unbind handling with jQuery `.one('load', ...)`, so each iframe load is counted once and the handler is automatically removed.