### PR TITLE
fix: address release-retired-learner-email PR review feedback

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -10,7 +10,6 @@ import ddt
 import pytest
 from completion import models
 from completion.test_utils import CompletionWaffleTestMixin
-from django.conf import settings
 from django.db import connection
 from django.db.models.signals import pre_delete
 from django.test import TestCase
@@ -316,16 +315,16 @@ class ReleaseRetiredLearnerEmailTest(RetirementTestCase):
         return create_retirement_status(user, state=RetirementState.objects.get(state_name=state_name))
 
     def test_releases_email_when_retirement_complete(self):
-        user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
+        user = UserFactory(email='retired__user_abc123@retired.invalid')
         self._retire_user_to_state(user, 'COMPLETE')
 
         release_retired_learner_email(user)
 
         user.refresh_from_db()
-        assert user.email == f'retired__uid_{user.id}@{settings.RETIRED_EMAIL_DOMAIN}'
+        assert user.email == f'retired__uid_{user.id}@retired.invalid'
 
     def test_raises_when_retirement_still_in_progress(self):
-        user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
+        user = UserFactory(email='retired__user_abc123@retired.invalid')
         self._retire_user_to_state(user, 'RETIRING_LMS')
 
         with pytest.raises(RetirementStateError, match=r"retirement is in state 'RETIRING_LMS', not COMPLETE"):
@@ -333,10 +332,10 @@ class ReleaseRetiredLearnerEmailTest(RetirementTestCase):
 
         # A rejected release must not touch the email.
         user.refresh_from_db()
-        assert user.email == f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}'
+        assert user.email == 'retired__user_abc123@retired.invalid'
 
     def test_is_idempotent(self):
-        user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
+        user = UserFactory(email='retired__user_abc123@retired.invalid')
         self._retire_user_to_state(user, 'COMPLETE')
 
         release_retired_learner_email(user)
@@ -348,12 +347,12 @@ class ReleaseRetiredLearnerEmailTest(RetirementTestCase):
         assert user.email == released_email
 
     def test_releases_email_when_status_row_archived(self):
-        user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
+        user = UserFactory(email='retired__user_abc123@retired.invalid')
 
         release_retired_learner_email(user)
 
         user.refresh_from_db()
-        assert user.email == f'retired__uid_{user.id}@{settings.RETIRED_EMAIL_DOMAIN}'
+        assert user.email == f'retired__uid_{user.id}@retired.invalid'
 
     def test_raises_when_user_does_not_appear_retired(self):
         user = UserFactory(email='still.active@example.com')

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -316,7 +316,7 @@ class ReleaseRetiredLearnerEmailTest(RetirementTestCase):
         return create_retirement_status(user, state=RetirementState.objects.get(state_name=state_name))
 
     def test_releases_email_when_retirement_complete(self):
-        user = UserFactory(email='retired__user_abc123@retired.invalid')
+        user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
         self._retire_user_to_state(user, 'COMPLETE')
 
         release_retired_learner_email(user)
@@ -325,7 +325,7 @@ class ReleaseRetiredLearnerEmailTest(RetirementTestCase):
         assert user.email == f'retired__uid_{user.id}@{settings.RETIRED_EMAIL_DOMAIN}'
 
     def test_raises_when_retirement_still_in_progress(self):
-        user = UserFactory(email='retired__user_abc123@retired.invalid')
+        user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
         self._retire_user_to_state(user, 'RETIRING_LMS')
 
         with pytest.raises(RetirementStateError, match=r"retirement is in state 'RETIRING_LMS', not COMPLETE"):
@@ -333,10 +333,10 @@ class ReleaseRetiredLearnerEmailTest(RetirementTestCase):
 
         # A rejected release must not touch the email.
         user.refresh_from_db()
-        assert user.email == 'retired__user_abc123@retired.invalid'
+        assert user.email == f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}'
 
     def test_is_idempotent(self):
-        user = UserFactory(email='retired__user_abc123@retired.invalid')
+        user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
         self._retire_user_to_state(user, 'COMPLETE')
 
         release_retired_learner_email(user)

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -11,7 +11,7 @@ import waffle  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from completion.models import BlockCompletion
 from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.db import transaction
 from django.db.models import CharField, TextField, Value
 from django.db.models.functions import Cast, Concat

--- a/openedx/core/djangoapps/user_api/management/commands/release_retired_user_email.py
+++ b/openedx/core/djangoapps/user_api/management/commands/release_retired_user_email.py
@@ -4,7 +4,7 @@ registration, without touching the archived UserRetirementStatus row.
 """
 import logging
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand, CommandError
 
 from openedx.core.djangoapps.user_api.accounts.utils import release_retired_learner_email
@@ -23,26 +23,16 @@ class Command(BaseCommand):
     help = "Releases a retired learner's email address so it can be reused for a new registration."
 
     def add_arguments(self, parser):
-        # Mutually exclusive + required enforces "exactly one of the two" for us,
-        # so handle() doesn't need to re-validate that itself.
-        identifier = parser.add_mutually_exclusive_group(required=True)
-        identifier.add_argument('--username', type=str, help='Username of the retired learner to release.')
-        identifier.add_argument('--user_id', type=int, help='User ID of the retired learner to release.')
+        # user_id only - avoids taking a username (PII) as input for a retired-learner tool.
+        parser.add_argument('--user_id', type=int, required=True, help='User ID of the retired learner to release.')
 
     def handle(self, *args, **options):
-        username = options['username']
         user_id = options['user_id']
 
-        # Branch on which option was actually supplied (argparse leaves the other as
-        # None), not on truthiness - an explicitly passed empty --username must still
-        # be looked up as itself rather than silently falling through to user_id=None.
-        lookup = {'username': username} if username is not None else {'id': user_id}
         try:
-            user = User.objects.get(**lookup)
+            user = User.objects.get(id=user_id)
         except User.DoesNotExist as exc:
-            # Don't echo the username (PII) back in the error - only user_id is safe to log/print.
-            identifier = 'username' if username is not None else f'user_id={user_id!r}'
-            raise CommandError(f'No user found for the given {identifier}.') from exc
+            raise CommandError(f'No user found for the given user_id={user_id!r}.') from exc
 
         try:
             release_retired_learner_email(user)

--- a/openedx/core/djangoapps/user_api/management/tests/test_release_retired_user_email.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_release_retired_user_email.py
@@ -6,7 +6,6 @@ Test the release_retired_user_email management command
 from unittest.mock import patch
 
 import pytest
-from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.management import CommandError, call_command
 
@@ -26,13 +25,13 @@ def _retire_user(user, state_name):
 
 @patch('openedx.core.djangoapps.user_api.management.commands.release_retired_user_email.logger')
 def test_releases_email_by_user_id(mock_logger, setup_retirement_states):  # pylint: disable=redefined-outer-name, unused-argument
-    user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
+    user = UserFactory(email='retired__user_abc123@retired.invalid')
     _retire_user(user, 'COMPLETE')
 
     call_command('release_retired_user_email', user_id=user.id)
 
     user.refresh_from_db()
-    assert user.email == f'retired__uid_{user.id}@{settings.RETIRED_EMAIL_DOMAIN}'
+    assert user.email == f'retired__uid_{user.id}@retired.invalid'
     mock_logger.info.assert_called_with(f'Successfully released email for user {user.id}.')
 
 
@@ -47,14 +46,14 @@ def test_unknown_user_id():
 
 
 def test_blocked_while_retirement_in_progress(setup_retirement_states):  # pylint: disable=redefined-outer-name, unused-argument
-    user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
+    user = UserFactory(email='retired__user_abc123@retired.invalid')
     _retire_user(user, 'RETIRING_LMS')
 
     with pytest.raises(CommandError, match=r'not COMPLETE'):
         call_command('release_retired_user_email', user_id=user.id)
 
     user.refresh_from_db()
-    assert User.objects.get(id=user.id).email == f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}'
+    assert User.objects.get(id=user.id).email == 'retired__user_abc123@retired.invalid'
 
 
 def test_releases_email_when_status_row_archived():
@@ -63,12 +62,12 @@ def test_releases_email_when_status_row_archived():
     deleted by the partner-report cleanup endpoint), but the email is still in
     the retired-domain format - the command should fall back to that and succeed.
     """
-    user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
+    user = UserFactory(email='retired__user_abc123@retired.invalid')
 
     call_command('release_retired_user_email', user_id=user.id)
 
     user.refresh_from_db()
-    assert user.email == f'retired__uid_{user.id}@{settings.RETIRED_EMAIL_DOMAIN}'
+    assert user.email == f'retired__uid_{user.id}@retired.invalid'
 
 
 def test_raises_when_user_does_not_appear_retired():
@@ -91,7 +90,7 @@ def test_running_twice_is_idempotent(mock_logger, setup_retirement_states):  # p
     A second run against an already-released user must not error - it should
     hit release_retired_learner_email()'s early return and still report success.
     """
-    user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
+    user = UserFactory(email='retired__user_abc123@retired.invalid')
     _retire_user(user, 'COMPLETE')
 
     call_command('release_retired_user_email', user_id=user.id)

--- a/openedx/core/djangoapps/user_api/management/tests/test_release_retired_user_email.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_release_retired_user_email.py
@@ -3,9 +3,11 @@ Test the release_retired_user_email management command
 """
 
 
+from unittest.mock import patch
+
 import pytest
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.management import CommandError, call_command
 
 from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (  # pylint: disable=unused-import
@@ -22,49 +24,37 @@ def _retire_user(user, state_name):
     return create_retirement_status(user, state=RetirementState.objects.get(state_name=state_name))
 
 
-def test_releases_email_by_username(setup_retirement_states, capsys):  # pylint: disable=redefined-outer-name, unused-argument
-    user = UserFactory(email='retired__user_abc123@retired.invalid')
-    _retire_user(user, 'COMPLETE')
-
-    call_command('release_retired_user_email', username=user.username)
-
-    user.refresh_from_db()
-    assert user.email == f'retired__uid_{user.id}@{settings.RETIRED_EMAIL_DOMAIN}'
-    assert 'Successfully released email' in capsys.readouterr().out
-
-
-def test_releases_email_by_user_id(setup_retirement_states):  # pylint: disable=redefined-outer-name, unused-argument
-    user = UserFactory(email='retired__user_abc123@retired.invalid')
+@patch('openedx.core.djangoapps.user_api.management.commands.release_retired_user_email.logger')
+def test_releases_email_by_user_id(mock_logger, setup_retirement_states):  # pylint: disable=redefined-outer-name, unused-argument
+    user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
     _retire_user(user, 'COMPLETE')
 
     call_command('release_retired_user_email', user_id=user.id)
 
     user.refresh_from_db()
     assert user.email == f'retired__uid_{user.id}@{settings.RETIRED_EMAIL_DOMAIN}'
+    mock_logger.info.assert_called_with(f'Successfully released email for user {user.id}.')
 
 
-def test_requires_exactly_one_identifier():
-    with pytest.raises(CommandError, match=r'one of the arguments --username --user_id is required'):
+def test_requires_user_id():
+    with pytest.raises(CommandError, match=r'the following arguments are required: --user_id'):
         call_command('release_retired_user_email')
 
-    with pytest.raises(CommandError, match=r'not allowed with argument'):
-        call_command('release_retired_user_email', username='someone', user_id=1)
 
-
-def test_unknown_user():
-    with pytest.raises(CommandError, match=r'No user found'):
-        call_command('release_retired_user_email', username='nonexistent')
+def test_unknown_user_id():
+    with pytest.raises(CommandError, match=r'No user found for the given user_id=999999'):
+        call_command('release_retired_user_email', user_id=999999)
 
 
 def test_blocked_while_retirement_in_progress(setup_retirement_states):  # pylint: disable=redefined-outer-name, unused-argument
-    user = UserFactory(email='retired__user_abc123@retired.invalid')
+    user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
     _retire_user(user, 'RETIRING_LMS')
 
     with pytest.raises(CommandError, match=r'not COMPLETE'):
-        call_command('release_retired_user_email', username=user.username)
+        call_command('release_retired_user_email', user_id=user.id)
 
     user.refresh_from_db()
-    assert User.objects.get(id=user.id).email == 'retired__user_abc123@retired.invalid'
+    assert User.objects.get(id=user.id).email == f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}'
 
 
 def test_releases_email_when_status_row_archived():
@@ -75,7 +65,7 @@ def test_releases_email_when_status_row_archived():
     """
     user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
 
-    call_command('release_retired_user_email', username=user.username)
+    call_command('release_retired_user_email', user_id=user.id)
 
     user.refresh_from_db()
     assert user.email == f'retired__uid_{user.id}@{settings.RETIRED_EMAIL_DOMAIN}'
@@ -89,36 +79,27 @@ def test_raises_when_user_does_not_appear_retired():
     user = UserFactory(email='still.active@example.com')
 
     with pytest.raises(CommandError, match=r'does not appear to be a retired user'):
-        call_command('release_retired_user_email', username=user.username)
+        call_command('release_retired_user_email', user_id=user.id)
 
     user.refresh_from_db()
     assert user.email == 'still.active@example.com'
 
 
-def test_running_twice_is_idempotent(setup_retirement_states, capsys):  # pylint: disable=redefined-outer-name, unused-argument
+@patch('openedx.core.djangoapps.user_api.management.commands.release_retired_user_email.logger')
+def test_running_twice_is_idempotent(mock_logger, setup_retirement_states):  # pylint: disable=redefined-outer-name, unused-argument
     """
     A second run against an already-released user must not error - it should
     hit release_retired_learner_email()'s early return and still report success.
     """
-    user = UserFactory(email='retired__user_abc123@retired.invalid')
+    user = UserFactory(email=f'retired__user_abc123@{settings.RETIRED_EMAIL_DOMAIN}')
     _retire_user(user, 'COMPLETE')
 
-    call_command('release_retired_user_email', username=user.username)
+    call_command('release_retired_user_email', user_id=user.id)
     user.refresh_from_db()
     released_email = user.email
 
-    call_command('release_retired_user_email', username=user.username)
+    call_command('release_retired_user_email', user_id=user.id)
 
     user.refresh_from_db()
     assert user.email == released_email
-    assert 'Successfully released email' in capsys.readouterr().out
-
-
-def test_unknown_user_id():
-    """
-    Mirrors test_unknown_user, but for the --user_id branch: the error message
-    is built from a separate f'user_id={user_id!r}' f-string that the
-    username-only test above never exercises.
-    """
-    with pytest.raises(CommandError, match=r'No user found for the given user_id=999999'):
-        call_command('release_retired_user_email', user_id=999999)
+    mock_logger.info.assert_called_with(f'Successfully released email for user {user.id}.')


### PR DESCRIPTION
## Description

Follow-up to [#460](https://github.com/edx/edx-platform/pull/460) addressing the review comments that were
still open when that PR merged into `release-ulmo`. No new behavior is introduced `release_retired_learner_email()`
itself is unchanged. This is cleanup of the surrounding code and tests, plus one CLI interface change:

- **Removed `--username` from the `release_retired_user_email` management command.** Per review feedback, a
  tool built for retired learners shouldn't accept a username (PII-shaped input) at all `--user_id` is now the
  only supported identifier. **This is a breaking change for anyone already scripting the old `--username` flag.**
- Dropped the `lint-amnesty` tag on the `User` import in `accounts/utils.py` and in the management command —
  it's slated for removal from openedx altogether, so it shouldn't be copied into new files.
- Test setup emails now use `settings.RETIRED_EMAIL_DOMAIN` instead of a hardcoded `retired.invalid`, matching
  the assertions in the same tests and removing the inconsistency flagged in review.
- Switched the command's two "success message" tests from asserting against captured stdout (`capsys`) to
  mocking the logger (`mock_logger.info.assert_called_with(...)`), matching the existing pattern in
  `common/djangoapps/student/management/tests/test_change_enrollment.py`.

## Supporting information

- [LP-1177](https://openedx.atlassian.net/browse/LP-1177) (private)
- Original PR: [#460](https://github.com/edx/edx-platform/pull/460)

## Testing instructions

1. Retire a test user to the `COMPLETE` state.
2. `is_email_retired("learner@example.com")` => `True`.
3. `./manage.py lms release_retired_user_email --user_id <retired_user_id>`
4. `is_email_retired("learner@example.com")` => `False`; confirm re-registration succeeds.
5. Confirm the old `--username <retired_username>` form now fails with an "unrecognized arguments" error.
6. `pytest openedx/core/djangoapps/user_api/accounts/tests/test_utils.py openedx/core/djangoapps/user_api/management/tests/test_release_retired_user_email.py`

## Deadline

None.

## Other information

- Depends on / follows up: #460, already merged into `release-ulmo`.
- Breaking change: any existing script or runbook using `release_retired_user_email --username <...>` must
  switch to `--user_id <...>`.
- No database migration involved.