### PR TITLE
feat: Upgrade Python dependency snowflake-connector-python

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -16,9 +16,32 @@
 #  this file from Github directly. It does not require packaging in edx-lint.
 
 # using LTS django version
-
+Django<6.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
+
+# 2026-07-06: Constrain social-auth-* packages to the latest version compatible with
+# edx-drf-extensions<=10.6.0. (Newer versions require a POST instead of a GET.)
+# Tracking issue: https://github.com/openedx/edx-drf-extensions/issues/561
+social-auth-app-django<6.0.0
+social-auth-core<5.0.0
+
+# 2026-08-11: pip-tools is only tested against the latest pip released at the time
+# pip-tools was released; also, pip-tools package dependencies are extremely permissive
+# about the pip version required, so the dependency resolver will not prevent an unwanted
+# pip upgrade which would break pip-tools. The end result is that pip MUST be constrained
+# by all pip-tools users in order to avoid potentially weeks-long lapses in pip <->
+# pip-tools compatibility.  We've constrained pip here in common_constraints.txt in the
+# past, but always removed it once the issue was "fixed". Removing this constraint was
+# always a mistake.
+#
+# This is a semi-permanent constraint and should be manually bumped after each pip-tools
+# release.
+#
+# Exceptional conditions for removal:
+# - We stop using pip-tools, OR
+# - We migrate to the proposed `pip-tools[stable]` extra: https://github.com/jazzband/pip-tools/pull/2257
+pip<26.2.1  # Known to work with pip-tools==7.6.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,10 +13,6 @@
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
 
-# Date: 2025-10-07
-# Stay on LTS version, remove once this is added to common constraint
-Django<6.0
-
 # Date: 2020-02-26
 # As it is not clarified what exact breaking changes will be introduced as per
 # the next major release, ensure the installed version is within boundaries.
@@ -130,9 +126,11 @@ django-debug-toolbar<6.0.0
 # Cryptography 46.0.0 conflicts with system dependencies needed for snowflake-connector-python
 # snowflake-connector-python comes as a dependency of edx-enterprise so it can not be directly pinned here.
 # See issue https://github.com/openedx/edx-platform/issues/37417 for details on this.
-# This can be unpinned once snowflake-connector-python==4.0.0 is available (contains the fix).
-# pact-python==3.0.0 also removes cffi dependency and is causing the upgrade build to fail
-# This should also be removed together with cryptography constraint.
+# Update 2026-08-24: snowflake-connector-python is now upgraded to 4.x, which dropped its cffi
+# dependency and no longer conflicts with cryptography>=46.0.0 on its own. This constraint remains
+# in place only because of the coupled pact-python issue below - pact-python==3.0.0 also removes
+# its cffi dependency and causes the upgrade build to fail, so cryptography and pact-python need to
+# be unpinned together once pact-python 3.0.0 compatibility is verified.
 # Issue: https://github.com/openedx/edx-platform/issues/37435
 cryptography<46.0.0
 pact-python<3.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -113,7 +113,6 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-    #   snowflake-connector-python
 chardet==5.2.0
     # via pysrt
 charset-normalizer==3.4.3
@@ -169,6 +168,7 @@ defusedxml==0.7.1
     #   social-auth-core
 django==5.2.7
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-appconf
@@ -1119,15 +1119,17 @@ slumber==0.7.1
     #   enterprise-integrated-channels
 sniffio==1.3.1
     # via anyio
-snowflake-connector-python==3.18.0
+snowflake-connector-python==4.3.0
     # via edx-enterprise
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
 social-auth-core==4.7.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -204,7 +204,6 @@ cffi==1.17.1
     #   cryptography
     #   pact-python
     #   pynacl
-    #   snowflake-connector-python
 chardet==5.2.0
     # via
     #   -r requirements/edx/doc.txt
@@ -333,6 +332,7 @@ distlib==0.4.0
     #   virtualenv
 django==5.2.7
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1941,19 +1941,21 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==3.18.0
+snowflake-connector-python==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
 social-auth-core==4.7.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -155,7 +155,6 @@ cffi==1.17.1
     #   -r requirements/edx/base.txt
     #   cryptography
     #   pynacl
-    #   snowflake-connector-python
 chardet==5.2.0
     # via
     #   -r requirements/edx/base.txt
@@ -227,6 +226,7 @@ defusedxml==0.7.1
     #   social-auth-core
 django==5.2.7
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
@@ -1370,17 +1370,19 @@ sniffio==1.3.1
     #   anyio
 snowballstemmer==3.0.1
     # via sphinx
-snowflake-connector-python==3.18.0
+snowflake-connector-python==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
 social-auth-core==4.7.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -154,7 +154,6 @@ cffi==1.17.1
     #   cryptography
     #   pact-python
     #   pynacl
-    #   snowflake-connector-python
 chardet==5.2.0
     # via
     #   -r requirements/edx/base.txt
@@ -253,6 +252,7 @@ distlib==0.4.0
     # via virtualenv
 django==5.2.7
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
@@ -1478,17 +1478,19 @@ sniffio==1.3.1
     # via
     #   -r requirements/edx/base.txt
     #   anyio
-snowflake-connector-python==3.18.0
+snowflake-connector-python==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
 social-auth-core==4.7.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,6 +9,8 @@ wheel==0.45.1
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.2
-    # via -r requirements/pip.in
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in
 setuptools==80.9.0
     # via -r requirements/pip.in

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -36,6 +36,7 @@ cryptography==45.0.7
     #   pyjwt
 django==5.2.7
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   django-crum
     #   django-waffle


### PR DESCRIPTION
Description

Bump snowflake-connector-python from 3.18.0 to 4.3.0.

Required to unblock upgrading enterprise-integrated-channels past 0.1.37: that package's own dependency on snowflake-connector-python moved to >=4.0.0,<5.0.0 as of its 0.1.38 release (ENT-11229), but  edx-platform's pin was never bumped to match, so make upgrade-package package=enterprise-integrated-channels could not resolve past the last version compatible with our stale 3.18.0 pin.

edx-platform has no direct usage of this package; it's pulled in transitively via edx-enterprise. The only real caller is channel_integrations.integrated_channel.snowflake_client (enterprise-integrated-channels), which uses only the stable DB-API 2.0 surface (connect/cursor/execute/fetchone/close) with plain username/password auth - reviewed the 4.0.0 changelog and none of its changes (DictCursor typing, config-file permission checks, OAuth/workload-identity auth paths, OCSP enhancements) touch that surface.

Scope note

This PR's diff also includes an automatic refresh of requirements/common_constraints.txt (adding Django<6.0, social-auth-app-django<6.0.0, social-auth-core<5.0.0, and pip<26.2.1). That file is unconditionally re-fetched fresh from edx-lint's canonical version on every make upgrade-package run in this repo, regardless of which package is targeted - it isn't something this PR intentionally changes, and it would appear identically in any other dependency bump run today. Flagging explicitly per review feedback so it doesn't read as an undisclosed scope

changes:
  - The new social-auth-app-django<6.0.0 common constraint is redundant with (and less strict than) edx-platform's existing local social-auth-app-django<=5.4.1 pin in requirements/constraints.txt - no functional change, since the stricter pin wins.
  - Also removed the now-redundant local Django<6.0 override from requirements/constraints.txt, since its own comment said to do so once it landed in common_constraints.txt (which this PR's refresh does).
  - Updated a stale comment on the cryptography<46.0.0 constraint: it referenced snowflake-connector-python 4.0.0 becoming available as the unblocking condition, which is now true. Left the actual pin (and its pact-python coupling, tracked separately in #37435) untouched - only the comment's accuracy changed.