### PR TITLE
docs: document transcript upload response codes [LP-910]

### DIFF
--- a/cms/djangoapps/contentstore/transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/transcript_storage_handlers.py
@@ -169,12 +169,19 @@ def _create_or_update_video_transcript(**kwargs):
 
 def upload_transcript(request):
     """
-    Upload a transcript file
+    Upload a transcript file for a video, creating or replacing the transcript
+    for ``new_language_code``.
 
     Arguments:
-        request: A WSGI request object
+        request: A WSGI request object. ``request.POST`` must contain
+            ``edx_video_id``, ``language_code`` (the language of the transcript
+            being replaced, if any) and ``new_language_code``; ``request.FILES``
+            must contain the transcript ``file`` in SRT (SubRip) format.
 
-        Transcript file in SRT format
+    Returns:
+        - 201 Created if no transcript existed for ``new_language_code`` yet.
+        - 200 OK if an existing transcript for ``new_language_code`` was replaced.
+        - 400 Bad Request if the file could not be parsed as SRT or decoded as UTF-8.
     """
     edx_video_id = request.POST['edx_video_id']
     language_code = request.POST['language_code']

--- a/cms/djangoapps/contentstore/views/transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/transcript_settings.py
@@ -108,8 +108,11 @@ def transcript_upload_handler(request):
     Transcript file should be in SRT(SubRip) format.
 
     Returns
-        - A 400 if any of the validation fails
-        - A 200 if transcript has been uploaded successfully
+        - A 400 if any of the validation fails: a required parameter or the file is
+          missing, ``new_language_code`` already has a transcript when it differs from
+          ``language_code``, or the file is not valid SRT / UTF-8.
+        - A 201 if a transcript was created for a language that had none.
+        - A 200 if an existing transcript for that language was replaced.
     """
     error = validate_transcript_upload_data(data=request.POST, files=request.FILES)
     if error:


### PR DESCRIPTION
Mirrors https://github.com/openedx/openedx-platform/pull/39090, the follow-up Robert requested after merging
#39038: the transcript upload endpoint's return values are documented in the API docstrings
instead of only in an inline comment. Keeps the fork a no-op against upstream for these files.

- `transcript_upload_handler`: `Returns` now lists 400 (validation failure - missing
  parameter or file, `new_language_code` already has a transcript when it differs from
  `language_code`, or invalid SRT / UTF-8), 201 (transcript created), 200 (existing
  transcript replaced). The previous text said "200 if uploaded successfully".
- `upload_transcript`: documents the request contract and the same 201 / 200 / 400 outcomes.

Docstring-only; no behavior change.

## Supporting information
- Upstream original change: openedx/openedx-platform#39038 (fork parity landed)
- Jira: https://2u-internal.atlassian.net/browse/LP-910

## Testing instructions

No functional change.

```
pytest cms/djangoapps/contentstore/views/tests/test_transcript_settings.py -q
```

## Deadline

None.

## Other information

No migrations, no settings changes, no deploy effect.
