### PR TITLE
feat: replace static Zendesk OAuth access token with Client Credentials grant

### DIFF
--- a/cms/envs/mock.yml
+++ b/cms/envs/mock.yml
@@ -817,7 +817,8 @@ ZENDESK_CUSTOM_FIELDS:
   referrer: 0
 ZENDESK_GROUP_ID_MAPPING:
   Financial Assistance: fin_assistance
-ZENDESK_OAUTH_ACCESS_TOKEN: test_zendesk_access
+ZENDESK_OAUTH_CLIENT_ID: test_zendesk_client_id
+ZENDESK_OAUTH_CLIENT_SECRET: test_zendesk_client_secret
 ZENDESK_URL: https://zendesk.com
 ZENDESK_USER: daemon@example.com
 

--- a/lms/envs/mock.yml
+++ b/lms/envs/mock.yml
@@ -1246,7 +1246,8 @@ ZENDESK_CUSTOM_FIELDS:
   referrer: 5
 ZENDESK_GROUP_ID_MAPPING:
   Financial Assistance: '9999999999'
-ZENDESK_OAUTH_ACCESS_TOKEN: test_zendesk_oauth
+ZENDESK_OAUTH_CLIENT_ID: test_zendesk_client_id
+ZENDESK_OAUTH_CLIENT_SECRET: test_zendesk_client_secret
 ZENDESK_URL: https://12345.zendesk.com
 ZENDESK_USER: daemon@example.com
 

--- a/openedx/core/djangoapps/zendesk_proxy/settings/common.py
+++ b/openedx/core/djangoapps/zendesk_proxy/settings/common.py
@@ -2,5 +2,9 @@
 
 
 def plugin_settings(settings):
+    """Add default Zendesk OAuth client-credentials settings."""
     settings.ZENDESK_URL = None
-    settings.ZENDESK_OAUTH_ACCESS_TOKEN = None
+    settings.ZENDESK_OAUTH_CLIENT_ID = None
+    settings.ZENDESK_OAUTH_CLIENT_SECRET = None
+    settings.ZENDESK_OAUTH_SCOPE = 'tickets:write'
+    settings.ZENDESK_OAUTH_TOKEN_EXPIRES_IN = 86400

--- a/openedx/core/djangoapps/zendesk_proxy/settings/production.py
+++ b/openedx/core/djangoapps/zendesk_proxy/settings/production.py
@@ -2,5 +2,11 @@
 
 
 def plugin_settings(settings):
+    """Override Zendesk OAuth settings from ENV_TOKENS and AUTH_TOKENS."""
     settings.ZENDESK_URL = settings.ENV_TOKENS.get('ZENDESK_URL', settings.ZENDESK_URL)
-    settings.ZENDESK_OAUTH_ACCESS_TOKEN = settings.AUTH_TOKENS.get("ZENDESK_OAUTH_ACCESS_TOKEN")
+    settings.ZENDESK_OAUTH_CLIENT_ID = settings.AUTH_TOKENS.get('ZENDESK_OAUTH_CLIENT_ID')
+    settings.ZENDESK_OAUTH_CLIENT_SECRET = settings.AUTH_TOKENS.get('ZENDESK_OAUTH_CLIENT_SECRET')
+    settings.ZENDESK_OAUTH_SCOPE = settings.ENV_TOKENS.get('ZENDESK_OAUTH_SCOPE', settings.ZENDESK_OAUTH_SCOPE)
+    settings.ZENDESK_OAUTH_TOKEN_EXPIRES_IN = settings.ENV_TOKENS.get(
+        'ZENDESK_OAUTH_TOKEN_EXPIRES_IN', settings.ZENDESK_OAUTH_TOKEN_EXPIRES_IN
+    )

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_utils.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_utils.py
@@ -70,6 +70,7 @@ def _post_side_effect(token_response, ticket_response):
     ZENDESK_OAUTH_SCOPE="tickets:write",
     ZENDESK_OAUTH_TOKEN_EXPIRES_IN=3600,
     ZENDESK_GROUP_ID_MAPPING={"Financial Assistance": 123},
+    CACHES=LOCMEM_CACHES,
 )
 class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
     def setUp(self):
@@ -402,6 +403,7 @@ class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-doc
     ZENDESK_OAUTH_CLIENT_SECRET="test_client_secret",
     ZENDESK_OAUTH_SCOPE="tickets:write",
     ZENDESK_OAUTH_TOKEN_EXPIRES_IN=3600,
+    CACHES=LOCMEM_CACHES,
 )
 class TestPostAdditionalInfoAsComment(ApiTestCase):
     """Tests for `post_additional_info_as_comment` in isolation."""

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_utils.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_utils.py
@@ -7,17 +7,68 @@ import json
 from collections import OrderedDict
 
 from unittest.mock import MagicMock, patch
+from django.core.cache import cache
 from django.test.utils import override_settings
 
 import ddt
-from openedx.core.djangoapps.zendesk_proxy.utils import create_zendesk_ticket
+from openedx.core.djangoapps.zendesk_proxy.utils import (
+    ZENDESK_OAUTH_ACCESS_TOKEN_CACHE_KEY,
+    create_zendesk_ticket,
+    post_additional_info_as_comment,
+)
 from openedx.core.lib.api.test_utils import ApiTestCase
+
+ZENDESK_URL = "https://www.superrealurlsthataredefinitelynotfake.com"
+TOKEN_URL = ZENDESK_URL + "/oauth/tokens"
+TICKET_URL = ZENDESK_URL + "/api/v2/tickets.json"
+
+LOCMEM_CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'zendesk_proxy_test',
+    }
+}
+
+
+def _mock_response(status_code, json_data=None, raise_on_json=False):
+    """Build a MagicMock standing in for a `requests` response."""
+    response = MagicMock(status_code=status_code)
+    if raise_on_json:
+        response.json.side_effect = ValueError("not json")
+    else:
+        response.json.return_value = json_data if json_data is not None else {}
+    response.content = json.dumps(json_data).encode('utf-8') if json_data is not None else b''
+    return response
+
+
+def _mock_token_response(access_token='test_access_token', expires_in=3600, status_code=200):
+    return _mock_response(status_code, {
+        'access_token': access_token,
+        'token_type': 'bearer',
+        'expires_in': expires_in,
+        'scope': 'tickets:write',
+    })
+
+
+def _post_side_effect(token_response, ticket_response):
+    """
+    Return a side_effect function for `requests.post` that routes to the
+    token response or ticket response based on the requested URL.
+    """
+    def _side_effect(url, data=None, headers=None):  # pylint: disable=unused-argument
+        if url == TOKEN_URL:
+            return token_response
+        return ticket_response
+    return _side_effect
 
 
 @ddt.ddt
 @override_settings(
-    ZENDESK_URL="https://www.superrealurlsthataredefinitelynotfake.com",
-    ZENDESK_OAUTH_ACCESS_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890",
+    ZENDESK_URL=ZENDESK_URL,
+    ZENDESK_OAUTH_CLIENT_ID="test_client_id",
+    ZENDESK_OAUTH_CLIENT_SECRET="test_client_secret",
+    ZENDESK_OAUTH_SCOPE="tickets:write",
+    ZENDESK_OAUTH_TOKEN_EXPIRES_IN=3600,
     ZENDESK_GROUP_ID_MAPPING={"Financial Assistance": 123},
 )
 class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
@@ -28,60 +79,172 @@ class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-doc
             'subject': 'Python Unit Test Help Request',
             'body': "Help! I'm trapped in a unit test factory and I can't get out!",
         }
+        cache.clear()
         return super().setUp()
 
-    @override_settings(
-        ZENDESK_URL=None,
-        ZENDESK_OAUTH_ACCESS_TOKEN=None
-    )
-    def test_missing_settings(self):
-        status_code = create_zendesk_ticket(
+    def _create_ticket(self, **kwargs):
+        """Create a ticket from the test request data, with optional overrides."""
+        params = dict(
             requester_name=self.request_data['name'],
             requester_email=self.request_data['email'],
             subject=self.request_data['subject'],
             body=self.request_data['body'],
         )
+        params.update(kwargs)
+        return create_zendesk_ticket(**params)
 
+    # -- Configuration --
+
+    @ddt.data(
+        {'ZENDESK_URL': None},
+        {'ZENDESK_OAUTH_CLIENT_ID': None},
+        {'ZENDESK_OAUTH_CLIENT_SECRET': None},
+    )
+    def test_missing_settings(self, overridden_settings):
+        with override_settings(**overridden_settings):
+            status_code = self._create_ticket()
         assert status_code == 503
 
-    @ddt.data(201, 400, 401, 403, 404, 500)
-    def test_zendesk_status_codes(self, mock_code):
-        with patch('requests.post', return_value=MagicMock(status_code=mock_code)):
-            status_code = create_zendesk_ticket(
-                requester_name=self.request_data['name'],
-                requester_email=self.request_data['email'],
-                subject=self.request_data['subject'],
-                body=self.request_data['body'],
-            )
+    # -- Basic ticket creation status codes --
 
-            assert status_code == mock_code
+    @ddt.data(201, 400, 403, 404, 500)
+    def test_zendesk_status_codes(self, mock_code):
+        token_response = _mock_token_response()
+        ticket_response = _mock_response(mock_code)
+        with patch('requests.post', side_effect=_post_side_effect(token_response, ticket_response)):
+            status_code = self._create_ticket()
+        assert status_code == mock_code
+
+    def test_401_without_invalid_token_error_does_not_retry(self):
+        """A 401 that isn't 'invalid_token' should not trigger token regeneration."""
+        token_response = _mock_token_response()
+        ticket_response = _mock_response(401, {'error': 'not_authorized'})
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+        assert status_code == 401
+        assert mock_post.call_count == 2  # one token request, one ticket request
 
     def test_unexpected_error_pinging_zendesk(self):
         with patch('requests.post', side_effect=Exception("WHAMMY")):
-            status_code = create_zendesk_ticket(
-                requester_name=self.request_data['name'],
-                requester_email=self.request_data['email'],
-                subject=self.request_data['subject'],
-                body=self.request_data['body'],
-            )
-            assert status_code == 500
+            status_code = self._create_ticket()
+        assert status_code == 500
+
+    # -- OAuth token generation --
+
+    def test_token_request_payload(self):
+        token_response = _mock_token_response(access_token='shiny-token')
+        ticket_response = _mock_response(201)
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+
+        assert status_code == 201
+        token_call = next(call for call in mock_post.call_args_list if call.args[0] == TOKEN_URL)
+        sent_payload = json.loads(token_call.kwargs['data'])
+        assert sent_payload == {
+            'grant_type': 'client_credentials',
+            'client_id': 'test_client_id',
+            'client_secret': 'test_client_secret',
+            'scope': 'tickets:write',
+            'expires_in': 3600,
+        }
+
+        ticket_call = next(call for call in mock_post.call_args_list if call.args[0] == TICKET_URL)
+        assert ticket_call.kwargs['headers']['Authorization'] == 'Bearer shiny-token'
+
+    # -- Token caching --
+
+    @override_settings(CACHES=LOCMEM_CACHES)
+    def test_token_is_cached_and_reused(self):
+        token_response = _mock_token_response()
+        ticket_response = _mock_response(201)
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            self._create_ticket()
+            self._create_ticket()
+
+        token_calls = [call for call in mock_post.call_args_list if call.args[0] == TOKEN_URL]
+        ticket_calls = [call for call in mock_post.call_args_list if call.args[0] == TICKET_URL]
+        assert len(token_calls) == 1
+        assert len(ticket_calls) == 2
+
+    def test_token_cache_ttl_uses_expiry_buffer(self):
+        token_response = _mock_token_response(expires_in=120)
+        ticket_response = _mock_response(201)
+        with patch('requests.post', side_effect=_post_side_effect(token_response, ticket_response)):
+            with patch('openedx.core.djangoapps.zendesk_proxy.utils.cache') as mock_cache:
+                mock_cache.get.return_value = None
+                self._create_ticket()
+
+        mock_cache.set.assert_called_once_with(
+            ZENDESK_OAUTH_ACCESS_TOKEN_CACHE_KEY, 'test_access_token', 60
+        )
+
+    # -- Missing/malformed token response --
+
+    def test_token_response_missing_access_token(self):
+        token_response = _mock_token_response()
+        token_response.json.return_value = {'token_type': 'bearer'}
+        ticket_response = _mock_response(201)
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+
+        assert status_code == 503
+        ticket_calls = [call for call in mock_post.call_args_list if call.args[0] == TICKET_URL]
+        assert not ticket_calls
+
+    def test_token_response_malformed_non_json(self):
+        token_response = _mock_response(200, raise_on_json=True)
+        ticket_response = _mock_response(201)
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+
+        assert status_code == 503
+        ticket_calls = [call for call in mock_post.call_args_list if call.args[0] == TICKET_URL]
+        assert not ticket_calls
+
+    @ddt.data(
+        {'access_token': 'test_access_token', 'expires_in': 3600, 'scope': 'tickets:write'},
+        {'access_token': 'test_access_token', 'token_type': 'bearer', 'scope': 'tickets:write'},
+        {'access_token': 'test_access_token', 'token_type': 'bearer', 'expires_in': 3600},
+        {'access_token': 'test_access_token', 'token_type': 'mac', 'expires_in': 3600, 'scope': 'tickets:write'},
+        {'access_token': 'test_access_token', 'token_type': 'bearer', 'expires_in': 0, 'scope': 'tickets:write'},
+    )
+    def test_token_response_invalid_expected_fields(self, token_data):
+        token_response = _mock_response(200, token_data)
+        ticket_response = _mock_response(201)
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+
+        assert status_code == 503
+        ticket_calls = [call for call in mock_post.call_args_list if call.args[0] == TICKET_URL]
+        assert not ticket_calls
+
+    # -- Financial Assistance / additional info flow --
 
     def test_financial_assistant_ticket(self):
-        """ Test Financial Assistent request ticket. """
+        """ Test Financial Assistance request ticket. """
         ticket_creation_response_data = {
             "ticket": {
                 "id": 35436,
                 "subject": "My printer is on fire!",
             }
         }
-        response_text = json.dumps(ticket_creation_response_data)
-        with patch('requests.post', return_value=MagicMock(status_code=200, text=response_text)):
-            with patch('requests.put', return_value=MagicMock(status_code=200)):
-                status_code = create_zendesk_ticket(
-                    requester_name=self.request_data['name'],
-                    requester_email=self.request_data['email'],
-                    subject=self.request_data['subject'],
-                    body=self.request_data['body'],
+        token_response = _mock_token_response(access_token='fa-token')
+        ticket_response = _mock_response(201, ticket_creation_response_data)
+        with patch('requests.post', side_effect=_post_side_effect(token_response, ticket_response)):
+            with patch('requests.put', return_value=MagicMock(status_code=200)) as mock_put:
+                status_code = self._create_ticket(
                     group='Financial Assistance',
                     additional_info=OrderedDict(
                         (
@@ -92,4 +255,143 @@ class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-doc
                         )
                     ),
                 )
-                assert status_code == 200
+        assert status_code == 200
+        (put_args, put_kwargs) = mock_put.call_args
+        assert put_args == (f'{ZENDESK_URL}/api/v2/tickets/35436.json',)
+        assert put_kwargs['headers']['Authorization'] == 'Bearer fa-token'
+
+    def test_additional_info_not_posted_when_ticket_creation_fails(self):
+        token_response = _mock_token_response()
+        ticket_response = _mock_response(400)
+        with patch('requests.post', side_effect=_post_side_effect(token_response, ticket_response)):
+            with patch('requests.put') as mock_put:
+                status_code = self._create_ticket(additional_info={'Username': 'test'})
+
+        assert status_code == 400
+        mock_put.assert_not_called()
+
+    # -- 401 invalid_token retry behavior --
+
+    def test_401_invalid_token_triggers_single_retry_and_succeeds(self):
+        first_token_response = _mock_token_response(access_token='expired-token')
+        second_token_response = _mock_token_response(access_token='fresh-token')
+        unauthorized_response = _mock_response(401, {'error': 'invalid_token'})
+        success_response = _mock_response(201)
+
+        token_responses = iter([first_token_response, second_token_response])
+        ticket_responses = iter([unauthorized_response, success_response])
+
+        def _side_effect(url, data=None, headers=None):  # pylint: disable=unused-argument
+            if url == TOKEN_URL:
+                return next(token_responses)
+            return next(ticket_responses)
+
+        with patch('requests.post', side_effect=_side_effect) as mock_post:
+            status_code = self._create_ticket()
+
+        assert status_code == 201
+        token_calls = [call for call in mock_post.call_args_list if call.args[0] == TOKEN_URL]
+        ticket_calls = [call for call in mock_post.call_args_list if call.args[0] == TICKET_URL]
+        assert len(token_calls) == 2
+        assert len(ticket_calls) == 2
+        assert ticket_calls[0].kwargs['headers']['Authorization'] == 'Bearer expired-token'
+        assert ticket_calls[1].kwargs['headers']['Authorization'] == 'Bearer fresh-token'
+
+    def test_401_invalid_token_retry_failure_does_not_retry_again(self):
+        token_response = _mock_token_response()
+        unauthorized_response = _mock_response(401, {'error': 'invalid_token'})
+
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, unauthorized_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+
+        assert status_code == 401
+        token_calls = [call for call in mock_post.call_args_list if call.args[0] == TOKEN_URL]
+        ticket_calls = [call for call in mock_post.call_args_list if call.args[0] == TICKET_URL]
+        assert len(token_calls) == 2
+        assert len(ticket_calls) == 2
+
+    @ddt.data(403, 404, 422, 500)
+    def test_non_auth_errors_do_not_regenerate_token(self, error_code):
+        token_response = _mock_token_response()
+        ticket_response = _mock_response(error_code)
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+
+        assert status_code == error_code
+        token_calls = [call for call in mock_post.call_args_list if call.args[0] == TOKEN_URL]
+        ticket_calls = [call for call in mock_post.call_args_list if call.args[0] == TICKET_URL]
+        assert len(token_calls) == 1
+        assert len(ticket_calls) == 1
+
+    # -- Token endpoint failures --
+
+    @ddt.data(400, 401, 500)
+    def test_token_endpoint_error_status_fails_cleanly(self, token_status_code):
+        token_response = _mock_response(token_status_code, {
+            'access_token': 'should-not-be-used',
+            'token_type': 'bearer',
+            'expires_in': 3600,
+            'scope': 'tickets:write',
+        })
+        ticket_response = _mock_response(201)
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+
+        assert status_code == 503
+        ticket_calls = [call for call in mock_post.call_args_list if call.args[0] == TICKET_URL]
+        assert not ticket_calls
+
+    def test_token_endpoint_network_failure_fails_cleanly(self):
+        import requests as requests_module
+
+        def _side_effect(url, data=None, headers=None):  # pylint: disable=unused-argument
+            if url == TOKEN_URL:
+                raise requests_module.exceptions.Timeout("timed out")
+            raise AssertionError("ticket endpoint should not be called")
+
+        with patch('requests.post', side_effect=_side_effect):
+            status_code = self._create_ticket()
+
+        assert status_code == 503
+
+    # -- Security: secrets must never be logged --
+
+    def test_client_secret_not_logged_on_token_failure(self):
+        token_response = _mock_response(400, {'error': 'invalid_client'})
+        ticket_response = _mock_response(201)
+        with patch('requests.post', side_effect=_post_side_effect(token_response, ticket_response)):
+            with self.assertLogs('openedx.core.djangoapps.zendesk_proxy.utils', level='ERROR') as log_context:
+                self._create_ticket()
+
+        logged_output = '\n'.join(log_context.output)
+        assert 'test_client_secret' not in logged_output
+
+
+@override_settings(
+    ZENDESK_URL=ZENDESK_URL,
+    ZENDESK_OAUTH_CLIENT_ID="test_client_id",
+    ZENDESK_OAUTH_CLIENT_SECRET="test_client_secret",
+    ZENDESK_OAUTH_SCOPE="tickets:write",
+    ZENDESK_OAUTH_TOKEN_EXPIRES_IN=3600,
+)
+class TestPostAdditionalInfoAsComment(ApiTestCase):
+    """Tests for `post_additional_info_as_comment` in isolation."""
+
+    def setUp(self):
+        cache.clear()
+        return super().setUp()
+
+    def test_uses_oauth_token(self):
+        token_response = _mock_token_response(access_token='comment-token')
+        with patch('requests.post', return_value=token_response):
+            with patch('requests.put', return_value=MagicMock(status_code=200)) as mock_put:
+                status_code = post_additional_info_as_comment(35436, {'Username': 'test'})
+
+        assert status_code == 200
+        assert mock_put.call_args.kwargs['headers']['Authorization'] == 'Bearer comment-token'

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_utils.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_utils.py
@@ -126,6 +126,29 @@ class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-doc
         assert status_code == 401
         assert mock_post.call_count == 2  # one token request, one ticket request
 
+    def test_401_with_non_json_body_does_not_retry(self):
+        """A 401 with a non-JSON body can't be positively identified as invalid_token, so no retry."""
+        token_response = _mock_token_response()
+        ticket_response = _mock_response(401, raise_on_json=True)
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+        assert status_code == 401
+        assert mock_post.call_count == 2  # one token request, one ticket request
+
+    def test_401_with_non_dict_json_body_does_not_retry(self):
+        """A 401 with a non-dict JSON body (e.g. a list) must not raise and must not retry."""
+        token_response = _mock_token_response()
+        ticket_response = _mock_response(401)
+        ticket_response.json.return_value = ['unexpected', 'array']
+        with patch(
+            'requests.post', side_effect=_post_side_effect(token_response, ticket_response)
+        ) as mock_post:
+            status_code = self._create_ticket()
+        assert status_code == 401
+        assert mock_post.call_count == 2  # one token request, one ticket request
+
     def test_unexpected_error_pinging_zendesk(self):
         with patch('requests.post', side_effect=Exception("WHAMMY")):
             status_code = self._create_ticket()

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
@@ -12,11 +12,31 @@ from django.test.utils import override_settings
 from openedx.core.djangoapps.zendesk_proxy.v0.views import ZENDESK_REQUESTS_PER_HOUR
 from openedx.core.lib.api.test_utils import ApiTestCase
 
+ZENDESK_URL = "https://www.superrealurlsthataredefinitelynotfake.com"
+TOKEN_URL = ZENDESK_URL + "/oauth/tokens"
+TICKET_URL = ZENDESK_URL + "/api/v2/tickets.json"
+ACCESS_TOKEN = "abcdefghijklmnopqrstuvwxyz1234567890"
+
+
+def _post_side_effect(ticket_response):
+    """Route requests.post to a fake OAuth token response, or the given ticket response."""
+    def _side_effect(url, data=None, headers=None):  # pylint: disable=unused-argument
+        if url == TOKEN_URL:
+            token_response = MagicMock(status_code=200)
+            token_response.json.return_value = {
+                'access_token': ACCESS_TOKEN, 'token_type': 'bearer',
+                'expires_in': 3600, 'scope': 'tickets:write',
+            }
+            return token_response
+        return ticket_response
+    return _side_effect
+
 
 @ddt.ddt
 @override_settings(
-    ZENDESK_URL="https://www.superrealurlsthataredefinitelynotfake.com",
-    ZENDESK_OAUTH_ACCESS_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890"
+    ZENDESK_URL=ZENDESK_URL,
+    ZENDESK_OAUTH_CLIENT_ID="test_client_id",
+    ZENDESK_OAUTH_CLIENT_SECRET="test_client_secret",
 )
 class ZendeskProxyTestCase(ApiTestCase):
     """Tests for zendesk_proxy views."""
@@ -35,7 +55,7 @@ class ZendeskProxyTestCase(ApiTestCase):
         return super().setUp()
 
     def test_post(self):
-        with patch('requests.post', return_value=MagicMock(status_code=201)) as mock_post:
+        with patch('requests.post', side_effect=_post_side_effect(MagicMock(status_code=201))) as mock_post:
             response = self.request_without_auth(
                 'post',
                 self.url,
@@ -44,10 +64,10 @@ class ZendeskProxyTestCase(ApiTestCase):
             )
             self.assertHttpCreated(response)
             (mock_args, mock_kwargs) = mock_post.call_args
-            assert mock_args == ('https://www.superrealurlsthataredefinitelynotfake.com/api/v2/tickets.json',)
+            assert mock_args == (TICKET_URL,)
             self.assertCountEqual(mock_kwargs.keys(), ['headers', 'data'])
             assert mock_kwargs['headers'] == {
-                'content-type': 'application/json', 'Authorization': 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
+                'content-type': 'application/json', 'Authorization': f'Bearer {ACCESS_TOKEN}'
             }
             assert json.loads(mock_kwargs['data']) == {
                 'ticket':

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
@@ -6,6 +6,7 @@ import json
 
 from unittest.mock import MagicMock, patch
 import ddt
+from django.core.cache import cache
 from django.urls import reverse
 from django.test.utils import override_settings
 
@@ -37,6 +38,12 @@ def _post_side_effect(ticket_response):
     ZENDESK_URL=ZENDESK_URL,
     ZENDESK_OAUTH_CLIENT_ID="test_client_id",
     ZENDESK_OAUTH_CLIENT_SECRET="test_client_secret",
+    CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'zendesk_proxy',
+        }
+    }
 )
 class ZendeskProxyTestCase(ApiTestCase):
     """Tests for zendesk_proxy views."""
@@ -52,6 +59,7 @@ class ZendeskProxyTestCase(ApiTestCase):
                 'message': "Help! I'm trapped in a unit test factory and I can't get out!",
             }
         }
+        cache.clear()
         return super().setUp()
 
     def test_post(self):
@@ -63,7 +71,8 @@ class ZendeskProxyTestCase(ApiTestCase):
                 content_type='application/json'
             )
             self.assertHttpCreated(response)
-            (mock_args, mock_kwargs) = mock_post.call_args
+            ticket_call = next(call for call in mock_post.call_args_list if call.args[0] == TICKET_URL)
+            (mock_args, mock_kwargs) = ticket_call
             assert mock_args == (TICKET_URL,)
             self.assertCountEqual(mock_kwargs.keys(), ['headers', 'data'])
             assert mock_kwargs['headers'] == {

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import ddt
+from django.core.cache import cache
 from django.urls import reverse
 from django.test.utils import override_settings
 
@@ -38,6 +39,12 @@ def _post_side_effect(ticket_response):
     ZENDESK_URL=ZENDESK_URL,
     ZENDESK_OAUTH_CLIENT_ID="test_client_id",
     ZENDESK_OAUTH_CLIENT_SECRET="test_client_secret",
+    CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'zendesk_proxy',
+        }
+    }
 )
 class ZendeskProxyTestCase(ApiTestCase):
     """Tests for zendesk_proxy views."""
@@ -67,6 +74,7 @@ class ZendeskProxyTestCase(ApiTestCase):
                 }
             ],
         }
+        cache.clear()
         return super().setUp()
 
     @ddt.data(
@@ -87,7 +95,8 @@ class ZendeskProxyTestCase(ApiTestCase):
                 content_type='application/json'
             )
             self.assertHttpCreated(response)
-            (mock_args, mock_kwargs) = mock_post.call_args
+            ticket_call = next(call for call in mock_post.call_args_list if call.args[0] == TICKET_URL)
+            (mock_args, mock_kwargs) = ticket_call
             assert mock_args == (TICKET_URL,)
             self.assertCountEqual(mock_kwargs.keys(), ['headers', 'data'])
             assert mock_kwargs['headers'] == {

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
@@ -13,11 +13,31 @@ from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.zendesk_proxy.v1.views import ZendeskProxyThrottle
 from openedx.core.lib.api.test_utils import ApiTestCase
 
+ZENDESK_URL = "https://www.superrealurlsthataredefinitelynotfake.com"
+TOKEN_URL = ZENDESK_URL + "/oauth/tokens"
+TICKET_URL = ZENDESK_URL + "/api/v2/tickets.json"
+ACCESS_TOKEN = "abcdefghijklmnopqrstuvwxyz1234567890"
+
+
+def _post_side_effect(ticket_response):
+    """Route requests.post to a fake OAuth token response, or the given ticket response."""
+    def _side_effect(url, data=None, headers=None):  # pylint: disable=unused-argument
+        if url == TOKEN_URL:
+            token_response = MagicMock(status_code=200)
+            token_response.json.return_value = {
+                'access_token': ACCESS_TOKEN, 'token_type': 'bearer',
+                'expires_in': 3600, 'scope': 'tickets:write',
+            }
+            return token_response
+        return ticket_response
+    return _side_effect
+
 
 @ddt.ddt
 @override_settings(
-    ZENDESK_URL="https://www.superrealurlsthataredefinitelynotfake.com",
-    ZENDESK_OAUTH_ACCESS_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890"
+    ZENDESK_URL=ZENDESK_URL,
+    ZENDESK_OAUTH_CLIENT_ID="test_client_id",
+    ZENDESK_OAUTH_CLIENT_SECRET="test_client_secret",
 )
 class ZendeskProxyTestCase(ApiTestCase):
     """Tests for zendesk_proxy views."""
@@ -59,7 +79,7 @@ class ZendeskProxyTestCase(ApiTestCase):
         """
         self.user.is_active = user_activation_status
         self.user.save()
-        with patch('requests.post', return_value=MagicMock(status_code=201)) as mock_post:
+        with patch('requests.post', side_effect=_post_side_effect(MagicMock(status_code=201))) as mock_post:
             response = self.request_without_auth(
                 'post',
                 self.url,
@@ -68,10 +88,10 @@ class ZendeskProxyTestCase(ApiTestCase):
             )
             self.assertHttpCreated(response)
             (mock_args, mock_kwargs) = mock_post.call_args
-            assert mock_args == ('https://www.superrealurlsthataredefinitelynotfake.com/api/v2/tickets.json',)
+            assert mock_args == (TICKET_URL,)
             self.assertCountEqual(mock_kwargs.keys(), ['headers', 'data'])
             assert mock_kwargs['headers'] == {
-                'content-type': 'application/json', 'Authorization': 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
+                'content-type': 'application/json', 'Authorization': f'Bearer {ACCESS_TOKEN}'
             }
             assert json.loads(mock_kwargs['data']) == {
                 'ticket': {

--- a/openedx/core/djangoapps/zendesk_proxy/utils.py
+++ b/openedx/core/djangoapps/zendesk_proxy/utils.py
@@ -9,9 +9,19 @@ from urllib.parse import urljoin  # pylint: disable=import-error
 
 import requests
 from django.conf import settings
+from django.core.cache import cache
 from rest_framework import status
 
 log = logging.getLogger(__name__)
+
+# Cache key for the Zendesk OAuth access token obtained via the Client
+# Credentials grant. Uses Django's shared cache so the token is reusable
+# across all LMS/CMS worker processes, instead of process-local state.
+ZENDESK_OAUTH_ACCESS_TOKEN_CACHE_KEY = 'zendesk_proxy.oauth_access_token'
+
+# Safety buffer (in seconds) subtracted from the token's expires_in, so a
+# token is never used right at its expiration boundary.
+ZENDESK_OAUTH_TOKEN_EXPIRY_BUFFER = 60
 
 
 def _std_error_message(details, payload):
@@ -19,11 +29,140 @@ def _std_error_message(details, payload):
     return f'zendesk_proxy action required\n{details}\nNo ticket created for payload {payload}'
 
 
-def _get_request_headers():
+def _zendesk_configured():
+    """Return True if the settings required to authenticate with Zendesk are present."""
+    return bool(settings.ZENDESK_URL and settings.ZENDESK_OAUTH_CLIENT_ID and settings.ZENDESK_OAUTH_CLIENT_SECRET)
+
+
+def _request_zendesk_access_token():
+    """
+    Request a new OAuth access token from Zendesk using the Client Credentials
+    grant. This grant is intended for confidential/server-side clients: it
+    does not require interactive user authorization and does not return a
+    refresh token.
+
+    Note: the resulting access token acts on behalf of the Zendesk
+    administrator who owns the OAuth client, so that admin must retain
+    sufficient Zendesk access for the token to keep working. This is an
+    operational/deployment concern, not something this code can enforce.
+
+    Returns a (access_token, expires_in) tuple, or (None, None) on failure.
+    """
+    url = urljoin(settings.ZENDESK_URL, '/oauth/tokens')
+    payload = json.dumps({
+        'grant_type': 'client_credentials',
+        'client_id': settings.ZENDESK_OAUTH_CLIENT_ID,
+        'client_secret': settings.ZENDESK_OAUTH_CLIENT_SECRET,
+        'scope': settings.ZENDESK_OAUTH_SCOPE,
+        'expires_in': settings.ZENDESK_OAUTH_TOKEN_EXPIRES_IN,
+    })
+
+    try:
+        response = requests.post(url, data=payload, headers={'content-type': 'application/json'})
+    except requests.RequestException:
+        log.exception('Zendesk OAuth token request failed')
+        return None, None
+
+    if not status.HTTP_200_OK <= response.status_code < status.HTTP_300_MULTIPLE_CHOICES:
+        log.error(f'Zendesk OAuth token request failed: HTTP {response.status_code}')
+        return None, None
+
+    try:
+        token_data = response.json()
+    except ValueError:
+        log.error(f'Zendesk OAuth token request returned a malformed response: HTTP {response.status_code}')
+        return None, None
+
+    if not isinstance(token_data, dict):
+        log.error(f'Zendesk OAuth token request returned a malformed response: HTTP {response.status_code}')
+        return None, None
+
+    access_token = token_data.get('access_token')
+    if not access_token:
+        log.error(f'Zendesk OAuth token request did not return an access token: HTTP {response.status_code}')
+        return None, None
+
+    token_type = token_data.get('token_type')
+    if not isinstance(token_type, str) or token_type.lower() != 'bearer':
+        log.error(f'Zendesk OAuth token request returned an invalid token type: HTTP {response.status_code}')
+        return None, None
+
+    if not token_data.get('scope'):
+        log.error(f'Zendesk OAuth token request returned an invalid scope: HTTP {response.status_code}')
+        return None, None
+
+    expires_in = token_data.get('expires_in')
+    if not isinstance(expires_in, int) or expires_in <= 0:
+        log.error(f'Zendesk OAuth token request returned an invalid expires_in: HTTP {response.status_code}')
+        return None, None
+
+    return access_token, expires_in
+
+
+def _get_zendesk_access_token(force_refresh=False):
+    """
+    Return a Zendesk OAuth access token, fetching and caching a new one if
+    necessary, so a new token is not requested for every Zendesk API call.
+    """
+    if not force_refresh:
+        cached_token = cache.get(ZENDESK_OAUTH_ACCESS_TOKEN_CACHE_KEY)
+        if cached_token:
+            return cached_token
+
+    access_token, expires_in = _request_zendesk_access_token()
+    if not access_token:
+        return None
+
+    cache_timeout = max(expires_in - ZENDESK_OAUTH_TOKEN_EXPIRY_BUFFER, 1)
+    cache.set(ZENDESK_OAUTH_ACCESS_TOKEN_CACHE_KEY, access_token, cache_timeout)
+    return access_token
+
+
+def _invalidate_zendesk_access_token():
+    """Remove any cached Zendesk OAuth access token."""
+    cache.delete(ZENDESK_OAUTH_ACCESS_TOKEN_CACHE_KEY)
+
+
+def _get_request_headers(access_token):
     return {
         'content-type': 'application/json',
-        'Authorization': f"Bearer {settings.ZENDESK_OAUTH_ACCESS_TOKEN}",
+        'Authorization': f"Bearer {access_token}",
     }
+
+
+def _is_invalid_token_response(response):
+    """Return True if the response indicates the OAuth access token is invalid/expired."""
+    if response.status_code != status.HTTP_401_UNAUTHORIZED:
+        return False
+    try:
+        return response.json().get('error') == 'invalid_token'
+    except ValueError:
+        return True
+
+
+def _zendesk_request(method, url, payload):
+    """
+    Make an authenticated Zendesk API request. Obtains a (cached) OAuth access
+    token and retries at most once if Zendesk reports the token as
+    invalid/expired.
+
+    Returns the `requests` response, or None if no access token could be
+    obtained at all.
+    """
+    access_token = _get_zendesk_access_token()
+    if not access_token:
+        return None
+
+    response = method(url, data=payload, headers=_get_request_headers(access_token))
+
+    if _is_invalid_token_response(response):
+        log.info('Zendesk access token invalid; requesting replacement')
+        _invalidate_zendesk_access_token()
+        access_token = _get_zendesk_access_token(force_refresh=True)
+        if access_token:
+            response = method(url, data=payload, headers=_get_request_headers(access_token))
+
+    return response
 
 
 def create_zendesk_ticket(
@@ -61,7 +200,7 @@ def create_zendesk_ticket(
         }
     }
 
-    if not (settings.ZENDESK_URL and settings.ZENDESK_OAUTH_ACCESS_TOKEN):
+    if not _zendesk_configured():
         log.error(_std_error_message("zendesk not configured", data))
         return status.HTTP_503_SERVICE_UNAVAILABLE
 
@@ -81,18 +220,23 @@ def create_zendesk_ticket(
     url = urljoin(settings.ZENDESK_URL, '/api/v2/tickets.json')
 
     try:
-        response = requests.post(url, data=payload, headers=_get_request_headers())
+        response = _zendesk_request(requests.post, url, payload)
+        if response is None:
+            log.error(_std_error_message('Unable to obtain a Zendesk OAuth access token', payload))
+            return status.HTTP_503_SERVICE_UNAVAILABLE
 
         # Check for HTTP codes other than 201 (Created)
-        if response.status_code == status.HTTP_201_CREATED:
-            log.debug(f'Successfully created ticket for {requester_email}')
-        else:
+        if response.status_code != status.HTTP_201_CREATED:
             log.error(
                 _std_error_message(
                     f'Unexpected response: {response.status_code} - {response.content}',
                     payload
                 )
             )
+            return response.status_code
+
+        log.debug(f'Successfully created ticket for {requester_email}')
+
         if additional_info:
             try:
                 ticket = response.json()['ticket']
@@ -133,9 +277,14 @@ def post_additional_info_as_comment(ticket_id, additional_info):
     }
 
     url = urljoin(settings.ZENDESK_URL, f'api/v2/tickets/{ticket_id}.json')
+    payload = json.dumps(data)
 
     try:
-        response = requests.put(url, data=json.dumps(data), headers=_get_request_headers())
+        response = _zendesk_request(requests.put, url, payload)
+        if response is None:
+            log.error(_std_error_message('Unable to obtain a Zendesk OAuth access token', data))
+            return status.HTTP_503_SERVICE_UNAVAILABLE
+
         if response.status_code == 200:
             log.debug(f'Successfully created comment for ticket {ticket_id}')
         else:

--- a/openedx/core/djangoapps/zendesk_proxy/utils.py
+++ b/openedx/core/djangoapps/zendesk_proxy/utils.py
@@ -135,9 +135,10 @@ def _is_invalid_token_response(response):
     if response.status_code != status.HTTP_401_UNAUTHORIZED:
         return False
     try:
-        return response.json().get('error') == 'invalid_token'
+        data = response.json()
     except ValueError:
-        return True
+        return False
+    return isinstance(data, dict) and data.get('error') == 'invalid_token'
 
 
 def _zendesk_request(method, url, payload):
@@ -276,7 +277,7 @@ def post_additional_info_as_comment(ticket_id, additional_info):
         }
     }
 
-    url = urljoin(settings.ZENDESK_URL, f'api/v2/tickets/{ticket_id}.json')
+    url = urljoin(settings.ZENDESK_URL, f'/api/v2/tickets/{ticket_id}.json')
     payload = json.dumps(data)
 
     try:

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1815,7 +1815,10 @@ OPTIMIZELY_FULLSTACK_SDK_KEY = None
 ################################# Zendesk ##################################
 ZENDESK_URL = ''
 ZENDESK_CUSTOM_FIELDS = {}
-ZENDESK_OAUTH_ACCESS_TOKEN = ''
+ZENDESK_OAUTH_CLIENT_ID = ''
+ZENDESK_OAUTH_CLIENT_SECRET = ''
+ZENDESK_OAUTH_SCOPE = 'tickets:write'
+ZENDESK_OAUTH_TOKEN_EXPIRES_IN = 86400
 # A mapping of string names to Zendesk Group IDs
 # To get the IDs of your groups you can go to
 # {zendesk_url}/api/v2/groups.json


### PR DESCRIPTION
## Description

Replaces the Zendesk proxy's dependency on a permanently configured, manually-rotated
`ZENDESK_OAUTH_ACCESS_TOKEN` with the OAuth 2.0 Client Credentials grant, per
Zendesk's documented flow for confidential/server-side integrations
(https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/).

Access tokens are now fetched on demand from `POST {ZENDESK_URL}/oauth/tokens`,
cached in Django's shared cache (safe across all LMS/CMS worker processes), and
automatically refreshed once when Zendesk reports the cached token as invalid/expired.

## What changed

- **Token lifecycle** (`openedx/core/djangoapps/zendesk_proxy/utils.py`):
  - `_request_zendesk_access_token()` — calls Zendesk's `client_credentials` grant
    and validates the response (`access_token`, `token_type == "bearer"`, `scope`,
    positive integer `expires_in`) before trusting it.
  - `_get_zendesk_access_token(force_refresh=False)` — reads/writes the token from
    Django's cache; TTL is `expires_in` minus a 60s safety buffer.
  - `_zendesk_request(method, url, payload)` — shared authenticated-request helper
    used by both `create_zendesk_ticket()` and `post_additional_info_as_comment()`,
    so token/retry logic isn't duplicated. On `401` with `error: invalid_token`, it
    invalidates the cached token, fetches a fresh one, and retries **exactly once**.
- **Bug fix**: `create_zendesk_ticket()` now only parses `response.json()["ticket"]`
  after a genuine `201 Created` — previously it could attempt this on error responses.
- **New settings** (`settings/common.py`, `settings/production.py`, `openedx/envs/common.py`):
  `ZENDESK_OAUTH_CLIENT_ID`, `ZENDESK_OAUTH_CLIENT_SECRET`, `ZENDESK_OAUTH_SCOPE`
  (default `tickets:write`), `ZENDESK_OAUTH_TOKEN_EXPIRES_IN` (default `86400`).
  `ZENDESK_OAUTH_ACCESS_TOKEN` is removed entirely (no remaining references/usages).
- **Devstack mock configs** (`cms/envs/mock.yml`, `lms/envs/mock.yml`): updated to
  supply fake `ZENDESK_OAUTH_CLIENT_ID`/`ZENDESK_OAUTH_CLIENT_SECRET` values.
- **Tests**: rewrote `tests/test_utils.py` and updated `tests/test_v0_views.py` /
  `tests/test_v1_views.py` to mock the token endpoint and ticket endpoint separately,
  covering: missing config, token request payload, token caching, cache TTL,
  malformed/missing token fields, `401 invalid_token` single-retry (success and
  failure), non-auth errors not triggering token regeneration, token-endpoint
  failures (4xx/5xx/network), and a check that secrets never appear in logs.

## Not changed

- Public signature of `create_zendesk_ticket()` — unchanged.
- Financial Assistance / ticket creation business behavior — unchanged.
- No new database model, no refresh-token persistence, no global/process-local
  token state.

## Deployment follow-up (outside this PR)

`ZENDESK_OAUTH_CLIENT_ID` / `ZENDESK_OAUTH_CLIENT_SECRET` need to be supplied via
`AUTH_TOKENS` in production config (replacing `ZENDESK_OAUTH_ACCESS_TOKEN`), and a
Zendesk OAuth client with the `tickets:write` scope needs to be provisioned in the
Zendesk Admin Center.

## Support ticket
- [LP-1018](https://2u-internal.atlassian.net/browse/LP-1018)