### PR TITLE
chore(video): remove audio description waffle flag and related gating [LP-1205]

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -34,7 +34,6 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
     enable_course_optimizer_check_prev_run_links = serializers.SerializerMethodField()
     enable_unit_expanded_view = serializers.SerializerMethodField()
     enable_outline_component_creation = serializers.SerializerMethodField()
-    enable_audio_description = serializers.SerializerMethodField()
 
     def get_course_key(self):
         """
@@ -193,10 +192,3 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         """
         course_key = self.get_course_key()
         return toggles.enable_outline_component_creation(course_key)
-
-    def get_enable_audio_description(self, obj):
-        """
-        Method to get the enable_audio_description waffle flag.
-        """
-        course_key = self.get_course_key()
-        return toggles.audio_description_enabled(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_waffle_flags.py
@@ -63,8 +63,7 @@ class CourseWaffleFlagsView(APIView):
             "use_new_textbooks_page": true,
             "use_new_group_configurations_page": true,
             "use_react_markdown_editor": true,
-            "use_video_gallery_flow": true,
-            "enable_audio_description": false
+            "use_video_gallery_flow": true
         }
         ```
         """

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -3,7 +3,6 @@ Unit tests for the course waffle flags view
 """
 
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 
 from cms.djangoapps.contentstore import toggles
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
@@ -41,7 +40,6 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         "enable_course_optimizer_check_prev_run_links": False,
         "enable_unit_expanded_view": False,
         "enable_outline_component_creation": False,
-        "enable_audio_description": False,
     }
 
     def setUp(self):
@@ -73,14 +71,3 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
             "enable_course_optimizer": True,
             "enable_course_optimizer_check_prev_run_links": True,
         }
-
-    @override_waffle_flag(toggles.ENABLE_AUDIO_DESCRIPTION, active=True)
-    def test_audio_description_upload_flag_enabled(self):
-        """
-        When the global AD upload flag is on, the serializer should
-        report it as True regardless of which course (or no course) is
-        in the request.
-        """
-        url = reverse("cms.djangoapps.contentstore:v1:course_waffle_flags")
-        response = self.client.get(url)
-        assert response.data["enable_audio_description"] is True

--- a/cms/djangoapps/contentstore/tests/test_video_audio_description_handler.py
+++ b/cms/djangoapps/contentstore/tests/test_video_audio_description_handler.py
@@ -1,28 +1,24 @@
 """
-Tests for the studio_audio_description XBlock handler and its
-contentstore.enable_audio_description waffle flag gate.
+Tests for the studio_audio_description XBlock handler.
 
 The handler itself delegates to the storage helpers in
 cms.djangoapps.contentstore.audio_description_storage_handlers; these
-tests focus on the handler's gating behavior and dispatch logic, not on
-the storage helpers themselves.
+tests focus on the handler's dispatch logic, not on the storage helpers
+themselves.
 
 These tests live in CMS-test land (rather than alongside the rest of
 the LMS-side video handler tests in
-lms/djangoapps/courseware/tests/test_video_handlers.py) because
-cms.djangoapps.contentstore.toggles transitively imports the
-Studio-only search-api and so cannot be loaded under LMS test settings.
+lms/djangoapps/courseware/tests/test_video_handlers.py) because the
+handler imports the Studio-only audio_description_storage_handlers
+module, which cannot be loaded under LMS test settings.
 """
 
 import importlib
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
-from edx_toggles.toggles.testutils import override_waffle_flag
-from opaque_keys.edx.locator import CourseLocator
 from webob import Request
 
-from cms.djangoapps.contentstore.toggles import ENABLE_AUDIO_DESCRIPTION
 from xmodule.video_block.video_block import VideoBlock
 
 
@@ -53,13 +49,11 @@ class StudioAudioDescriptionHandlerTest(TestCase):
                 "edx_video_id",
                 "audio_description",
                 "audio_description_video_id",
-                "course_id",
             ]
         )
         block.edx_video_id = edx_video_id
         block.audio_description = audio_description
         block.audio_description_video_id = ""
-        block.course_id = CourseLocator(org="test", course="test", run="test")
         return block
 
     def _call(self, block, method, body=None, request=None):
@@ -75,21 +69,9 @@ class StudioAudioDescriptionHandlerTest(TestCase):
         request = Request.blank("", **kwargs)
         return VideoBlock.studio_audio_description(block, request=request)
 
-    @override_waffle_flag(ENABLE_AUDIO_DESCRIPTION, active=False)
-    def test_handler_returns_404_when_flag_disabled(self):
-        """
-        When the upload flag is off, every HTTP method on the handler
-        must return 404 so the endpoint looks non-existent to clients.
-        """
-        block = self._build_block_mock()
-        for method in ("GET", "POST", "DELETE"):
-            response = self._call(block, method)
-            self.assertEqual(response.status_code, 404, msg=f"method={method}")
-
-    @override_waffle_flag(ENABLE_AUDIO_DESCRIPTION, active=True)
     def test_post_uploads_file_and_returns_url(self):
         """
-        With the flag on, a POST request carrying a file should reach
+        A POST request carrying a file should reach
         upload_audio_description and return {file_name, url} with 201.
         """
         block = self._build_block_mock(edx_video_id="video-1")
@@ -125,11 +107,10 @@ class StudioAudioDescriptionHandlerTest(TestCase):
                 file_data=file_mock.file,
             )
 
-    @override_waffle_flag(ENABLE_AUDIO_DESCRIPTION, active=True)
     def test_post_returns_400_when_file_missing(self):
         """
-        With the flag on but no file in the POST body, the handler must
-        return 400 with an error message.
+        With no file in the POST body, the handler must return 400 with
+        an error message.
         """
         block = self._build_block_mock(edx_video_id="video-1")
 
@@ -142,11 +123,10 @@ class StudioAudioDescriptionHandlerTest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("error", response.json)
 
-    @override_waffle_flag(ENABLE_AUDIO_DESCRIPTION, active=True)
     def test_get_returns_404_when_no_url(self):
         """
-        With the flag on but no AD record on the block, the GET branch
-        should return 404 (the storage helper returns None).
+        With no AD record on the block, the GET branch should return 404
+        (the storage helper returns None).
         """
         block = self._build_block_mock()
 
@@ -156,12 +136,11 @@ class StudioAudioDescriptionHandlerTest(TestCase):
 
             self.assertEqual(response.status_code, 404)
 
-    @override_waffle_flag(ENABLE_AUDIO_DESCRIPTION, active=True)
     def test_get_returns_url_when_present(self):
         """
-        With the flag on and a ready AD record, the GET branch returns
-        a JSON body containing the helper's pre-signed URL plus the
-        block's stored filename.
+        With a ready AD record, the GET branch returns a JSON body
+        containing the helper's pre-signed URL plus the block's stored
+        filename.
         """
         block = self._build_block_mock(audio_description="bar.mp3")
 
@@ -178,12 +157,10 @@ class StudioAudioDescriptionHandlerTest(TestCase):
                 },
             )
 
-    @override_waffle_flag(ENABLE_AUDIO_DESCRIPTION, active=True)
-    def test_delete_when_flag_enabled(self):
+    def test_delete_clears_field_and_returns_204(self):
         """
-        With the flag on, a DELETE request should call the storage
-        helper, clear the block's audio_description field, and return
-        204.
+        A DELETE request should call the storage helper, clear the
+        block's audio_description field, and return 204.
         """
         block = self._build_block_mock(
             edx_video_id="video-1", audio_description="bar.mp3"

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -66,30 +66,6 @@ def bypass_olx_failure_enabled():
     return BYPASS_OLX_FAILURE.is_enabled()
 
 
-# .. toggle_name: contentstore.enable_audio_description
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enables the audio description (AD) upload UI in the
-#   Studio video editor and the corresponding studio_audio_description XBlock
-#   handler. When disabled, course authors cannot upload, replace, or delete
-#   audio description files for video blocks. Playback of AD files that were
-#   already uploaded is NOT gated by this flag and continues to work in the
-#   LMS -- disable the playback path with a separate flag if needed.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2026-04-07
-ENABLE_AUDIO_DESCRIPTION = CourseWaffleFlag(
-    f'{CONTENTSTORE_NAMESPACE}.enable_audio_description',
-    __name__,
-)
-
-
-def audio_description_enabled(course_key):
-    """
-    Return True if the audio description upload UI and handler are enabled.
-    """
-    return ENABLE_AUDIO_DESCRIPTION.is_enabled(course_key)
-
-
 # .. toggle_name: legacy_studio.exam_settings
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -1354,12 +1354,11 @@ class TestVideoBlockAudioDescriptionPlayback(TestVideo):  # lint-amnesty, pylint
     Tests for VideoBlock._get_audio_description_url, the LMS-side
     playback helper used by get_html / student_view_data.
 
-    The companion handler tests for studio_audio_description and the
-    contentstore.enable_audio_description waffle flag live in
+    The companion handler tests for studio_audio_description live in
     cms/djangoapps/contentstore/tests/test_video_audio_description_handler.py
-    -- they cannot live here because cms.djangoapps.contentstore.toggles
-    transitively imports the Studio-only search-api and won't load
-    under LMS test settings.
+    -- they cannot live here because the handler imports the Studio-only
+    cms.djangoapps.contentstore.audio_description_storage_handlers module,
+    which won't load under LMS test settings.
     """
     DATA = """
         <video show_captions="true" display_name="A Name">
@@ -1374,12 +1373,6 @@ class TestVideoBlockAudioDescriptionPlayback(TestVideo):  # lint-amnesty, pylint
         When the block has an AD attached and an edx_video_id set,
         _get_audio_description_url should delegate to the audio
         description URL helper and return its result.
-
-        This is also a regression guard: the helper module must NEVER
-        check the contentstore.enable_audio_description waffle
-        flag. Existing AD files must continue to play in the LMS even
-        after the upload flag is flipped off (see plan
-        audio-description-waffle-flag.md).
         """
         mock_generate.return_value = 'https://s3.example/get-presigned'
         self.block.audio_description = 'bar.mp3'

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -132,7 +132,6 @@ class TestVideoYouTube(TestVideo):  # lint-amnesty, pylint: disable=missing-clas
                 'completionPercentage': 0.95,
                 'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
                 'prioritizeHls': False,
-                'audioDescriptionEnabled': False,
             })),
             'track': None,
             'transcript_download_format': 'srt',
@@ -223,7 +222,6 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
                 'completionPercentage': 0.95,
                 'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
                 'prioritizeHls': False,
-                'audioDescriptionEnabled': False,
             })),
             'track': None,
             'transcript_download_format': 'srt',
@@ -384,7 +382,6 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'completionPercentage': 0.95,
             'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
             'prioritizeHls': False,
-            'audioDescriptionEnabled': False,
         })
 
     def get_handler_url(self, handler, suffix):
@@ -2445,7 +2442,6 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
                 'completionPercentage': 0.95,
                 'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
                 'prioritizeHls': False,
-                'audioDescriptionEnabled': False,
             })),
             'track': None,
             'transcript_download_format': 'srt',
@@ -2535,7 +2531,6 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
                 'completionPercentage': 0.95,
                 'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
                 'prioritizeHls': False,
-                'audioDescriptionEnabled': False,
             })),
             'track': None,
             'transcript_download_format': 'srt',

--- a/xmodule/js/src/video/09_video_audio_description.js
+++ b/xmodule/js/src/video/09_video_audio_description.js
@@ -29,7 +29,6 @@
                 this.state = state;
                 this.state.videoAudioDescription = this;
                 this.hasSource = !!state.config.audioDescriptionUrl;
-                this.featureEnabled = state.config.audioDescriptionEnabled;
                 this._currentSpeed = parseFloat(state.speed) || 1.0;
 
                 this.initialize();
@@ -46,7 +45,7 @@
                         ? (this.state.config.audioDescriptionActive || false)
                         : false;
                     this.renderElements();
-                    if (this.hasSource && this.featureEnabled) {
+                    if (this.hasSource) {
                         this.bindHandlers();
                     }
                     if (this.isActive) {
@@ -56,9 +55,6 @@
 
                 renderElements: function() {
                     var buttonHtml, secondaryControls;
-                    if (!this.featureEnabled) {
-                        return;
-                    }
 
                     if (this.hasSource) {
                         var audioEl = $('<audio>', {

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -475,15 +475,6 @@ class _BuiltInVideoBlock(
         if audio_description_url:
             metadata['audioDescriptionUrl'] = audio_description_url
 
-        try:
-            from cms.djangoapps.contentstore.toggles import (  # pylint: disable=import-outside-toplevel
-                audio_description_enabled
-            )
-            ad_feature_enabled = bool(audio_description_enabled(self.course_id))
-        except Exception:  # pylint: disable=broad-except
-            ad_feature_enabled = False
-        metadata['audioDescriptionEnabled'] = ad_feature_enabled
-
         bumperize(self)
 
         is_video_from_same_origin = bool(download_video_link and cdn_url and download_video_link.startswith(cdn_url))
@@ -991,18 +982,12 @@ class _BuiltInVideoBlock(
         }
 
         _context.update({'transcripts_basic_tab_metadata': metadata})
-        from cms.djangoapps.contentstore.toggles import audio_description_enabled  # pylint: disable=import-outside-toplevel
 
         # Audio description upload context for studio editor
-        ad_upload_enabled = bool(
-            audio_description_enabled and audio_description_enabled(self.course_id)
-        )
-        _context['audio_description_enabled'] = ad_upload_enabled
-        if ad_upload_enabled:
-            _context['audio_description_file_name'] = getattr(self, 'audio_description', '')
-            _context['audio_description_handler_url'] = self.runtime.handler_url(
-                self, 'studio_audio_description'
-            ).rstrip('/?')
+        _context['audio_description_file_name'] = getattr(self, 'audio_description', '')
+        _context['audio_description_handler_url'] = self.runtime.handler_url(
+            self, 'studio_audio_description'
+        ).rstrip('/?')
 
         return _context
 

--- a/xmodule/video_block/video_handlers.py
+++ b/xmodule/video_block/video_handlers.py
@@ -696,10 +696,6 @@ class VideoStudioViewHandlers:
             get_audio_description_url,
             upload_audio_description,
         )
-        from cms.djangoapps.contentstore.toggles import audio_description_enabled  # pylint: disable=import-outside-toplevel
-
-        if not audio_description_enabled or not audio_description_enabled(self.course_id):
-            return Response(status=404)
 
         if request.method == 'POST':
             try:


### PR DESCRIPTION
Removes the `contentstore.enable_audio_description` CourseWaffleFlag and all
gating on it. The feature is fully rolled out on edx.org (TNL2-606), so the
flag is dead weight, and removing it downstream first means the upstream
contribution under LP-911 doesn't need to carry it. Same approach as the
transcript editor in LP-1108.

## Changes

| File | Change |
|---|---|
| `cms/djangoapps/contentstore/toggles.py` | Remove `ENABLE_AUDIO_DESCRIPTION` flag, annotation and `audio_description_enabled()` helper |
| `xmodule/video_block/video_handlers.py` | `studio_audio_description` no longer 404s when the flag is off |
| `xmodule/video_block/video_block.py` | Studio context always sets `audio_description_file_name` / `audio_description_handler_url`; LMS player metadata no longer includes `audioDescriptionEnabled` |
| `xmodule/js/src/video/09_video_audio_description.js` | Drop `featureEnabled`; render and bind the AD control whenever `audioDescriptionUrl` is present |
| `cms/.../serializers/course_waffle_flags.py` | Remove `enable_audio_description` field and getter |
| `cms/.../views/course_waffle_flags.py` | Remove the key from the docstring example |
| `cms/.../tests/test_course_waffle_flags.py` | Remove the key from expected defaults and the flag-on test; drop now-unused `override_waffle_flag` import |
| `cms/.../tests/test_video_audio_description_handler.py` | Remove flag-off 404 test and all `override_waffle_flag` decorators; drop unused `course_id` from the block mock; rename `test_delete_when_flag_enabled` → `test_delete_clears_field_and_returns_204` |
| `lms/djangoapps/courseware/tests/test_video_handlers.py` | Docstrings only - remove references to the flag |

## Note on the player JS

The toggle's docstring stated LMS playback was not gated by this flag. It was:
`video_block.py` wrote the flag into player metadata as `audioDescriptionEnabled`,
and `09_video_audio_description.js` skipped rendering/binding when it was falsy.
Removing only the Python side would have left that key `undefined` and broken AD
playback. The JS gate is removed in the same change so playback matches current
production (flag-on) behaviour.

Not touched: the `'audio_description_enabled': bool(audio_description_url)`
template-context key in `video_block.py` and its expectations in
`test_video_mongo.py` - that key means "this video has an AD file", not the flag.

## Testing

- `pytest cms/djangoapps/contentstore/tests/test_video_audio_description_handler.py cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py --ds=cms.envs.test`
- `pytest lms/djangoapps/courseware/tests/test_video_handlers.py -k AudioDescription --ds=lms.envs.test`
- `git grep -n -E "enable_audio_description|audio_description_enabled|ENABLE_AUDIO_DESCRIPTION|audioDescriptionEnabled"` → only the `bool(url)` template key remains
- Manual: upload / play / delete an AD file in Studio and LMS with no flag row present


## Ticket
- [LP-1205](https://2u-internal.atlassian.net/browse/LP-1205) 