### PR TITLE
fix: handle None responses in discussion comment list

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1725,15 +1725,15 @@ def get_comment_list(
     if not responses and page != 1:
         raise PageNotFoundError("Page not found (No results on this page).")
     num_pages = (resp_total + page_size - 1) // page_size if resp_total else 1
-    if not show_deleted and responses:
-        responses = [
-            response for response in responses if not response.get("is_deleted", False)
-        ]
-    else:
+    if show_deleted:
         if not context["has_moderation_privilege"]:
             raise PermissionDenied(
                 "`show_deleted` can only be set by users with moderation roles."
             )
+    elif responses:
+        responses = [
+            response for response in responses if not response.get("is_deleted", False)
+        ]
 
     # Always filter muted content for All Posts tab
     if include_muted:

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1725,8 +1725,7 @@ def get_comment_list(
     if not responses and page != 1:
         raise PageNotFoundError("Page not found (No results on this page).")
     num_pages = (resp_total + page_size - 1) // page_size if resp_total else 1
-
-    if not show_deleted:
+    if not show_deleted and responses:
         responses = [
             response for response in responses if not response.get("is_deleted", False)
         ]


### PR DESCRIPTION
## Summary

Fixes an issue in the Discussion REST API where `responses` could be `None`, causing a `TypeError`, and ensures `show_deleted` permission validation is handled correctly.

## Issue

The Discussion API was failing with:

```text
TypeError: 'NoneType' object is not iterable
```

This occurred when `responses` was `None` and the code attempted to filter deleted responses.

During testing, Student users also received:

```text
PermissionDenied: `show_deleted` can only be set by users with moderation roles.
```

## Fix

Updated the response handling logic to:

* Validate `show_deleted` permissions only when deleted responses are explicitly requested.
* Filter deleted responses only when `responses` contains data.
* Avoid iterating over `None`.

```python
if show_deleted:
    if not context["has_moderation_privilege"]:
        raise PermissionDenied(
            "`show_deleted` can only be set by users with moderation roles."
        )
elif responses:
    responses = [
        response for response in responses
        if not response.get("is_deleted", False)
    ]
```

## Testing

Ran the Discussion REST API test suite.

Result:

```text
535 passed
```

The previous 12 `PermissionDenied` failures for Student users were resolved.

The fix also prevents the original `NoneType` iteration error.
```

Jira: https://2u-internal.atlassian.net/browse/LP-1033
