### PR TITLE
feat: enable intergrated channel pipeline - sync_tpa_budget_group

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -1035,6 +1035,7 @@ def insert_enterprise_pipeline_elements(pipeline):
     """
     additional_elements = (
         'enterprise.tpa_pipeline.handle_enterprise_logistration',
+        'channel_integrations.integrated_channel.pipeline.sync_tpa_budget_group',
     )
 
     insert_point = pipeline.index('social_core.pipeline.social_auth.load_extra_data')

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -1088,6 +1088,7 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         assert pipeline == \
                [
                    'abc', 'enterprise.tpa_pipeline.handle_enterprise_logistration',
+                   'channel_integrations.integrated_channel.pipeline.sync_tpa_budget_group',
                    'social_core.pipeline.social_auth.load_extra_data', 'def'
                ]
 


### PR DESCRIPTION
## Description

Wires a new login-time step into the SSO pipeline: `channel_integrations.integrated_channel.pipeline.sync_tpa_budget_group`, appended to the `additional_elements` tuple in `insert_enterprise_pipeline_elements` (`openedx/features/enterprise_support/api.py`), right after `enterprise.tpa_pipeline.handle_enterprise_logistration`.

This is Stage 3 of a staged rollout for ENT-12084 (Learner Credit Subsidies: restrict Skillsoft learners to the budget matching the org they logged in under). The function itself lives in `enterprise-integrated-channels` (PR openedx/enterprise-integrated-channels#190) and, once wired in here, checks a waffle switch (`enable_tpa_org_group_login_sync`, default **off**) before doing anything - so merging and deploying this PR causes **no behavior change** for any customer on its own. Its only purpose is to prove the new pipeline entry resolves and imports cleanly on every SSO login. See that repo's `docs/how-tos/onboard_skillsoft_org_budget.rst` for the full mechanism.

Affected user role: none directly (Operator-only, behind a flag that stays off until a later, separate rollout stage).

## Supporting information

- ENT-12084 (Jira)
- openedx/enterprise-integrated-channels#190 - adds `pipeline.sync_tpa_budget_group` and the waffle switch this PR references

## Testing instructions

1. Deploy to staging with the switch left off (default).
2. Log in via any configured SSO/SAML identity provider.
3. Confirm login succeeds and no import/attribute errors appear in LMS logs referencing `sync_tpa_budget_group` or `enterprise_support`.
4. Confirm behavior is unchanged for the logged-in learner (no new group membership, no visible difference) - this step is expected to be a no-op with the switch off.

No canary/functional test of the actual budget-group sync is possible from this PR alone; that requires the switch to be enabled and at least one org mapped, which happens in a later rollout stage.

## Deadline

None.

## Other information

- **Blocking dependency, must land first:** `enterprise-integrated-channels` must be pinned to `>=0.1.67` (published from openedx/enterprise-integrated-channels#190) before this PR is deployed. As of this branch, `requirements/edx/base.txt` still pins `enterprise-integrated-channels==0.1.18`, which does not contain `channel_integrations.integrated_channel.pipeline`. **Deploying this change ahead of that pin bump would make the dotted-path pipeline entry unresolvable at Django startup, breaking SSO login for every customer, not just Skillsoft.** The pin bump should land and be verified as its own prior PR/deploy (`make upgrade-package package=enterprise-integrated-channels`) before this one merges.
- No database migration.
- Safe to revert independently: removing this one line from `additional_elements` fully reverts the change.
