### PR TITLE
feat: add 14-day audit expiry experiment variants

### DIFF
--- a/lms/djangoapps/experiments/audit_expiry_urgency.py
+++ b/lms/djangoapps/experiments/audit_expiry_urgency.py
@@ -31,7 +31,9 @@ EXPERIMENT_KEY = 'audit_expiry_urgency_v1'
 
 VARIANT_CONTROL = 'control_5_7_weeks'
 VARIANT_EXPIRY_7_DAYS = 'expiry_7_days'
-VALID_VARIANTS = {VARIANT_CONTROL, VARIANT_EXPIRY_7_DAYS}
+VARIANT_EXPIRY_14_DAYS = 'expiry_14_days'
+VARIANT_EXPIRY_21_DAYS = 'expiry_21_days'
+VALID_VARIANTS = {VARIANT_CONTROL, VARIANT_EXPIRY_7_DAYS, VARIANT_EXPIRY_14_DAYS, VARIANT_EXPIRY_21_DAYS}
 
 ATTRIBUTE_NAMESPACE = 'audit_expiry_experiment'
 ATTRIBUTE_NAME_EXPERIMENT_KEY = 'experiment_key'
@@ -204,6 +206,12 @@ def compute_audit_expiry_at(enrollment, variant, access_duration):
     if variant == VARIANT_EXPIRY_7_DAYS:
         expiry_at = content_availability_date + timedelta(days=7)
         return expiry_at, 7
+    elif variant == VARIANT_EXPIRY_14_DAYS:
+        expiry_at = content_availability_date + timedelta(days=14)
+        return expiry_at, 14
+    elif variant == VARIANT_EXPIRY_21_DAYS:
+        expiry_at = content_availability_date + timedelta(days=21)
+        return expiry_at, 21
     expiry_at = content_availability_date + access_duration
     return expiry_at, access_duration.days
 

--- a/lms/djangoapps/experiments/audit_expiry_urgency.py
+++ b/lms/djangoapps/experiments/audit_expiry_urgency.py
@@ -32,8 +32,7 @@ EXPERIMENT_KEY = 'audit_expiry_urgency_v1'
 VARIANT_CONTROL = 'control_5_7_weeks'
 VARIANT_EXPIRY_7_DAYS = 'expiry_7_days'
 VARIANT_EXPIRY_14_DAYS = 'expiry_14_days'
-VARIANT_EXPIRY_21_DAYS = 'expiry_21_days'
-VALID_VARIANTS = {VARIANT_CONTROL, VARIANT_EXPIRY_7_DAYS, VARIANT_EXPIRY_14_DAYS, VARIANT_EXPIRY_21_DAYS}
+VALID_VARIANTS = {VARIANT_CONTROL, VARIANT_EXPIRY_7_DAYS, VARIANT_EXPIRY_14_DAYS}
 
 ATTRIBUTE_NAMESPACE = 'audit_expiry_experiment'
 ATTRIBUTE_NAME_EXPERIMENT_KEY = 'experiment_key'
@@ -209,9 +208,6 @@ def compute_audit_expiry_at(enrollment, variant, access_duration):
     elif variant == VARIANT_EXPIRY_14_DAYS:
         expiry_at = content_availability_date + timedelta(days=14)
         return expiry_at, 14
-    elif variant == VARIANT_EXPIRY_21_DAYS:
-        expiry_at = content_availability_date + timedelta(days=21)
-        return expiry_at, 21
     expiry_at = content_availability_date + access_duration
     return expiry_at, access_duration.days
 


### PR DESCRIPTION
## Summary

Extend the audit expiry experiment by introducing two additional variants:
- `expiry_14_days`

This allows testing the impact of longer audit content availability periods alongside the existing 7-day variant and control group.

## Changes

### Added Experiment Variants
- Added `VARIANT_EXPIRY_14_DAYS`
- Updated `VALID_VARIANTS` to include the new variants

### Updated Expiry Calculation Logic
Enhanced `compute_audit_expiry_at()` to support:
- 7-day expiry
- 14-day expiry

The function now returns:
- Expiry timestamp based on variant configuration
- Corresponding expiry duration in days

## Example

| Variant | Expiry Calculation |
|----------|-------------------|
| control | Content availability date + access duration |
| expiry_7_days | Content availability date + 7 days |
| expiry_14_days | Content availability date + 14 days |

## Testing
- Verified new variants are accepted in `VALID_VARIANTS`
- Verified expiry dates are correctly calculated for 14-day variant
- Confirmed existing control and 7-day behavior remains unchanged

Jira: https://2u-internal.atlassian.net/browse/LP-981