### PR TITLE
feat: replace enterprise support contact-tag import with filter call

### DIFF
--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -115,6 +115,30 @@ class SupportViewManageUserTests(SupportViewTestCase):
         response = self.client.get(url)
         assert response.status_code == 200
 
+    @override_settings(ZENDESK_URL=ZENDESK_URL)
+    @patch('lms.djangoapps.support.views.contact_us.SupportContactContextRequested.run_filter')
+    def test_get_contact_us_tags_run_through_filter(self, mock_run_filter):
+        """
+        The page context (including tags) is passed through the SupportContactContextRequested
+        filter, and the filter's return value is used as the final context for the rendered page.
+
+        The behavior of the filter's pipeline step (edx-enterprise's SupportContactEnterpriseTagStep)
+        is covered by edx-enterprise's own test suite. This view only needs to verify it wires
+        the filter's return value through correctly.
+        """
+        def fake_run_filter(context):
+            return {**context, 'tags': [*context['tags'], 'enterprise_learner']}
+
+        mock_run_filter.side_effect = fake_run_filter
+
+        response = self.client.get(reverse('support:contact_us'))
+
+        assert response.status_code == 200
+        mock_run_filter.assert_called_once()
+        _, call_kwargs = mock_run_filter.call_args
+        assert call_kwargs['context']['tags'] == ['LMS']
+        assert b'enterprise_learner' in response.content
+
     def test_get_contact_us_redirect_if_undefined_zendesk_url(self):
         """
         Tests the Support contact us Page redirects if ZENDESK_URL setting is not defined

--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -7,11 +7,11 @@ from django.conf import settings
 from django.http import Http404
 from django.shortcuts import redirect
 from django.views.generic import View
+from openedx_filters.learning.filters import SupportContactContextRequested
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import CourseEnrollment
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.features.enterprise_support import api as enterprise_api
 
 
 class ContactUsView(View):
@@ -35,21 +35,19 @@ class ContactUsView(View):
         }
 
         # Tag all issues with LMS to distinguish channel which received the request
-        tags = ['LMS']
+        context['tags'] = ['LMS']
 
         # Per edX support, we would like to be able to route feedback items by site via tagging
         current_site_name = configuration_helpers.get_value("SITE_NAME")
         if current_site_name:
             current_site_name = current_site_name.replace(".", "_")
-            tags.append(f"site_name_{current_site_name}")
+            context['tags'].append(f"site_name_{current_site_name}")
 
         if request.user.is_authenticated:
             context['course_id'] = request.session.get('course_id', '')
             context['user_enrollments'] = CourseEnrollment.enrollments_for_user_with_overviews_preload(request.user)
-            enterprise_customer = enterprise_api.enterprise_customer_for_request(request)
-            if enterprise_customer:
-                tags.append('enterprise_learner')
 
-        context['tags'] = tags
+        if request.user.is_authenticated:
+            context = SupportContactContextRequested.run_filter(context=context)
 
         return render_to_response("support/contact_us.html", context)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -42,7 +42,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==8.9.4
+edx-enterprise==8.11.0
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -473,7 +473,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.9.4
+edx-enterprise==8.11.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
@@ -829,7 +829,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.9.0
+openedx-filters==3.11.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.9.4
+edx-enterprise==8.11.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
@@ -1375,7 +1375,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.9.0
+openedx-filters==3.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -557,7 +557,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.9.4
+edx-enterprise==8.11.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
@@ -1001,7 +1001,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.9.0
+openedx-filters==3.11.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -578,7 +578,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==8.9.4
+edx-enterprise==8.11.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
@@ -1046,7 +1046,7 @@ openedx-events==10.5.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==3.9.0
+openedx-filters==3.11.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
ENT-11574

Sibling of the openedx/openedx-platform PR of the same name, carrying the same call-site
change to this deployable fork so it can go through stage/prod ahead of the upstream merge,
per the enterprise plugin ticket runbook. Devstack only boots this repo (not
openedx/openedx-platform), so this is also the branch used for local integration testing.

Swaps the direct `openedx.features.enterprise_support` import in the support contact-us view
for a call to the `SupportContactContextRequested` openedx-filter. No settings changes in
this PR: `OPEN_EDX_FILTERS_CONFIG` registration for the pipeline step lives entirely in
edx-enterprise's own `plugin_settings()` (`enterprise/settings/common.py`), per the `ENT-11830`
ownership handoff — already merged in this repo (#281) well before this branch existed.
(An earlier version of this PR incorrectly re-added `OPEN_EDX_FILTERS_CONFIG` to
`lms/envs/common.py`; that's been reverted.)

`lms/djangoapps/support/views/enrollments.py` is untouched — this PR is scoped to the
contact-tag filter only.

## Update: filter shape corrected per review feedback

Per [review feedback](https://github.com/edx/edx-platform/pull/455#discussion_r3981440210)
(and the [follow-up comment](https://github.com/edx/edx-platform/pull/455#discussion_r3981468500)
on `user`), the filter's original shape was wrong — it claimed to request the whole page
"context" but only ever passed/returned a bare `tags` list. `SupportContactContextRequested.run_filter`
now accepts/returns the entire `context` dict (the call is made after `context['tags'] = tags`),
and the unused `user` argument was dropped entirely (pipeline steps fetch it via `crum`
internally, matching the convention used elsewhere). [Acknowledged directly on the review thread](https://github.com/edx/edx-platform/pull/455#discussion_r3982551721).

Since the original shape (#390 / #2688 below) had already merged and released, this required new
PRs in openedx-filters and edx-enterprise rather than amendments — both are now merged and
released (3.11.0 / 8.11.0), and this PR's call site and requirements pins are updated to match,
verified locally against the real released packages.

## Related PRs

* openedx/openedx-filters — original filter: https://github.com/openedx/openedx-filters/pull/390
* openedx/openedx-filters — shape-fix (context dict, drop `user`): https://github.com/openedx/openedx-filters/pull/394
* openedx/edx-enterprise — original pipeline step: https://github.com/openedx/edx-enterprise/pull/2688
* openedx/edx-enterprise — matching shape-fix: https://github.com/openedx/edx-enterprise/pull/2691
* openedx/openedx-platform — same call-site change upstream, merges last: https://github.com/openedx/openedx-platform/pull/39076

## Merge order (per the enterprise plugin ticket runbook)

Merge this **after** local devstack testing and **before** the openedx/openedx-platform PR.
Auto-deploys to stage on merge — test in stage, then deploy to prod and confirm working, before
the openedx-platform PR is rebased and merged.

## CI note

Previously CI here was expected to be red until openedx-filters/edx-enterprise released — that
dependency chain has since resolved. Both packages are now released (openedx-filters 3.11.0,
edx-enterprise 8.11.0, carrying the shape-fix above) and this PR's requirements pins are bumped
to match. CI is green.

## Testing

Same test change as the openedx-platform PR: `SupportContactContextRequested.run_filter` is
mocked at the call site in `lms/djangoapps/support/tests/test_views.py`; the pipeline-step
behavior itself is covered by edx-enterprise's own test suite.

Local devstack integration testing (with the openedx-filters, edx-enterprise, and this branch
checked out together) is required before merging — see handoff prompt for exact steps.
