### PR TITLE
feat: [programs API] replace enterprise dependency with plugin hook

### DIFF
--- a/openedx/core/djangoapps/programs/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/programs/rest_api/v1/tests/test_views.py
@@ -6,9 +6,9 @@ from unittest import mock
 from uuid import uuid4
 
 from django.core.cache import cache
+from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse_lazy
-from enterprise.models import EnterpriseCourseEnrollment
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import (
@@ -27,18 +27,13 @@ from openedx.core.djangoapps.catalog.tests.factories import (
     PathwayFactory,
     ProgramFactory,
 )
+from openedx.core.djangoapps.programs.rest_api.v1.views import get_enterprise_course_ids
 from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.site_configuration.tests.test_util import (
     with_site_configuration,
 )
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.features.enterprise_support.api import enterprise_is_enabled
-from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerFactory,
-    EnterpriseCustomerUserFactory,
-)
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import (
     CourseFactory as ModuleStoreCourseFactory,
@@ -144,6 +139,38 @@ class TestProgramProgressDetailView(ProgramsApiConfigMixin, SharedModuleStoreTes
         assert response.data["error_code"] == "No program data available."
 
 
+# Test target for OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS.
+_fake_get_enterprise_course_ids = mock.MagicMock(return_value=[])
+FAKE_OVERRIDE_PATH = f"{__name__}._fake_get_enterprise_course_ids"
+
+
+@skip_unless_lms
+class TestGetEnterpriseCourseIds(TestCase):
+    """Unit tests for the get_enterprise_course_ids pluggable override point."""
+
+    def test_get_enterprise_course_ids_default(self):
+        """With no plugin override configured, the base implementation returns an empty list"""
+        enterprise_uuid, user = str(uuid4()), mock.Mock()
+
+        result = get_enterprise_course_ids(enterprise_uuid=enterprise_uuid, user=user)
+
+        assert not result
+
+    @override_settings(OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS=FAKE_OVERRIDE_PATH)
+    def test_get_enterprise_course_ids_uses_plugin_override(self):
+        """When OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS is configured, it is used instead"""
+        enterprise_uuid, user = str(uuid4()), mock.Mock()
+        _fake_get_enterprise_course_ids.reset_mock()
+        _fake_get_enterprise_course_ids.return_value = ["course-v1:edX+DemoX+Demo_Course"]
+
+        result = get_enterprise_course_ids(enterprise_uuid=enterprise_uuid, user=user)
+
+        assert result == ["course-v1:edX+DemoX+Demo_Course"]
+        _fake_get_enterprise_course_ids.assert_called_once_with(
+            mock.ANY, enterprise_uuid=enterprise_uuid, user=user
+        )
+
+
 @skip_unless_lms
 class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
     """Unit tests for the program details page."""
@@ -158,17 +185,10 @@ class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
 
         cls.user = UserFactory()
         modulestore_course = ModuleStoreCourseFactory()
-        course_run = CourseRunFactory(key=str(modulestore_course.id))
+        cls.course_id = str(modulestore_course.id)
+        course_run = CourseRunFactory(key=cls.course_id)
         course = CourseFactory(course_runs=[course_run])
-        enterprise_customer = EnterpriseCustomerFactory(uuid=cls.enterprise_uuid)
-        enterprise_customer_user = EnterpriseCustomerUserFactory(
-            user_id=cls.user.id, enterprise_customer=enterprise_customer
-        )
         CourseEnrollmentFactory(is_active=True, course_id=modulestore_course.id, user=cls.user)
-        EnterpriseCourseEnrollmentFactory(
-            course_id=modulestore_course.id,
-            enterprise_customer_user=enterprise_customer_user,
-        )
 
         cls.program = ProgramFactory(
             uuid=cls.program_uuid,
@@ -193,20 +213,20 @@ class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
             program_uuid=self.program_uuid,
             external_user_key="0001",
         )
-
-    @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
-    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
-    @enterprise_is_enabled()
-    def test_program_list_enterprise(self):
-        """
-        Verify API returns proper response.
-        """
+        _fake_get_enterprise_course_ids.reset_mock()
+        _fake_get_enterprise_course_ids.return_value = [self.course_id]
         cache.set(
             SITE_PROGRAM_UUIDS_CACHE_KEY_TPL.format(domain=self.site.domain),
             [self.program_uuid],
             None,
         )
 
+    @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
+    @override_settings(OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS=FAKE_OVERRIDE_PATH)
+    def test_program_list_enterprise(self):
+        """
+        Verify API returns proper response.
+        """
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         program = response.data[0]
@@ -225,25 +245,30 @@ class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
             "all_unenrolled": False,
         }
 
+        _fake_get_enterprise_course_ids.assert_called_once_with(
+            mock.ANY, enterprise_uuid=self.enterprise_uuid, user=self.user
+        )
+
     @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
-    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
-    @enterprise_is_enabled()
+    @override_settings(OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS=FAKE_OVERRIDE_PATH)
     def test_program_empty_list_if_no_enterprise_enrollments(self):
         """
         Verify API returns empty response if no enterprise enrollments exists for a learner.
         """
-        # delete all enterprise course enrollments for the user
-        EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user__user_id=self.user.id).delete()
-
-        cache.set(
-            SITE_PROGRAM_UUIDS_CACHE_KEY_TPL.format(domain=self.site.domain),
-            [self.program_uuid],
-            None,
-        )
+        _fake_get_enterprise_course_ids.return_value = []
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [])
+
+    @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
+    def test_program_empty_list_without_override(self):
+        """
+        Verify API returns an empty response (not a 500) when no plugin override is installed.
+        """
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert not response.data
 
 
 @skip_unless_lms

--- a/openedx/core/djangoapps/programs/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/programs/rest_api/v1/views.py
@@ -3,7 +3,7 @@
 from typing import Any, TYPE_CHECKING
 import logging
 
-from django.db.models.query import EmptyQuerySet
+from edx_django_utils.plugins import pluggable_override
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -16,16 +16,24 @@ from openedx.core.djangoapps.programs.utils import (
     get_program_and_course_data,
     get_program_urls,
 )
-from openedx.features.enterprise_support.api import get_enterprise_course_enrollments, enterprise_is_enabled
 
 if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
     from django.contrib.auth.models import AnonymousUser, User  # pylint: disable=imported-auth-user
     from django.contrib.sites.models import Site
-    from django.db.models.query import QuerySet
-    from common.djangoapps.student.models import CourseEnrollment
 
 logger = logging.getLogger(__name__)
+
+
+@pluggable_override('OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS')
+def get_enterprise_course_ids(enterprise_uuid: str, user: "AnonymousUser | User") -> list[str]:
+    """
+    Return the course IDs the given user is enterprise-enrolled in for one enterprise customer.
+
+    This function can be overridden by an installed plugin via the
+    OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS setting.
+    """
+    return []
 
 
 class Programs(APIView):
@@ -91,9 +99,10 @@ class Programs(APIView):
         user: "AnonymousUser | User" = request.user
 
         if enterprise_uuid:
-            enrollments = list(self._get_enterprise_course_enrollments(enterprise_uuid, user))
+            course_ids = get_enterprise_course_ids(enterprise_uuid=enterprise_uuid, user=user)
+            enrollments = list(get_course_enrollments(user=user, is_filtered=True, course_ids=course_ids))
         else:
-            enrollments = list(get_course_enrollments(user))
+            enrollments = list(get_course_enrollments(user=user))
 
         # return empty reponse if no enrollments exists for a user
         if not enrollments:
@@ -177,23 +186,6 @@ class Programs(APIView):
             programs.append(program)
 
         return programs
-
-    @enterprise_is_enabled(otherwise=EmptyQuerySet)
-    def _get_enterprise_course_enrollments(
-        self, enterprise_uuid: str, user: "AnonymousUser | User"
-    ) -> "QuerySet[CourseEnrollment]":
-        """
-        Return only enterprise enrollments for a user.
-        """
-        enterprise_enrollment_course_ids = (
-            get_enterprise_course_enrollments(user)
-            .filter(enterprise_customer_user__enterprise_customer__uuid=enterprise_uuid)
-            .values_list("course_id", flat=True)
-        )
-
-        course_enrollments = get_course_enrollments(user, True, list(enterprise_enrollment_course_ids))
-
-        return course_enrollments
 
 
 class ProgramProgressDetailView(APIView):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -42,7 +42,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==8.9.2
+edx-enterprise==8.9.3
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -473,7 +473,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.9.2
+edx-enterprise==8.9.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.9.2
+edx-enterprise==8.9.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -557,7 +557,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.9.2
+edx-enterprise==8.9.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -578,7 +578,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.9.2
+edx-enterprise==8.9.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
The programs API has two variants: B2C and B2B:

- B2C: `GET /api/dashboard/v1/programs/`
- B2B: `GET /api/dashboard/v1/programs/{enterprise_uuid}/`

The B2B variant uses enterprise internal functions to help filter the response to include only enterprise-subsidized enrollments. This can't go on any longer because we need to remove all enterprise imports from the platform.

This commit replaces those enterprise function calls with a plugin hook point. We introduce the `OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS` pluggable override which allows the enterprise plugin itself register an implementation, allowing all `enterprise` imports to be removed from the programs API views.py file.

ENT-11575