### PR TITLE
fix: adjust print CSS margin for verified certificate label to prevent PDF shift

### DIFF
--- a/lms/static/certificates/sass/_print.scss
+++ b/lms/static/certificates/sass/_print.scss
@@ -201,7 +201,8 @@
     }
 
     .accomplishment-type {
-      margin-top: -(map-get($spacing-vertical, mid-large));
+      margin-top: -(map-get($spacing-vertical, large));
+      margin-bottom: 0;
     }
 
     .accomplishment-type-symbol {


### PR DESCRIPTION
## Summary
Fixes the "Verified Certificate" label shifting when saving a course certificate as PDF in stage and prod environments.
### Problem
When printing or saving a course certificate as PDF, the "Verified Certificate" label shifts from its expected position. This is caused by incorrect margin-top value in the media print CSS that does not match the screen rendering value.
### Changes
Updated _print.scss to correct the .accomplishment-type margin value so it matches the screen rendering, preventing the label from shifting in PDF output

### Ticket : [LP-530](https://2u-internal.atlassian.net/browse/LP-530)