### PR TITLE
fix: narrow FieldDataCache prefetch to a learner's saved question picks

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -749,7 +749,7 @@ class FieldDataCache:
             if depth is None or depth > 0:
                 new_depth = depth - 1 if depth is not None else depth
 
-                for child in block.get_children() + block.get_required_block_descriptors():
+                for child in self._children_to_prefetch(block):
                     blocks.extend(get_child_blocks(child, new_depth, block_filter))
 
             return blocks
@@ -758,6 +758,81 @@ class FieldDataCache:
             blocks = get_child_blocks(block, depth, block_filter)
 
         self.add_blocks_to_cache(blocks)
+
+    def _children_to_prefetch(self, block):
+        """
+        Return the children of `block` whose saved state we should load ahead of
+        rendering.
+
+        A randomized question bank (library_content / item_bank) picks a subset
+        of its problem pool per learner. `get_children()` on this kind of block
+        returns the whole pool, not the learner's picks, so using it here would
+        load saved state for every candidate problem instead of just the ones
+        that will render.
+
+        We can't fix that by calling the block's own `get_child_blocks()`
+        instead: at this point `block` isn't bound to a learner yet (that
+        happens after this whole prefetch step finishes), and without a bound
+        learner `get_child_blocks()` can't tell "no picks yet" apart from "not
+        bound yet" -- it would either come back empty or invent a fresh
+        selection and fire an "assigned" analytics event, neither of which is
+        safe to trigger while just warming a cache.
+
+        So instead we read the learner's already-saved picks directly out of
+        the database (`_persisted_selection_usage_keys` below), and only narrow
+        down to them when we actually find some saved. If none are saved yet
+        (first visit), we fall back to loading the whole pool, same as before --
+        harmless in that case, since there's no saved state to load either way.
+        """
+        has_dynamic_children = getattr(block, 'has_dynamic_children', None)
+        if callable(has_dynamic_children) and has_dynamic_children():
+            selected_keys = self._persisted_selection_usage_keys(block)
+            if selected_keys is not None:
+                selected_children = [
+                    child for child in (block.get_child(key) for key in selected_keys)
+                    if child is not None
+                ]
+                return selected_children + block.get_required_block_descriptors()
+
+        return block.get_children() + block.get_required_block_descriptors()
+
+    def _persisted_selection_usage_keys(self, block):
+        """
+        Look up which problems this learner was already assigned from `block`'s
+        question pool, by reading their saved row directly out of the database --
+        the same table (`StudentModule`) that stores every learner's saved answers.
+
+        Returns the list of those problems' keys, or None if we don't find a saved
+        row for this learner and this block yet (meaning: they haven't visited
+        this question bank before, so no pick has been made or saved).
+        """
+        if not self.user.is_authenticated:
+            return None
+
+        try:
+            module = StudentModule.objects.get(
+                student=self.user,
+                course_id=block.location.course_key,
+                module_state_key=block.location,
+            )
+        except StudentModule.DoesNotExist:
+            return None
+
+        try:
+            state = json.loads(module.state)
+        except (TypeError, ValueError):
+            log.warning(
+                "Could not parse saved state for %s / %s while narrowing FieldDataCache prefetch",
+                self.user.id, block.location,
+            )
+            return None
+
+        selected = state.get('selected')
+        if not selected:
+            return None
+
+        course_key = block.location.course_key
+        return [course_key.make_usage_key(block_type, block_id) for block_type, block_id in selected]
 
     @classmethod
     def cache_for_block_descendents(cls, course_id, user, block, depth=None,

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -28,6 +28,7 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict, namedtuple
 
 from django.db import DatabaseError, IntegrityError, transaction
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 from opaque_keys.edx.block_types import BlockTypeKeyV1
 from opaque_keys.edx.keys import LearningContextKey
@@ -832,7 +833,14 @@ class FieldDataCache:
             return None
 
         course_key = block.location.course_key
-        return [course_key.make_usage_key(block_type, block_id) for block_type, block_id in selected]
+        try:
+            return [course_key.make_usage_key(block_type, block_id) for block_type, block_id in selected]
+        except (TypeError, ValueError, InvalidKeyError):
+            log.warning(
+                "Malformed 'selected' state for %s / %s while narrowing FieldDataCache prefetch",
+                self.user.id, block.location,
+            )
+            return None
 
     @classmethod
     def cache_for_block_descendents(cls, course_id, user, block, depth=None,

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -444,3 +444,102 @@ class TestStudentInfoStorage(OtherUserFailureTestMixin, StorageTestBase, TestCas
     storage_class = XModuleStudentInfoField
     other_key_factory = partial(DjangoKeyValueStore.Key, Scope.user_info, 2, 'mock_problem')  # user_id=2, not 1
     existing_field_name = "existing_field"
+
+
+class TestFieldDataCacheDynamicChildren(TestCase):
+    """
+    Tests that prefetch narrows to a question bank's saved per-learner picks
+    (read straight from the database) rather than its whole problem pool.
+
+    Note the fake "block" objects below never need to claim they know who the
+    learner is -- the fix doesn't ask the block at all, which is the point.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.parent_location = COURSE_KEY.make_usage_key('library_content', 'pool')
+        self.pool_locations = [
+            COURSE_KEY.make_usage_key('problem', f'p{i}') for i in range(6)
+        ]
+
+    def _make_parent_block(self):
+        """
+        Fake stand-in for a question-bank block that has 6 possible problems in
+        its pool (self.pool_locations), any of which might get picked for a
+        given learner.
+        """
+        pool_blocks = {}
+        for loc in self.pool_locations:
+            child = mock_block()
+            child.location = loc
+            child.has_dynamic_children.return_value = False
+            child.get_children.return_value = []
+            child.get_required_block_descriptors.return_value = []
+            pool_blocks[loc] = child
+
+        parent = mock_block()
+        parent.location = self.parent_location
+        parent.has_dynamic_children.return_value = True
+        parent.get_children.return_value = list(pool_blocks.values())
+        parent.get_required_block_descriptors.return_value = []
+        parent.get_child.side_effect = pool_blocks.get
+        return parent
+
+    def test_narrows_prefetch_to_persisted_selection(self):
+        """
+        With 3 saved picks out of a 6-problem pool, prefetch loads only those 3
+        (via get_child()) and never calls get_children().
+        """
+        StudentModule.objects.create(
+            student=self.user,
+            course_id=COURSE_KEY,
+            module_state_key=self.parent_location,
+            module_type='library_content',
+            state=json.dumps({'selected': [['problem', 'p0'], ['problem', 'p2'], ['problem', 'p4']]}),
+        )
+        parent = self._make_parent_block()
+
+        cache = FieldDataCache([], COURSE_KEY, self.user)
+        cache.add_block_descendents(parent)
+
+        called_keys = {call.args[0] for call in parent.get_child.call_args_list}
+        assert called_keys == {
+            COURSE_KEY.make_usage_key('problem', 'p0'),
+            COURSE_KEY.make_usage_key('problem', 'p2'),
+            COURSE_KEY.make_usage_key('problem', 'p4'),
+        }
+        parent.get_children.assert_not_called()
+
+    def test_falls_back_to_full_pool_when_no_selection_saved(self):
+        """
+        With no saved picks (no StudentModule row for this block/user), prefetch
+        falls back to loading the whole pool, same as before this fix.
+        """
+        parent = self._make_parent_block()
+
+        cache = FieldDataCache([], COURSE_KEY, self.user)
+        cache.add_block_descendents(parent)
+
+        parent.get_children.assert_called_once()
+        parent.get_child.assert_not_called()
+
+    def test_ignores_empty_selection(self):
+        """
+        A saved row with an empty pick list is treated the same as no row at
+        all -- falls back to the full pool, not down to zero problems.
+        """
+        StudentModule.objects.create(
+            student=self.user,
+            course_id=COURSE_KEY,
+            module_state_key=self.parent_location,
+            module_type='library_content',
+            state=json.dumps({'selected': []}),
+        )
+        parent = self._make_parent_block()
+
+        cache = FieldDataCache([], COURSE_KEY, self.user)
+        cache.add_block_descendents(parent)
+
+        parent.get_children.assert_called_once()
+        parent.get_child.assert_not_called()

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -543,3 +543,24 @@ class TestFieldDataCacheDynamicChildren(TestCase):
 
         parent.get_children.assert_called_once()
         parent.get_child.assert_not_called()
+
+    def test_falls_back_on_malformed_selection(self):
+        """
+        A saved `selected` value that isn't a list of (block_type, block_id)
+        pairs shouldn't blow up the render -- fall back to the full pool, same
+        as any other case where we can't make sense of what's saved.
+        """
+        StudentModule.objects.create(
+            student=self.user,
+            course_id=COURSE_KEY,
+            module_state_key=self.parent_location,
+            module_type='library_content',
+            state=json.dumps({'selected': ['not-a-pair', 'also-not-a-pair']}),
+        )
+        parent = self._make_parent_block()
+
+        cache = FieldDataCache([], COURSE_KEY, self.user)
+        cache.add_block_descendents(parent)
+
+        parent.get_children.assert_called_once()
+        parent.get_child.assert_not_called()


### PR DESCRIPTION
## Description

Before rendering, `FieldDataCache` prefetches every relevant block's saved learner state in one batch. For randomized/library-content blocks (a question bank that shows each learner a different subset), it was prefetching the **entire candidate pool** instead of the subset actually assigned to the learner several times more DB work
than needed, which is what made large randomized assessments time out.

This narrows the prefetch to the learner's already-saved picks, read directly from `StudentModule`. We can't ask the block itself for this (`get_child_blocks()`), because at this point in the request it isn't bound to a learner yet — asking anyway risks it inventing a fresh random selection and firing an `assigned` event as a side effect. On a learner's first visit (nothing saved yet), it falls back to the original full-pool behavior, which is harmless since there's no saved state to load either way.

**Impacted:** Learners (fixes the timeout), Operators (less DB load per render). No UI change.

## Supporting information

[https://2u-internal.atlassian.net/browse/LP-284](https://2u-internal.atlassian.net/browse/LP-284)

## Testing instructions

1. `pytest lms/djangoapps/courseware/tests/test_model_data.py -k DynamicChildren -v`
2. Masquerade as a learner with an existing saved selection on a large randomized quiz and confirm the unit renders (and their saved answers still show).
3. Repeat as a learner on their first visit to that block, to confirm selection and problem count are unchanged.

## Deadline

None fixed, but the affected course's end date was extended to end of August 2026 specifically to give impacted learners time to finish once this lands.

## Other information

- No migration; read-path only.
- Self-contained to `lms/djangoapps/courseware/model_data.py`.
- Not yet verified: the saved `selected` field's exact shape (inferred from `item_bank_block.py`, not a real row), and instructor reset/regrade behavior for a learner whose assigned questions changed since an earlier visit.