### PR TITLE
feat(AUT-266): enforce fail-fast allowlist validation and prevent raw input reflection

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -10,6 +10,7 @@ import logging
 import re
 import urllib
 
+from django.core.exceptions import ValidationError
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth import login as django_login
@@ -19,6 +20,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
+from django.core.validators import validate_email
 from django.views.decorators.csrf import csrf_exempt, csrf_protect, ensure_csrf_cookie
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_http_methods
@@ -50,6 +52,7 @@ from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_LOGIN_USING_
 from openedx.core.djangoapps.user_authn.cookies import get_response_with_refreshed_jwt_cookies, set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError, VulnerablePasswordError
 from openedx.core.djangoapps.user_authn.tasks import check_pwned_password_and_send_track_event
+from openedx.core.djangoapps.user_authn.views.registration_form import validate_username
 from openedx.core.djangoapps.user_authn.toggles import (
     is_require_third_party_auth_enabled,
     should_redirect_to_authn_microfrontend,
@@ -66,6 +69,8 @@ log = logging.getLogger("edx.student")
 AUDIT_LOG = logging.getLogger("audit")
 USER_MODEL = get_user_model()
 PASSWORD_RESET_INITIATED = "edx.user.passwordreset.initiated"
+LOGIN_INFO_ERROR = _("There was an error receiving your login information. Please email us.")
+LOGIN_INVALID_INPUT_EMAIL = "[invalid input]"
 
 
 def _do_third_party_auth(request):
@@ -125,6 +130,26 @@ def _get_user_by_username(username):
         return None
 
 
+def _validate_login_identifier(identifier):
+    """
+    Validate the submitted login identifier before any auth logic runs.
+    """
+    if "@" in identifier:
+        try:
+            validate_email(identifier)
+        except ValidationError as exc:
+            raise AuthFailedError(LOGIN_INFO_ERROR) from exc
+        return
+
+    if not accounts.USERNAME_MIN_LENGTH <= len(identifier) <= accounts.USERNAME_MAX_LENGTH:
+        raise AuthFailedError(LOGIN_INFO_ERROR)
+
+    try:
+        validate_username(identifier)
+    except ValidationError as exc:
+        raise AuthFailedError(LOGIN_INFO_ERROR)
+
+
 def _get_user_by_email_or_username(request, api_version):
     """
     Finds a user object in the database based on the given request, ignores all fields except for email and username.
@@ -135,7 +160,7 @@ def _get_user_by_email_or_username(request, api_version):
         login_fields = ["email_or_username", "password"]
 
     if any(f not in request.POST.keys() for f in login_fields):
-        raise AuthFailedError(_("There was an error receiving your login information. Please email us."))
+        raise AuthFailedError(LOGIN_INFO_ERROR)
 
     email_or_username = request.POST.get("email", None) or request.POST.get("email_or_username", None)
     user = _get_user_by_email(email_or_username)
@@ -557,6 +582,7 @@ def login_user(request, api_version="v1"):  # pylint: disable=too-many-statement
     third_party_auth_requested = third_party_auth.is_enabled() and pipeline.running(request)
     first_party_auth_requested = any(bool(request.POST.get(p)) for p in ["email", "email_or_username", "password"])
     is_user_third_party_authenticated = False
+    user = None
 
     set_custom_attribute("login_user_course_id", request.POST.get("course_id"))
 
@@ -564,8 +590,13 @@ def login_user(request, api_version="v1"):  # pylint: disable=too-many-statement
         return HttpResponseForbidden(
             "Third party authentication is required to login. Username and password were received instead."
         )
-    possibly_authenticated_user = None
     try:
+        login_identifier = request.POST.get("email_or_username")
+        if login_identifier is None:
+            login_identifier = request.POST.get("email")
+        if login_identifier is not None:
+            _validate_login_identifier(login_identifier)
+
         if third_party_auth_requested and not first_party_auth_requested:
             # The user has already authenticated via third-party auth and has not
             # asked to do first party auth by supplying a username or password. We
@@ -682,10 +713,7 @@ def login_user(request, api_version="v1"):  # pylint: disable=too-many-statement
         error_code = response_content.get("error_code")
         if error_code:
             set_custom_attribute("login_error_code", error_code)
-        email_or_username_key = "email" if api_version == API_V1 else "email_or_username"
-        email_or_username = request.POST.get(email_or_username_key, None)
-        email_or_username = possibly_authenticated_user.email if possibly_authenticated_user else email_or_username
-        response_content["email"] = email_or_username
+        response_content["email"] = user.email if user else LOGIN_INVALID_INPUT_EMAIL
     except VulnerablePasswordError as error:
         response_content = error.get_response()
         log.exception(response_content)

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -147,7 +147,7 @@ def _validate_login_identifier(identifier):
     try:
         validate_username(identifier)
     except ValidationError as exc:
-        raise AuthFailedError(LOGIN_INFO_ERROR)
+        raise AuthFailedError(LOGIN_INFO_ERROR) from exc
 
 
 def _get_user_by_email_or_username(request, api_version):

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -63,7 +63,10 @@ from openedx.core.djangoapps.user_authn.views.registration_form import (
     RegistrationFormFactory,
     get_registration_extension_form
 )
-from openedx.core.djangoapps.user_authn.views.utils import get_auto_generated_username
+from openedx.core.djangoapps.user_authn.views.utils import (
+    get_auto_generated_username,
+    get_total_registration_time_validation_error,
+)
 from openedx.core.djangoapps.user_authn.tasks import check_pwned_password_and_send_track_event
 from openedx.core.djangoapps.user_authn.toggles import (
     is_require_third_party_auth_enabled,
@@ -587,6 +590,20 @@ class RegistrationView(APIView):
             )
 
         data = request.POST.copy()
+
+        validation_error = get_total_registration_time_validation_error(data)
+        if validation_error:
+            AUDIT_LOG.warning(
+                "Registration rejected due to invalid total_registration_time payload digest=%s",
+                validation_error["value_digest"],
+            )
+            return self._create_response(
+                request,
+                {validation_error["field"]: [{"user_message": validation_error["user_message"]}]},
+                status_code=400,
+                error_code=validation_error["error_code"],
+            )
+
         self._handle_terms_of_service(data)
 
         if is_auto_generated_username_enabled() and 'username' not in data:

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -1211,7 +1211,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
             "password": "invalid"
         })
         self.assertHttpBadRequest(response)
-        self._assert_response(response, success=False, absent_keys=["email"])
+        self._assert_response(response, success=False, email_value=self.EMAIL)
 
         # Invalid email address
         response = self.client.post(self.url, {
@@ -1219,7 +1219,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
             "password": self.PASSWORD,
         })
         self.assertHttpBadRequest(response)
-        self._assert_response(response, success=False, absent_keys=["email"])
+        self._assert_response(response, success=False, email_value="[invalid input]")
 
     @ddt.data(
         "bad input!",

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -354,6 +354,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
         self._assert_response(
             response, success=False, value=self.LOGIN_FAILED_WARNING, status_code=400
         )
+        self._assert_response(response, success=False, email_value="[invalid input]")
         self._assert_audit_log(mock_audit_log, 'warning', ['Login failed', 'Unknown user email', email_hash])
 
     @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
@@ -364,6 +365,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
             self.password,
         )
         self._assert_response(response, success=False, value=self.LOGIN_FAILED_WARNING)
+        self._assert_response(response, success=False, email_value="[invalid input]")
         self._assert_audit_log(mock_audit_log, 'warning', ['Login failed', 'Unknown user email'])
         self._assert_not_in_audit_log(mock_audit_log, 'warning', [nonexistent_email])
 
@@ -373,6 +375,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
             'wrong_password',
         )
         self._assert_response(response, success=False, value=self.LOGIN_FAILED_WARNING)
+        self._assert_response(response, success=False, email_value=self.user_email)
         self._assert_audit_log(mock_audit_log, 'warning',
                                ['Login failed', 'password for', str(self.user.id), 'invalid'])
 
@@ -380,6 +383,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
     def test_login_fail_wrong_password_no_pii(self):
         response, mock_audit_log = self._login_response(self.user_email, 'wrong_password')
         self._assert_response(response, success=False, value=self.LOGIN_FAILED_WARNING)
+        self._assert_response(response, success=False, email_value=self.user_email)
         self._assert_audit_log(
             mock_audit_log, 'warning', ['Login failed', 'password for', str(self.user.id), 'invalid']
         )
@@ -433,6 +437,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
             self.password
         )
         self._assert_response(response, success=False, error_code="inactive-user")
+        self._assert_response(response, success=False, email_value=self.user_email)
         self._assert_audit_log(mock_audit_log, 'warning', ['Login failed', 'Account not active for user'])
         self._assert_not_in_audit_log(mock_audit_log, 'warning', ['test'])
 
@@ -820,7 +825,16 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
             result = self.client.post(self.url, post_params, **extra)
         return result, mock_audit_log
 
-    def _assert_response(self, response, success=None, value=None, status_code=None, error_code=None):
+    def _assert_response(
+        self,
+        response,
+        success=None,
+        value=None,
+        status_code=None,
+        error_code=None,
+        email_value=None,
+        absent_keys=None,
+    ):
         """
         Assert that the response has the expected status code and returned a valid
         JSON-parseable dict.
@@ -850,6 +864,13 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
             msg = ("'%s' did not contain '%s'" %
                    (str(response_dict['value']), str(value)))
             assert value in response_dict['value'], msg
+
+        if email_value is not None:
+            assert response_dict['email'] == email_value
+
+        if absent_keys is not None:
+            for key in absent_keys:
+                assert key not in response_dict
 
     def _assert_redirect_url(self, response, expected_redirect_url):
         """
@@ -1190,6 +1211,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
             "password": "invalid"
         })
         self.assertHttpBadRequest(response)
+        self._assert_response(response, success=False, absent_keys=["email"])
 
         # Invalid email address
         response = self.client.post(self.url, {
@@ -1197,6 +1219,24 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
             "password": self.PASSWORD,
         })
         self.assertHttpBadRequest(response)
+        self._assert_response(response, success=False, absent_keys=["email"])
+
+    @ddt.data(
+        "bad input!",
+        "ab",
+        "not-an-email@",
+        "",
+    )
+    @patch('openedx.core.djangoapps.user_authn.views.login._get_user_by_email_or_username')
+    def test_login_rejects_invalid_login_identifier(self, invalid_identifier, mock_user_lookup):
+        response = self.client.post(self.url_v2, {
+            "email_or_username": invalid_identifier,
+            "password": self.PASSWORD,
+        })
+
+        self.assertHttpBadRequest(response)
+        self._assert_response(response, success=False, email_value="[invalid input]")
+        assert not mock_user_lookup.called
 
     @ddt.data(True, False)
     def test_missing_login_params(self, is_api_v1):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -1,5 +1,6 @@
 """Tests for account creation"""
 
+import hashlib
 import json
 from datetime import datetime
 from unittest import mock, skipIf, skipUnless
@@ -2091,6 +2092,47 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
     def setUp(self):  # pylint: disable=arguments-differ
         super(RegistrationViewTestV1, self).setUp()  # lint-amnesty, pylint: disable=bad-super-call
         self.url = reverse("user_api_registration_v2")
+
+    def test_register_invalid_total_registration_time(self):
+        invalid_total_registration_time = '57.664" AND "1"="1" --'
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "total_registration_time": invalid_total_registration_time,
+        })
+
+        self.assertHttpBadRequest(response)
+        response_json = json.loads(response.content.decode('utf-8'))
+        self.assertDictEqual(
+            response_json,
+            {
+                "total_registration_time": [{
+                    "user_message": "Enter a valid registration time value.",
+                }],
+                "error_code": "invalid-total-registration-time",
+            }
+        )
+
+        expected_digest = hashlib.shake_128(invalid_total_registration_time.encode("utf-8")).hexdigest(16)
+        with LogCapture() as logger:
+            self.client.post(self.url, {
+                "email": self.EMAIL,
+                "name": self.NAME,
+                "username": "another_user",
+                "password": self.PASSWORD,
+                "honor_code": "true",
+                "total_registration_time": invalid_total_registration_time,
+            })
+            logger.check_present(
+                (
+                    'audit',
+                    'WARNING',
+                    f'Registration rejected due to invalid total_registration_time payload digest={expected_digest}'
+                )
+            )
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={

--- a/openedx/core/djangoapps/user_authn/views/utils.py
+++ b/openedx/core/djangoapps/user_authn/views/utils.py
@@ -2,6 +2,7 @@
 User Auth Views Utils
 """
 import logging
+import hashlib
 import re
 from typing import Dict
 
@@ -25,6 +26,33 @@ log = logging.getLogger(__name__)
 API_V1 = 'v1'
 UUID4_REGEX = '[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
 ENTERPRISE_ENROLLMENT_URL_REGEX = fr'/enterprise/{UUID4_REGEX}/course/{settings.COURSE_KEY_REGEX}/enroll'
+TOTAL_REGISTRATION_TIME_RE = re.compile(r'^\d+(?:\.\d+)?$')
+
+
+def get_total_registration_time_validation_error(data):
+    """
+    Validate optional registration timing telemetry with an allowlist pattern.
+
+    Returns:
+        dict | None: error details when invalid, otherwise None.
+    """
+    total_registration_time = data.get('total_registration_time')
+    if total_registration_time is None:
+        total_registration_time = data.get('totalRegistrationTime')
+
+    if total_registration_time in (None, ''):
+        return None
+
+    normalized_value = str(total_registration_time).strip()
+    if TOTAL_REGISTRATION_TIME_RE.fullmatch(normalized_value):
+        return None
+
+    return {
+        "field": "total_registration_time",
+        "user_message": _("Enter a valid registration time value."),
+        "error_code": "invalid-total-registration-time",
+        "value_digest": hashlib.shake_128(normalized_value.encode("utf-8")).hexdigest(16),
+    }
 
 
 def third_party_auth_context(request, redirect_to, tpa_hint=None):


### PR DESCRIPTION

This PR hardens input validation and output handling across the login and registration API endpoints to address two security findings: improper input validation and raw user input reflection in API responses.

**Login endpoint (`/api/user/v{1,2}/account/login_session/`)**

- Added fail-fast allowlist validation for the `email_or_username` / `email` field at the very start of the request handler, before any auth lookup, database call, or downstream service logic runs.
- Email input is validated against RFC format using Django's `validate_email`.
- Username input is validated using the existing platform `validate_username` function from registration_form.py, which respects `ENABLE_UNICODE_USERNAME` and `USERNAME_REGEX_PARTIAL` settings, eliminating a previously hardcoded ASCII-only regex that would have caused false negatives.
- Raw user input is no longer reflected in error responses. The `email` field in 400 responses now returns the user's actual account email when the user is known, or the safe sentinel value `[invalid input]` when the identifier is unknown or malformed. This maintains backward API compatibility for clients that read the `email` field to repopulate forms.

**Registration endpoint (`/api/user/v{1,2}/account/registration/`)**

- Added strict allowlist validation for the optional telemetry field `total_registration_time` / `totalRegistrationTime` which previously accepted arbitrary strings including SQL-like payloads.
- Only numeric decimal values (e.g. `57.664`) are accepted. Malformed values are rejected immediately with HTTP 400 and `error_code: invalid-total-registration-time` before any account creation, filter, or CAPTCHA logic runs.
- Invalid payload attempts are logged to the audit log using a SHA digest of the malformed value, not the raw payload, to avoid storing or emitting attacker-controlled content in logs.
- Validation logic is centralized in utils.py as a shared utility function so it can be reused consistently across registration-related endpoints.

**User roles impacted**

- Learner: no visible change for legitimate users. Validation is allowlist-based and accepts all valid email/username formats including Unicode.
- Developer / Operator: new error code `invalid-total-registration-time` and additional audit log entries for suspicious registration telemetry.

---
## Testing instructions

**Prerequisites**

```
pip install -r requirements/edx/base.txt
pip install -r requirements/edx/testing.txt
```

**Automated tests**

```bash
# Login validation and non-reflection behavior
python manage.py lms test openedx.core.djangoapps.user_authn.views.tests.test_login.LoginSessionViewTest.test_invalid_credentials
python manage.py lms test openedx.core.djangoapps.user_authn.views.tests.test_login.LoginSessionViewTest.test_login_rejects_invalid_login_identifier
python manage.py lms test openedx.core.djangoapps.user_authn.views.tests.test_login.LoginTest.test_login_fail_no_user_exists
python manage.py lms test openedx.core.djangoapps.user_authn.views.tests.test_login.LoginTest.test_login_fail_wrong_password
python manage.py lms test openedx.core.djangoapps.user_authn.views.tests.test_login.LoginTest.test_login_not_activated_no_pii

# Registration telemetry validation and audit logging
python manage.py lms test openedx.core.djangoapps.user_authn.views.tests.test_register.RegistrationViewTestV2.test_register_invalid_total_registration_time
```

**Manual verification — Login**

1. Send a POST to `/api/user/v2/account/login_session/` with `email_or_username=trtrtr' AND '1'='1' -- ` and any password.
2. Confirm response is HTTP 400 with `success: false`.
3. Confirm the response body does **not** contain the SQL payload in any field.
4. Confirm `email` field is `[invalid input]`, not the raw submitted string.

**Manual verification — Registration**

1. Send a POST to `/api/user/v2/account/registration/` with all required fields and `total_registration_time=57.664" AND "1"="1" --`.
2. Confirm response is HTTP 400 with `error_code: invalid-total-registration-time`.
3. Confirm the request is rejected before account creation occurs.
4. Confirm the audit log contains a warning with a digest but not the raw payload string.

**Regression check — Valid values still work**

1. Login with a valid email and correct password — confirm HTTP 200.
2. Login with a valid username (including Unicode if `ENABLE_UNICODE_USERNAME` is on) — confirm HTTP 200.
3. Register with `total_registration_time=57.664` (valid numeric) — confirm HTTP 200 and account is created.