### PR TITLE
fix: skip header row in retire_user CSV

### DIFF
--- a/openedx/core/djangoapps/user_api/management/commands/retire_user.py
+++ b/openedx/core/djangoapps/user_api/management/commands/retire_user.py
@@ -70,6 +70,8 @@ class Command(BaseCommand):
             userdata = record.split(',')
             username = userdata[0].strip()
             user_email = userdata[1].strip()
+            if username.lower() == 'username' and user_email.lower() in ('email', 'user_email'):
+                continue
             try:
                 users.append(User.objects.get(username=username, email=user_email))
             except user_model.DoesNotExist:

--- a/openedx/core/djangoapps/user_api/management/tests/test_retire_user.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_retire_user.py
@@ -96,6 +96,30 @@ def test_successful_retire_with_userfile(setup_retirement_states):  # lint-amnes
 
 
 @skip_unless_lms
+def test_successful_retire_with_userfile_header(
+    setup_retirement_states
+):  # lint-amnesty, pylint: disable=redefined-outer-name, unused-argument
+    user = UserFactory.create(username='header-user', email="header-user@example.com")
+    username = user.username
+    user_email = user.email
+    with open(user_file, 'w', newline='') as file:
+        write = csv.writer(file)
+        write.writerow(['username', 'email'])
+        write.writerow([username, user_email])
+
+    try:
+        call_command('retire_user', user_file=user_file)
+        user = User.objects.get(username=username)
+        retired_user_status = UserRetirementStatus.objects.all()[0]
+        assert retired_user_status.original_username == username
+        assert retired_user_status.original_email == user_email
+        # Make sure that we have changed the email address linked to the original user
+        assert user.email != user_email
+    finally:
+        remove_user_file()
+
+
+@skip_unless_lms
 def test_retire_user_with_usename_email_mismatch(setup_retirement_states):  # lint-amnesty, pylint: disable=redefined-outer-name, unused-argument
     create_user_file(True)
     with pytest.raises(CommandError, match=r'Could not find users with specified username and email '):


### PR DESCRIPTION
## Description

Updates the `retire_user` management command to skip a CSV header row when the first two columns are `username,email` or `username,user_email`.

This fixes a Stage `retire_users_from_csv` failure where the command treated the header row as a real user and failed with:

`Could not find users with specified username and email address: [{'username': 'email'}]`

Impact: Operators running the retirement management command with a CSV file can now use a CSV that includes a standard header row. No learner-facing UI impact.

## Supporting information

Private Jira: BOMS-717

## Testing instructions

1. Create a CSV with a header row and one valid user:

   ```csv
   username,email
   <username>,<email>
   ```

2. Run:

   ```bash
   python manage.py lms retire_user --user_file <path-to-file>
   ```

3. Confirm the command skips the header row and processes the real user.

Automated coverage added:

- Added a regression test for `retire_user --user_file` with a `username,email` header row.

Local verification:

- Ran `python -m py_compile` on the touched command and test files.
- Targeted pytest could not run locally because this environment is missing `kombu` during `conftest.py` import.

## Deadline

None

## Other information

This does not include the `edx-internal` cleanup that will eventually re-enable notifications. That can happen after this fix is deployed to Stage and the `retire_users_from_csv` job is confirmed passing.

No migrations, UI changes, or accessibility concerns.
