### PR TITLE
feat: hydrate learner state for paginated assessment children

### DIFF
--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -1176,9 +1176,51 @@ def _allowed_child_usage_keys(parent):
     get_child_blocks = getattr(parent, 'get_child_blocks', None)
     if callable(has_dynamic_children) and has_dynamic_children() and callable(get_child_blocks):
         children = get_child_blocks()
-    else:
-        children = parent.get_children()
+        return {child.location for child in children if child is not None}
+
+    # ``children`` is a content-scoped field containing UsageKeys. Reading it does not
+    # instantiate/bind the child blocks. Calling ``parent.get_children()`` here would
+    # create child instances through the parent's shallow field-data cache; those
+    # instances must not later be rendered with a different learner-state cache.
+    child_usage_keys = getattr(parent, 'children', None)
+    if isinstance(child_usage_keys, (list, tuple)):
+        return {child_usage_key for child_usage_key in child_usage_keys if child_usage_key is not None}
+
+    # Keep compatibility with XBlocks that do not expose their children as a normal
+    # UsageKey list (and with older test doubles). This fallback is only an access check;
+    # the endpoint still resolves the objects it renders from the modulestore below.
+    children = parent.get_children()
     return {child.location for child in children if child is not None}
+
+
+def _load_unbound_child_descriptors(child_usage_keys, parent=None):
+    """
+    Resolve child usage keys to fresh, unbound XBlock descriptors.
+
+    The parent is intentionally not used for this lookup. A parent loaded with a shallow
+    FieldDataCache can already have child instances bound to that cache. Reusing one of
+    those instances and then passing a second cache to ``get_block_for_descriptor`` is
+    unsafe because ``bind_for_student`` skips rebinding when the user id is unchanged.
+
+    ``parent`` is optional and is used only to carry over the runtime's export filesystem
+    setting, which ``XModuleMixin.get_child()`` normally copies to child instances.
+    """
+    descriptors = {}
+    missing = []
+    store = modulestore()
+    for child_usage_key in child_usage_keys:
+        try:
+            descriptor = store.get_item(child_usage_key)
+        except ItemNotFoundError:
+            missing.append(child_usage_key)
+            continue
+        if descriptor is None:
+            missing.append(child_usage_key)
+            continue
+        if parent is not None:
+            descriptor.runtime.export_fs = parent.runtime.export_fs
+        descriptors[child_usage_key] = descriptor
+    return descriptors, missing
 
 
 def _lazy_child_student_view_context(request):
@@ -1243,11 +1285,9 @@ def render_xblock_children(request, parent_usage_key, child_usage_keys, course=N
             will_recheck_access=True,
         )
 
-        allowed_keys = _allowed_child_usage_keys(parent)
-        children_by_key = {child.location: child for child in parent.get_children() if child is not None}
-
         requested = []
         errors = []
+        allowed_keys = _allowed_child_usage_keys(parent)
         for child_key in child_usage_keys:
             if child_key in allowed_keys:
                 requested.append(child_key)
@@ -1262,58 +1302,38 @@ def render_xblock_children(request, parent_usage_key, child_usage_keys, course=N
         if not requested:
             return {'parent_usage_key': str(parent_usage_key), 'results': results, 'errors': errors}
 
+        # Resolve from the modulestore rather than reusing parent.get_children() instances.
+        # The latter may already be bound to the parent's depth-0 cache for this same user.
+        # Those instances would then skip rebinding when get_block_for_descriptor() is
+        # called with the batch cache, causing a valid StudentModule row to look absent.
+        children_by_key, missing_keys = _load_unbound_child_descriptors(requested, parent=parent)
+        for child_key in missing_keys:
+            errors.append({
+                'usage_key': str(child_key),
+                'error': 'not_found',
+                'message': 'Block could not be loaded.',
+            })
+
+        renderable_children = [
+            children_by_key[child_key] for child_key in requested if child_key in children_by_key
+        ]
+
         # One cache for the whole batch, not one per child. Depth=1 pulls in each child's
         # own selected problem (for library_content/item_bank children) without recursing
         # further -- matching the shape FieldDataCache._children_to_prefetch already
-        # narrows to for such blocks.
+        # narrows to for such blocks. The batch helper performs one state lookup for the
+        # complete set instead of one get_many() call per child.
         field_data_cache = FieldDataCache([], course_key, user, read_only=CrawlersConfig.is_crawler(request))
-        for child_key in requested:
-            child = children_by_key.get(child_key)
-            if child is None:
-                errors.append({
-                    'usage_key': str(child_key),
-                    'error': 'not_found',
-                    'message': 'Block could not be loaded.',
-                })
-                continue
-            field_data_cache.add_block_descendents(child, depth=1)
+        field_data_cache.add_block_descendents_batch(renderable_children, depth=1)
 
-        # Both computed once for the whole batch, not per child, matching how
-        # VerticalBlock computes them once for its own eager-rendered children.
-        block_has_access_error = getattr(parent, 'block_has_access_error', None)
-        completion_service = parent.runtime.service(parent, 'completion')
-        child_blocks_to_complete_on_view = set()
-        complete_on_view_delay = None
-        if completion_service and completion_service.completion_tracking_enabled():
-            requested_children = [
-                children_by_key[child_key] for child_key in requested if child_key in children_by_key
-            ]
-            child_blocks_to_complete_on_view = completion_service.blocks_to_mark_complete_on_view(
-                requested_children
-            )
-            complete_on_view_delay = completion_service.get_complete_on_view_delay_ms()
-
+        # Bind each fresh descriptor exactly once, after the cache containing the learner's
+        # state has been populated. Besides fixing state hydration, doing this before the
+        # completion/access pass keeps those checks aligned with the eventual render.
+        instances_by_key = {}
         for child_key in requested:
             child = children_by_key.get(child_key)
             if child is None:
                 continue
-
-            child_context = _lazy_child_student_view_context(request)
-            if (
-                child_context.get('hide_access_error_blocks')
-                and callable(block_has_access_error)
-                and block_has_access_error(child)
-            ):
-                # Matches VerticalBlock's own eager-render skip (block_has_access_error):
-                # a block gated for this learner must stay hidden whether it renders
-                # inline or gets lazy-loaded later.
-                results.append({'usage_key': str(child_key), 'html': ''})
-                continue
-            if child in child_blocks_to_complete_on_view:
-                child_context['wrap_xblock_data'] = {
-                    'mark-completed-on-view-after-delay': complete_on_view_delay
-                }
-
             try:
                 instance = get_block_for_descriptor(
                     user,
@@ -1324,13 +1344,68 @@ def render_xblock_children(request, parent_usage_key, child_usage_keys, course=N
                     course=course,
                     will_recheck_access=True,
                 )
-                if instance is None:
-                    errors.append({
-                        'usage_key': str(child_key),
-                        'error': 'forbidden',
-                        'message': 'Learner does not have access to this block.',
-                    })
-                    continue
+            except Exception as exc:  # pylint: disable=broad-except
+                log.exception('Incremental load: child %s under %s failed to bind', child_key, parent_usage_key)
+                errors.append({
+                    'usage_key': str(child_key),
+                    'error': 'render_failed',
+                    'message': str(exc),
+                })
+                continue
+            if instance is None:
+                errors.append({
+                    'usage_key': str(child_key),
+                    'error': 'forbidden',
+                    'message': 'Learner does not have access to this block.',
+                })
+                continue
+            log.debug(
+                'Incremental load: bound child %s for parent %s with the batch state cache; '
+                'user_id before=%s after=%s',
+                child_key,
+                parent_usage_key,
+                getattr(child.scope_ids, 'user_id', None),
+                getattr(instance.scope_ids, 'user_id', None),
+            )
+            instances_by_key[child_key] = instance
+
+        # Both computed once for the whole batch, not per child, matching how
+        # VerticalBlock computes them once for its own eager-rendered children.
+        block_has_access_error = getattr(parent, 'block_has_access_error', None)
+        completion_service = parent.runtime.service(parent, 'completion')
+        child_blocks_to_complete_on_view = set()
+        complete_on_view_delay = None
+        if completion_service and completion_service.completion_tracking_enabled():
+            requested_children = [
+                instances_by_key[child_key] for child_key in requested if child_key in instances_by_key
+            ]
+            child_blocks_to_complete_on_view = completion_service.blocks_to_mark_complete_on_view(
+                requested_children
+            )
+            complete_on_view_delay = completion_service.get_complete_on_view_delay_ms()
+
+        for child_key in requested:
+            instance = instances_by_key.get(child_key)
+            if instance is None:
+                continue
+
+            child_context = _lazy_child_student_view_context(request)
+            if (
+                child_context.get('hide_access_error_blocks')
+                and callable(block_has_access_error)
+                and block_has_access_error(instance)
+            ):
+                # Matches VerticalBlock's own eager-render skip (block_has_access_error):
+                # a block gated for this learner must stay hidden whether it renders
+                # inline or gets lazy-loaded later.
+                results.append({'usage_key': str(child_key), 'html': ''})
+                continue
+            if instance in child_blocks_to_complete_on_view:
+                child_context['wrap_xblock_data'] = {
+                    'mark-completed-on-view-after-delay': complete_on_view_delay
+                }
+
+            try:
                 instance, child_context = VerticalBlockChildRenderStarted.run_filter(
                     block=instance,
                     context=child_context

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -732,6 +732,24 @@ class FieldDataCache:
                 should be cached
         """
 
+        self.add_block_descendents_batch([block], depth=depth, block_filter=block_filter)
+
+    def add_block_descendents_batch(self, blocks, depth=None, block_filter=lambda block: True):
+        """
+        Add descendants of several blocks in one state-cache population operation.
+
+        This is the batch equivalent of :meth:`add_block_descendents`. It is useful for
+        endpoints that render several sibling blocks independently: walking each sibling
+        separately and calling ``add_blocks_to_cache`` each time causes one user-state
+        lookup per sibling even though all of the data belongs to the same request.
+
+        The supplied blocks must belong to the same course as this cache. Duplicate usage
+        keys are removed before the fields are read so shared required descriptors do not
+        cause duplicate work.
+        """
+        if not blocks:
+            return
+
         def get_child_blocks(block, depth, block_filter):
             """
             Return a list of all child blocks down to the specified depth
@@ -755,10 +773,16 @@ class FieldDataCache:
 
             return blocks
 
-        with modulestore().bulk_operations(block.location.course_key):
-            blocks = get_child_blocks(block, depth, block_filter)
+        blocks_to_cache = []
+        seen_locations = set()
+        with modulestore().bulk_operations(blocks[0].location.course_key):
+            for block in blocks:
+                for descendant in get_child_blocks(block, depth, block_filter):
+                    if descendant.location not in seen_locations:
+                        seen_locations.add(descendant.location)
+                        blocks_to_cache.append(descendant)
 
-        self.add_blocks_to_cache(blocks)
+        self.add_blocks_to_cache(blocks_to_cache)
 
     def _children_to_prefetch(self, block):
         """

--- a/lms/djangoapps/courseware/tests/test_incremental_render.py
+++ b/lms/djangoapps/courseware/tests/test_incremental_render.py
@@ -6,9 +6,11 @@ from unittest.mock import Mock, patch
 
 from django.test import RequestFactory, TestCase, override_settings
 from opaque_keys.edx.locator import CourseLocator
+from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from lms.djangoapps.courseware.block_render import (
     _allowed_child_usage_keys,
+    _load_unbound_child_descriptors,
     _lazy_child_student_view_context,
     count_renderable_descendants,
     should_use_incremental_load,
@@ -134,6 +136,14 @@ class AllowedChildUsageKeysTests(TestCase):
         parent = _block('vertical', children=children)
         assert _allowed_child_usage_keys(parent) == {child.location for child in children}
 
+    def test_static_parent_uses_content_keys_without_instantiating_children(self):
+        children = [_block('problem'), _block('problem')]
+        parent = _block('vertical')
+        parent.children = [child.location for child in children]
+        parent.get_children.side_effect = AssertionError('static children must not be instantiated')
+
+        assert _allowed_child_usage_keys(parent) == {child.location for child in children}
+
     def test_dynamic_parent_exposes_only_the_learner_selection(self):
         # A learner must not be able to pull problems the bank did not assign them.
         selected = _block('problem')
@@ -149,6 +159,39 @@ class AllowedChildUsageKeysTests(TestCase):
         good = _block('problem')
         parent = _block('vertical', children=[good, None])
         assert _allowed_child_usage_keys(parent) == {good.location}
+
+
+class UnboundChildDescriptorTests(TestCase):
+    """Tests for resolving lazy children independently of a parent instance cache."""
+
+    def test_resolves_requested_keys_without_using_parent_children(self):
+        first_key = COURSE_KEY.make_usage_key('problem', 'first')
+        second_key = COURSE_KEY.make_usage_key('problem', 'second')
+        first_descriptor = Mock()
+        second_descriptor = Mock()
+        store = Mock()
+        store.get_item.side_effect = [first_descriptor, second_descriptor]
+
+        with patch('lms.djangoapps.courseware.block_render.modulestore', return_value=store):
+            descriptors, missing = _load_unbound_child_descriptors([first_key, second_key])
+
+        assert list(descriptors) == [first_key, second_key]
+        assert descriptors[first_key] is first_descriptor
+        assert descriptors[second_key] is second_descriptor
+        assert not missing
+
+    def test_reports_missing_descriptor_without_aborting_the_batch(self):
+        existing_key = COURSE_KEY.make_usage_key('problem', 'existing')
+        missing_key = COURSE_KEY.make_usage_key('problem', 'missing')
+        existing_descriptor = Mock()
+        store = Mock()
+        store.get_item.side_effect = [existing_descriptor, ItemNotFoundError()]
+
+        with patch('lms.djangoapps.courseware.block_render.modulestore', return_value=store):
+            descriptors, missing = _load_unbound_child_descriptors([existing_key, missing_key])
+
+        assert descriptors == {existing_key: existing_descriptor}
+        assert missing == [missing_key]
 
 
 class LazyChildStudentViewContextTests(TestCase):

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -564,3 +564,27 @@ class TestFieldDataCacheDynamicChildren(TestCase):
 
         parent.get_children.assert_called_once()
         parent.get_child.assert_not_called()
+
+    def test_batch_descendent_prefetch_populates_the_cache_once(self):
+        """
+        Sibling lazy children share one user-state lookup instead of triggering one
+        cache population call per child.
+        """
+        first = mock_block()
+        first.location = COURSE_KEY.make_usage_key('problem', 'first')
+        first.has_dynamic_children.return_value = False
+        first.get_children.return_value = []
+        first.get_required_block_descriptors.return_value = []
+
+        second = mock_block()
+        second.location = COURSE_KEY.make_usage_key('problem', 'second')
+        second.has_dynamic_children.return_value = False
+        second.get_children.return_value = []
+        second.get_required_block_descriptors.return_value = []
+
+        cache = FieldDataCache([], COURSE_KEY, self.user)
+        with patch.object(cache, 'add_blocks_to_cache') as add_blocks_to_cache:
+            cache.add_block_descendents_batch([first, second], depth=1)
+
+        add_blocks_to_cache.assert_called_once()
+        assert add_blocks_to_cache.call_args.args[0] == [first, second]

--- a/lms/templates/vert_module_lazy_bootstrap.html
+++ b/lms/templates/vert_module_lazy_bootstrap.html
@@ -115,6 +115,42 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         initializeChild(el);
     }
 
+    function markChildError(usageKey, message) {
+        var el = container.querySelector('[data-usage-key="' + usageKey + '"]');
+        if (!el) {
+            return;
+        }
+
+        el.innerHTML = '';
+        el.classList.remove('vert-lazy-pending');
+        el.classList.add('vert-lazy-error');
+        el.setAttribute('aria-busy', 'false');
+        el.setAttribute('role', 'alert');
+
+        var messageEl = document.createElement('span');
+        messageEl.textContent = message || messages.failed;
+        el.appendChild(messageEl);
+
+        var retryButton = document.createElement('button');
+        retryButton.type = 'button';
+        retryButton.className = 'btn btn-link vert-lazy-retry';
+        retryButton.textContent = messages.retry;
+        retryButton.addEventListener('click', function () {
+            el.innerHTML = '';
+            el.classList.remove('vert-lazy-error');
+            el.classList.add('vert-lazy-pending');
+            el.removeAttribute('role');
+            el.setAttribute('aria-busy', 'true');
+            reportProgress();
+            loadBatch([usageKey]).catch(function (err) {
+                markChildError(usageKey, err.message);
+                reportProgress();
+            });
+        });
+        el.appendChild(document.createTextNode(' '));
+        el.appendChild(retryButton);
+    }
+
     function fetchBatch(keys) {
         var url = endpoint + '?child_usage_keys=' + encodeURIComponent(keys.join(','));
         var controller = window.AbortController ? new window.AbortController() : null;
@@ -167,6 +203,9 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         return fetchBatch(keys).then(function (data) {
             (data.results || []).forEach(function (result) {
                 fillChild(result.usage_key, result.html);
+            });
+            (data.errors || []).forEach(function (error) {
+                markChildError(error.usage_key, error.message);
             });
             postResize();
             reportProgress();

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -13,9 +13,11 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from edx_django_utils.cache import TieredCache
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
+from xmodule.capa.tests.response_xml_factory import OptionResponseXMLFactory
 from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -45,6 +47,7 @@ from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import CourseEnrollmentCelebrationFactory, UserFactory
 from openedx.core.djangoapps.agreements.api import create_integrity_signature
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from openedx.core.lib.url_utils import quote_slashes
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
 
 User = get_user_model()
@@ -531,6 +534,46 @@ class XBlockChildrenApiTestViews(BaseCoursewareTests):
         assert returned_keys == {str(child.location) for child in self.children}
         for result in data['results']:
             assert result['html']
+
+    def test_batch_renders_persisted_problem_state(self):
+        """
+        A problem rendered after the eager window must use the same StudentModule state
+        as the normal problem handler, rather than appearing as a fresh attempt.
+        """
+        problem_xml = OptionResponseXMLFactory().build_xml(
+            question_text='The correct answer is Correct',
+            num_inputs=1,
+            weight=1,
+            options=['Correct', 'Incorrect'],
+            correct_option='Correct',
+        )
+        problem = BlockFactory.create(
+            parent_location=self.unit.location,
+            category='problem',
+            data=problem_xml,
+            display_name='persisted-problem',
+        )
+
+        problem_check_url = reverse(
+            'xblock_handler',
+            kwargs={
+                'course_id': str(self.course.id),
+                'usage_id': quote_slashes(str(problem.location)),
+                'handler': 'xmodule_handler',
+                'suffix': 'problem_check',
+            },
+        )
+        answer_key = f'input_{problem.location.html_id()}_2_1'
+        submit_response = self.client.post(problem_check_url, {answer_key: 'Correct'})
+        assert submit_response.status_code == 200
+
+        response = self.client.get(self.url, {'child_usage_keys': str(problem.location)})
+        assert response.status_code == 200
+        data = response.json()
+        assert not data['errors']
+        rendered_html = data['results'][0]['html']
+        assert 'data-attempts-used="1"' in rendered_html
+        assert answer_key in rendered_html
 
     def test_batch_requires_authentication(self):
         self.client.logout()


### PR DESCRIPTION
## Summary

Fixes CR-8239, where incrementally loaded assessment questions could appear unanswered even though the learner’s attempt state existed in `StudentModule`.

When the learner submitted the question again, the backend detected the existing attempt and returned:

> The state of this problem has changed since you loaded this page.

## Root cause

Lazy children were obtained through `parent.get_children()` and could already be bound to the parent’s shallow field-data cache. When the endpoint later supplied the correct batch cache, `bind_for_student()` skipped rebinding because the user ID was unchanged. As a result, the question rendered with default state instead of the learner’s persisted answer and attempt count.

## Changes

- Resolve lazy children as fresh, unbound modulestore descriptors.
- Hydrate the learner state cache before binding and rendering children.
- Batch descendant state loading to avoid one state lookup per child.
- Preserve dynamic child selection, access checks, completion behavior, masquerading, and usage-key ordering.
- Display and retry individual lazy-load failures in the frontend.
- Add regression coverage for persisted problem state and batch cache population.