### PR TITLE
Fix ValueError in Mobile Course Info API

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -850,7 +850,7 @@ def get_assignments_grades(user, course_id, cache_timeout):
         subsection_grades = list(course_grade.subsection_grades.values())
     except Exception as err:  # pylint: disable=broad-except
         log.warning(f'Could not get grades for the course: {course_id}, error: {err}')
-        return []
+        return [], []
 
     return subsection_grades, course_grade.grader_result()['section_breakdown']
 


### PR DESCRIPTION
**Summary:**

* Fixed `ValueError: not enough values to unpack (expected 2, got 0)` in the Mobile Course Info API.
* Updated the affected method to consistently return two values (`[], []`) when no assignment progress data is available.
* Prevents the caller from failing while unpacking the subsection grades and section breakdown.
* Added/updated tests to cover the empty-result scenario.

**Jira:** https://2u-internal.atlassian.net/browse/LP-1034
**Datadog:** https://app.datadoghq.com/error-tracking/issue/ef0eb3da-94c4-11f0-b17f-da7ad0900002