### PR TITLE
feat: upgrade edx-enterprise to 8.9.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -42,7 +42,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==8.8.0
+edx-enterprise==8.9.0
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -473,7 +473,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.8.0
+edx-enterprise==8.9.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.8.0
+edx-enterprise==8.9.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -557,7 +557,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.8.0
+edx-enterprise==8.9.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -578,7 +578,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.8.0
+edx-enterprise==8.9.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

Bumps the manually-managed `edx-enterprise` pin from `8.8.0` to `8.9.0`.

Per the comment in `requirements/constraints.txt`, this package is intentionally
excluded from automated upgrades so the owning team controls its rollout, so this
is a deliberate manual bump.

**What 8.9.0 contains** (single entry in the upstream changelog):

> `feat: add non-production portal banner configuration`

Concretely, upstream adds a `Non-production` enterprise customer type. Assigning it
to an `EnterpriseCustomer` sets the new read-only `show_non_production_banner`
property, which is exposed on the enterprise customer API serializer so the
administrator and learner portals can render a banner indicating the portal is not
production.

**Requirements diff** — 5 files, one line each, all `edx-enterprise==8.8.0` →
`edx-enterprise==8.9.0`:

- `requirements/constraints.txt`
- `requirements/edx/base.txt`
- `requirements/edx/development.txt`
- `requirements/edx/doc.txt`
- `requirements/edx/testing.txt`

No transitive dependency churn: 8.9.0 declares the same 48 `Requires-Dist` entries
as 8.8.0, so `make compile-requirements` produces only the pinned version line.

**Affected user roles:** Operator and Administrator (configures the customer type),
Learner (sees the banner). No UI changes in this repo — the banner is rendered by
the portal MFEs off the API field.

## Supporting information

- Jira: ENT-12015
- Upstream release: https://github.com/openedx/edx-enterprise/releases/tag/8.9.0
- Changelog: https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst

## Testing instructions

1. Deploy this branch and run migrations:
   ```
   ./manage.py lms migrate enterprise
   ```
   Two new migrations should apply:
   - `enterprise.0250_alter_enterprisecustomer_customer_type_and_more`
   - `enterprise.0251_add_non_production_customer_type`
2. Confirm the data migration created the customer type:
   ```
   ./manage.py lms shell -c "from enterprise.models import EnterpriseCustomerType; \
     print(EnterpriseCustomerType.objects.filter(name='Non-production').exists())"
   ```
   Expect `True`.
3. In Django admin, edit an `EnterpriseCustomer` and set **Customer Type** to
   `Non-production`.
4. Hit the enterprise customer API and confirm `show_non_production_banner` is
   `true` for that customer and `false` for customers with any other type.
5. Regression check: existing enterprise customers keep their current customer
   type and report `show_non_production_banner: false`.

JIRA: [ENT-12015](https://2u-internal.atlassian.net/browse/ENT-12015)