### PR TITLE
feat: add exec ed course uuid to learner home serializer

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -13,6 +13,7 @@ from rest_framework import serializers
 from openedx_filters.learning.filters import CourseEnrollmentAPIRenderStarted, CourseRunAPIRenderStarted
 
 from common.djangoapps.course_modes.models import CourseMode
+from openedx.core.djangoapps.catalog.utils import get_course_uuid_for_course
 from openedx.features.course_experience import course_home_url
 from xmodule.data import CertificatesDisplayBehaviors
 from lms.djangoapps.learner_home.utils import course_progress_url
@@ -93,6 +94,7 @@ class CourseRunSerializer(serializers.Serializer):
     isStarted = serializers.SerializerMethodField()
     isArchived = serializers.SerializerMethodField()
     courseId = serializers.CharField(source="course_id")
+    courseUuid = serializers.SerializerMethodField()
     minPassingGrade = serializers.DecimalField(
         max_digits=5, decimal_places=2, source="course_overview.lowest_passing_grade"
     )
@@ -113,6 +115,10 @@ class CourseRunSerializer(serializers.Serializer):
 
     def get_isArchived(self, instance):
         return instance.course_overview.has_ended()
+
+    def get_courseUuid(self, instance):
+        course_uuid = get_course_uuid_for_course(instance.course_id)
+        return str(course_uuid) if course_uuid else None
 
     def get_homeUrl(self, instance):
         return course_home_url(instance.course_id)

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -203,7 +203,10 @@ class TestCourseRunSerializer(LearnerDashboardBaseTest):
             },
         }
 
-    def test_with_data(self):
+    @mock.patch("lms.djangoapps.learner_home.serializers.get_course_uuid_for_course")
+    def test_with_data(self, mock_get_course_uuid_for_course):
+        # Mocked so courseUuid is populated, same as every other field
+        mock_get_course_uuid_for_course.return_value = uuid4()
         input_data = self.create_test_enrollment()
         input_context = self.create_test_context(input_data.course.id)
 
@@ -226,6 +229,34 @@ class TestCourseRunSerializer(LearnerDashboardBaseTest):
 
         # Then the resumeUrl is None, which is allowed
         self.assertIsNone(output_data["resumeUrl"])
+
+    @mock.patch("lms.djangoapps.learner_home.serializers.get_course_uuid_for_course")
+    def test_course_uuid(self, mock_get_course_uuid_for_course):
+        # Given the catalog has a UUID for this course
+        course_uuid = uuid4()
+        mock_get_course_uuid_for_course.return_value = course_uuid
+        input_data = self.create_test_enrollment()
+        input_context = self.create_test_context(input_data.course.id)
+
+        # When I serialize
+        output_data = CourseRunSerializer(input_data, context=input_context).data
+
+        # Then courseUuid is the stringified catalog UUID, looked up by course_id
+        self.assertEqual(output_data["courseUuid"], str(course_uuid))
+        mock_get_course_uuid_for_course.assert_called_once_with(input_data.course_id)
+
+    @mock.patch("lms.djangoapps.learner_home.serializers.get_course_uuid_for_course")
+    def test_missing_course_uuid(self, mock_get_course_uuid_for_course):
+        # Given the catalog has no UUID for this course (e.g. no catalog integration configured)
+        mock_get_course_uuid_for_course.return_value = None
+        input_data = self.create_test_enrollment()
+        input_context = self.create_test_context(input_data.course.id)
+
+        # When I serialize
+        output_data = CourseRunSerializer(input_data, context=input_context).data
+
+        # Then courseUuid is None, which is allowed
+        self.assertIsNone(output_data["courseUuid"])
 
     def is_progress_url_matching_course_home_mfe_progress_tab_is_active(self):
         """


### PR DESCRIPTION
## Description

Adds a `courseUuid` field to the Learner Home `CourseRunSerializer`, populated for Executive Education (GetSmarter/Titan) enrollments.

## Supporting information

- Jira: [ENT-9254](https://2u-internal.atlassian.net/browse/ENT-9254) — EdX-ExecEd Dashboard redirect to OLC without stopping in Titan

Planned follow-ups (not in this PR):
1. `frontend-app-learner-dashboard`: extend `useCardExecEdTrackingParam` to append `courseUuid` as a `course_id` query param on the "Start/Resume Course" link, alongside the existing `org_id`. https://github.com/edx/frontend-app-learner-dashboard/pull/26
2. `titan`: read that param in `Spree::UsersControllerDecorator#show` and redirect straight to `partner_olc_link(product)` instead of rendering the profile page, when it matches an allocation. https://github.com/getsmarter/titan/pull/3903

## Testing instructions

1. Enroll a test user in a course with an Executive Education mode (`executive-education`, `paid-executive-education`, or `unpaid-executive-education`).
2. Hit the Learner Home API (`/api/learner_home/init` or equivalent) and confirm the corresponding `courseRun` entry has a non-null `courseUuid`.

Covered by new/updated unit tests in `lms/djangoapps/learner_home/test_serializers.py`:
- `test_with_data` (updated to exercise an enrollment)
- `test_course_uuid` (assers courseUUID is available after enrolment)
- `test_missing_course_uuid` (asserts `None`)

## Other information

- Depends on nothing merged elsewhere; the frontend and Titan follow-ups depend on this.
- No database migration.
- No new external calls for the common case — the catalog lookup only fires for Executive Education enrollments.
