### PR TITLE
fix: prefetch user state only for selected library_content children

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -660,6 +660,22 @@ class UserInfoCache(DjangoOrmFieldCache):
         return key.field_name
 
 
+def _children_for_field_data_cache(block):
+    """
+    Return child blocks whose field data should be prefetched for ``block``.
+
+    Dynamic blocks such as library_content expose a learner-specific subset via
+    ``get_child_blocks()``. Prefetching all modulestore children (``get_children()``)
+    loads user state for blocks that will never render for the current learner.
+    """
+    get_child_blocks = getattr(block, 'get_child_blocks', None)
+    has_dynamic_children = getattr(block, 'has_dynamic_children', None)
+    if callable(has_dynamic_children) and has_dynamic_children() and callable(get_child_blocks):
+        return list(get_child_blocks())
+
+    return list(block.get_children()) + list(block.get_required_block_descriptors())
+
+
 class FieldDataCache:
     """
     A cache of django model objects needed to supply the data
@@ -731,7 +747,7 @@ class FieldDataCache:
                 should be cached
         """
 
-        def get_child_blocks(block, depth, block_filter):
+        def collect_descendant_blocks(block, depth, block_filter):
             """
             Return a list of all child blocks down to the specified depth
             that match the block filter. Includes `block`
@@ -749,13 +765,13 @@ class FieldDataCache:
             if depth is None or depth > 0:
                 new_depth = depth - 1 if depth is not None else depth
 
-                for child in block.get_children() + block.get_required_block_descriptors():
-                    blocks.extend(get_child_blocks(child, new_depth, block_filter))
+                for child in _children_for_field_data_cache(block):
+                    blocks.extend(collect_descendant_blocks(child, new_depth, block_filter))
 
             return blocks
 
         with modulestore().bulk_operations(block.location.course_key):
-            blocks = get_child_blocks(block, depth, block_filter)
+            blocks = collect_descendant_blocks(block, depth, block_filter)
 
         self.add_blocks_to_cache(blocks)
 

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -13,7 +13,13 @@ from xblock.exceptions import KeyValueMultiSaveError
 from xblock.fields import BlockScope, Scope, ScopeIds
 
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.model_data import DjangoKeyValueStore, FieldDataCache, InvalidScopeError
+from lms.djangoapps.courseware.model_data import (
+    DjangoKeyValueStore,
+    FieldDataCache,
+    InvalidScopeError,
+    UserStateCache,
+    _children_for_field_data_cache,
+)
 from lms.djangoapps.courseware.models import (
     StudentModule,
     XModuleStudentInfoField,
@@ -444,3 +450,100 @@ class TestStudentInfoStorage(OtherUserFailureTestMixin, StorageTestBase, TestCas
     storage_class = XModuleStudentInfoField
     other_key_factory = partial(DjangoKeyValueStore.Key, Scope.user_info, 2, 'mock_problem')  # user_id=2, not 1
     existing_field_name = "existing_field"
+
+
+class TestFieldDataCacheDynamicChildren(TestCase):
+    """Tests for dynamic-child handling in FieldDataCache descendant prefetch."""
+
+    def test_children_for_field_data_cache_uses_get_child_blocks(self):
+        """
+        Dynamic blocks should only expose learner-selected children for prefetch.
+        """
+        selected_child = Mock(name='selected_child')
+        dynamic_block = Mock(name='dynamic_block')
+        dynamic_block.has_dynamic_children.return_value = True
+        dynamic_block.get_child_blocks.return_value = [selected_child]
+        dynamic_block.get_children.side_effect = AssertionError(
+            'get_children should not be called for dynamic blocks'
+        )
+
+        assert _children_for_field_data_cache(dynamic_block) == [selected_child]
+        dynamic_block.get_child_blocks.assert_called_once_with()
+        dynamic_block.get_children.assert_not_called()
+
+    def test_children_for_field_data_cache_uses_get_children_for_static_blocks(self):
+        """
+        Static blocks should continue to prefetch all modulestore children.
+        """
+        static_child = Mock(name='static_child')
+        static_block = Mock(name='static_block')
+        static_block.has_dynamic_children.return_value = False
+        static_block.get_children.return_value = [static_child]
+        static_block.get_required_block_descriptors.return_value = []
+
+        assert _children_for_field_data_cache(static_block) == [static_child]
+        static_block.get_children.assert_called_once_with()
+        static_block.get_required_block_descriptors.assert_called_once_with()
+
+    @patch('lms.djangoapps.courseware.model_data.modulestore')
+    def test_add_block_descendents_prefetches_only_selected_dynamic_children(self, mock_modulestore):
+        """
+        add_block_descendents should not walk unselected modulestore children.
+        """
+        mock_modulestore.return_value.bulk_operations.return_value.__enter__ = Mock(return_value=None)
+        mock_modulestore.return_value.bulk_operations.return_value.__exit__ = Mock(return_value=False)
+
+        user_state_field = mock_field(Scope.user_state, 'state')
+
+        def configure_static_block(block):
+            block.get_children.return_value = []
+            block.get_required_block_descriptors.return_value = []
+            block.has_dynamic_children.return_value = False
+            block.fields.values.return_value = [user_state_field]
+            block.has_score = False
+            block.location = LOCATION('usage_id')
+
+        unselected_children = [Mock(name=f'unselected_{index}') for index in range(3)]
+        selected_children = [Mock(name='selected_0'), Mock(name='selected_1')]
+        for child in selected_children + unselected_children:
+            configure_static_block(child)
+
+        library_content = Mock(name='library_content')
+        library_content.has_dynamic_children.return_value = True
+        library_content.get_child_blocks.return_value = selected_children
+        library_content.get_children.return_value = unselected_children + selected_children
+        library_content.get_required_block_descriptors.return_value = []
+        library_content.fields.values.return_value = [user_state_field]
+        library_content.has_score = False
+        library_content.location = LOCATION('library_content')
+        library_content.location.course_key = COURSE_KEY
+
+        vertical = Mock(name='vertical')
+        vertical.has_dynamic_children.return_value = False
+        vertical.get_children.return_value = [library_content]
+        vertical.get_required_block_descriptors.return_value = []
+        vertical.fields.values.return_value = [user_state_field]
+        vertical.has_score = False
+        vertical.location = LOCATION('vertical')
+        vertical.location.course_key = COURSE_KEY
+
+        user = UserFactory.create(username='dynamic_children_user')
+        field_data_cache = FieldDataCache([], COURSE_KEY, user)
+
+        cached_blocks = []
+
+        def capture_cache_fields(fields, blocks, aside_types):  # lint-amnesty, pylint: disable=unused-argument
+            cached_blocks.extend(blocks)
+
+        with patch.object(UserStateCache, 'cache_fields', side_effect=capture_cache_fields):
+            field_data_cache.add_block_descendents(vertical)
+
+        cached_block_names = {block._mock_name for block in cached_blocks}  # pylint: disable=protected-access
+        assert 'vertical' in cached_block_names
+        assert 'library_content' in cached_block_names
+        assert 'selected_0' in cached_block_names
+        assert 'selected_1' in cached_block_names
+        assert 'unselected_0' not in cached_block_names
+        assert 'unselected_1' not in cached_block_names
+        assert 'unselected_2' not in cached_block_names
+        library_content.get_child_blocks.assert_called_once_with()


### PR DESCRIPTION
This pull request improves how the `FieldDataCache` prefetches child blocks, especially for dynamic blocks such as `library_content`, ensuring that only the relevant learner-specific children are prefetched. This change prevents unnecessary loading of user state for blocks that will not be rendered for the current learner, optimizing performance and correctness. Additionally, comprehensive tests are added to verify the new behavior.

**Enhancements to child block prefetching:**

* Introduced the `_children_for_field_data_cache` helper function in `model_data.py` to determine which child blocks should be prefetched, using `get_child_blocks()` for dynamic blocks and falling back to `get_children()` and `get_required_block_descriptors()` for static blocks.
* Updated the descendant collection logic in `add_block_descendents` to use `_children_for_field_data_cache`, ensuring only the appropriate children are traversed and prefetched.
* Refactored the descendant collection function from `get_child_blocks` to `collect_descendant_blocks` for clarity and to support the new child selection logic.

**Testing improvements:**

* Added a new test class `TestFieldDataCacheDynamicChildren` in `test_model_data.py` to verify that dynamic blocks only prefetch learner-selected children and static blocks continue to prefetch all children. Also tested that unselected children are not prefetched.
* Updated imports in `test_model_data.py` to include the new helper function and related classes.When building FieldDataCache for render, walk get_child_blocks() for dynamic blocks (library_content, itembank) instead of all modulestore children. This aligns prefetch with vertical render behavior and reduces StudentModule over-fetch on large randomized quizzes.

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
