### PR TITLE
chore: remove transcript editor rollout toggle [LP-1108]

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -35,7 +35,6 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
     enable_unit_expanded_view = serializers.SerializerMethodField()
     enable_outline_component_creation = serializers.SerializerMethodField()
     enable_audio_description = serializers.SerializerMethodField()
-    enable_transcript_editor = serializers.SerializerMethodField()
 
     def get_course_key(self):
         """
@@ -201,10 +200,3 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         """
         course_key = self.get_course_key()
         return toggles.audio_description_enabled(course_key)
-
-    def get_enable_transcript_editor(self, obj):
-        """
-        Method to get the contentstore.enable_transcript_editor waffle flag.
-        """
-        course_key = self.get_course_key()
-        return toggles.transcript_editor_enabled(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -42,7 +42,6 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         "enable_unit_expanded_view": False,
         "enable_outline_component_creation": False,
         "enable_audio_description": False,
-        "enable_transcript_editor": False,
     }
 
     def setUp(self):
@@ -85,55 +84,3 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         url = reverse("cms.djangoapps.contentstore:v1:course_waffle_flags")
         response = self.client.get(url)
         assert response.data["enable_audio_description"] is True
-
-    def test_enable_transcript_editor_flag_default_is_false(self):
-        """
-        The contentstore.enable_transcript_editor flag should default to False when not
-        overridden, both globally and for a specific course.
-        """
-        global_url = reverse("cms.djangoapps.contentstore:v1:course_waffle_flags")
-        course_url = reverse(
-            "cms.djangoapps.contentstore:v1:course_waffle_flags",
-            kwargs={"course_id": self.course.id},
-        )
-        for url in (global_url, course_url):
-            response = self.client.get(url)
-            assert response.data["enable_transcript_editor"] is False
-
-    @override_waffle_flag(toggles.ENABLE_TRANSCRIPT_EDITOR, active=True)
-    def test_enable_transcript_editor_flag_enabled_globally(self):
-        """
-        When the contentstore.enable_transcript_editor flag is active globally, the
-        serializer should return True for both the global endpoint and any
-        course-specific endpoint.
-        """
-        global_url = reverse("cms.djangoapps.contentstore:v1:course_waffle_flags")
-        course_url = reverse(
-            "cms.djangoapps.contentstore:v1:course_waffle_flags",
-            kwargs={"course_id": self.course.id},
-        )
-        for url in (global_url, course_url):
-            response = self.client.get(url)
-            assert response.data["enable_transcript_editor"] is True
-
-    def test_enable_transcript_editor_flag_enabled_per_course(self):
-        """
-        When the contentstore.enable_transcript_editor flag is enabled via a
-        WaffleFlagCourseOverrideModel entry for a specific course, the
-        course-scoped endpoint should return True while the global endpoint
-        should remain False.
-        """
-        WaffleFlagCourseOverrideModel.objects.create(
-            waffle_flag=toggles.ENABLE_TRANSCRIPT_EDITOR.name,
-            course_id=self.course.id,
-            enabled=True,
-        )
-        global_url = reverse("cms.djangoapps.contentstore:v1:course_waffle_flags")
-        course_url = reverse(
-            "cms.djangoapps.contentstore:v1:course_waffle_flags",
-            kwargs={"course_id": self.course.id},
-        )
-        global_response = self.client.get(global_url)
-        course_response = self.client.get(course_url)
-        assert global_response.data["enable_transcript_editor"] is False
-        assert course_response.data["enable_transcript_editor"] is True

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -90,31 +90,6 @@ def audio_description_enabled(course_key):
     return ENABLE_AUDIO_DESCRIPTION.is_enabled(course_key)
 
 
-# .. toggle_name: contentstore.enable_transcript_editor
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enables the in-platform transcript editor in Studio's
-#   videos page. When enabled, course staff can open an editor modal from the
-#   transcript row action menu and edit transcript cue text directly in the
-#   browser; edits are saved via PATCH to a new v1 transcript endpoint. When
-#   disabled, the "Edit transcript" menu item is hidden and the API endpoint
-#   returns 404. Existing upload, download, and delete flows are unaffected.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2026-05-05
-# .. toggle_tickets: TNL2-608
-ENABLE_TRANSCRIPT_EDITOR = CourseWaffleFlag(
-    'contentstore.enable_transcript_editor',
-    __name__,
-)
-
-
-def transcript_editor_enabled(course_key):
-    """
-    Return True if the in-platform transcript editor is enabled for the course.
-    """
-    return ENABLE_TRANSCRIPT_EDITOR.is_enabled(course_key)
-
-
 # .. toggle_name: legacy_studio.exam_settings
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -339,6 +339,31 @@ class TranscriptUploadTest(CourseTestCase):
             file_data=ANY,
         )
 
+    @patch('cms.djangoapps.contentstore.transcript_storage_handlers.create_or_update_video_transcript')
+    @patch(
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
+        Mock(return_value=['en']),
+    )
+    def test_transcript_upload_handler_returns_200_on_replace(self, mock_create_or_update_video_transcript):
+        """
+        Verify that uploading a transcript for a language that already has a
+        transcript returns 200 (replace) instead of 201 (create).
+        """
+        transcript_file_stream = StringIO('0\n00:00:00,010 --> 00:00:00,100\nHello, edX greets you.\n\n')
+        response = self.client.post(
+            self.view_url,
+            {
+                'edx_video_id': '123',
+                'language_code': 'en',
+                'new_language_code': 'en',
+                'file': transcript_file_stream,
+            },
+            format='multipart'
+        )
+
+        self.assertEqual(response.status_code, 200)  # noqa: PT009
+        mock_create_or_update_video_transcript.assert_called_once()
+
     @ddt.data(
         (
             {


### PR DESCRIPTION
## Description

Removes the temporary rollout toggle for the in-platform transcript editor, per the product
decision to ship the feature without a flag, and brings the fork in line with the upstream
contribution (openedx/openedx-platform#39038) so the two diff as a no-op.

- `cms/djangoapps/contentstore/toggles.py`: drop `ENABLE_TRANSCRIPT_EDITOR`
  (`contentstore.enable_transcript_editor`) and the `transcript_editor_enabled()` helper.
- `rest_api/v1/serializers/course_waffle_flags.py`: drop the `enable_transcript_editor` field.
- `rest_api/v1/views/tests/test_course_waffle_flags.py`: drop the three flag tests.
- `views/tests/test_transcript_settings.py`: add `test_transcript_upload_handler_returns_200_on_replace`.
  This was missing on the fork — #267's tests only covered the toggle, so the 200-vs-201 upload
  response change had no coverage. Added at the same location as upstream.

`transcript_storage_handlers.py` (the 200-on-replace change from #267) is unchanged.

**Parity check:** the fork's net transcript-editor change after this PR (pre-#267 → this branch)
is line-for-line identical to the upstream PR's change set (28 lines each, zero diff).

## Supporting information

- Jira: https://2u-internal.atlassian.net/browse/LP-1108
- Upstream PR this brings the fork in line with: https://github.com/openedx/openedx-platform/pull/39038
- Context: Robert's review comment on the upstream PR asking why the test wasn't on the fork
  (<link to the GitHub line comment>) and the upstreaming-process Slack thread (<link>).
- Original downstream PR that introduced the toggle: edx/edx-platform#267

## Testing instructions

```
pytest cms/djangoapps/contentstore/views/tests/test_transcript_settings.py \
       cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
```

Manual: `GET /api/contentstore/v1/course_waffle_flags/<course_key>` no longer returns
`enable_transcript_editor`; uploading a transcript for a language that already has one returns 200,
a new language returns 201.
