### PR TITLE
fix: replace user identity strings with user IDs (#38775)

### DIFF
--- a/cms/djangoapps/course_creators/admin.py
+++ b/cms/djangoapps/course_creators/admin.py
@@ -158,8 +158,11 @@ def send_user_notification_callback(sender, **kwargs):  # pylint: disable=unused
 
     try:
         user.email_user(subject, message, studio_request_email)
-    except:  # lint-amnesty, pylint: disable=bare-except
-        log.warning("Unable to send course creator status e-mail to %s", user.email)
+    except:  # pylint: disable=bare-except
+        user_identifier_for_log = (
+            user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.email
+        )
+        log.warning("Unable to send course creator status e-mail to %s", user_identifier_for_log)
 
 
 @receiver(send_admin_notification, sender=CourseCreator)
@@ -169,8 +172,9 @@ def send_admin_notification_callback(sender, **kwargs):  # pylint: disable=unuse
     """
     user = kwargs['user']
 
-    studio_request_email = settings.FEATURES.get('STUDIO_REQUEST_EMAIL', '')
-    context = {'user_name': user.username, 'user_email': user.email}
+    # studio_request_email is a system email address, not PII, which can safely be logged.
+    context = course_creator_notification_context(user)
+    studio_request_email = context['studio_request_email']
 
     subject = render_to_string('emails/course_creator_admin_subject.txt', context)
     subject = ''.join(subject.splitlines())
@@ -185,7 +189,14 @@ def send_admin_notification_callback(sender, **kwargs):  # pylint: disable=unuse
             fail_silently=False
         )
     except SMTPException:
-        log.warning("Failure sending 'pending state' e-mail for %s to %s", user.email, studio_request_email)
+        user_identifier_for_log = (
+            user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.email
+        )
+        log.warning(
+            "Failure sending 'pending state' e-mail for %s to %s",
+            user_identifier_for_log,
+            studio_request_email,
+        )
 
 
 @receiver(m2m_changed, sender=CourseCreator.organizations.through)

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -3,6 +3,7 @@ Tests course_creators.admin.py.
 """
 
 
+from smtplib import SMTPException
 from unittest import mock
 
 from django.contrib.admin.sites import AdminSite
@@ -55,6 +56,7 @@ class CourseCreatorAdminTest(TestCase):
             "ENABLE_CREATOR_GROUP": True,
             "STUDIO_REQUEST_EMAIL": self.studio_request_email
         }
+        self.enable_creator_group_patch = {'ENABLE_CREATOR_GROUP': True}
 
     @mock.patch(
         'cms.djangoapps.course_creators.admin.render_to_string',
@@ -175,4 +177,57 @@ class CourseCreatorAdminTest(TestCase):
         self.assertTrue(self.creator_admin.has_change_permission(self.request))
 
         self.request.user = self.user
-        self.assertFalse(self.creator_admin.has_change_permission(self.request))
+        self.assertFalse(self.creator_admin.has_change_permission(self.request))  # noqa: PT009
+
+    @override_settings(ENABLE_CREATOR_GROUP=True, STUDIO_REQUEST_EMAIL='mark@marky.mark')
+    @mock.patch('cms.djangoapps.course_creators.admin.log')
+    @mock.patch('django.contrib.auth.models.User.email_user')
+    def test_send_user_notification_error_logging(self, mock_email_user, mock_log):
+        """
+        Test that email_user raising an exception logs the correct message based on SQUELCH_PII_IN_LOGS setting.
+        """
+        mock_email_user.side_effect = Exception("SMTP error")
+
+        def test_and_assert_case(squelch_pii, states):
+            mock_log.reset_mock()
+            with self.settings(SQUELCH_PII_IN_LOGS=squelch_pii), mock.patch.dict(
+                'django.conf.settings.FEATURES', self.enable_creator_group_patch
+            ):
+                for state in states:
+                    self._change_state(state)
+                expected_identifier = self.user.id if squelch_pii else self.user.email
+                mock_log.warning.assert_any_call(
+                    "Unable to send course creator status e-mail to %s",
+                    expected_identifier
+                )
+
+        test_and_assert_case(True, [CourseCreator.GRANTED])
+        # True case moved the object to GRANTED; False case needs DENIED -> GRANTED to retrigger.
+        test_and_assert_case(False, [CourseCreator.DENIED, CourseCreator.GRANTED])
+
+    @override_settings(ENABLE_CREATOR_GROUP=True, STUDIO_REQUEST_EMAIL='mark@marky.mark')
+    @mock.patch('cms.djangoapps.course_creators.admin.log')
+    @mock.patch('cms.djangoapps.course_creators.admin.send_mail')
+    def test_send_admin_notification_error_logging(self, mock_send_mail, mock_log):
+        """
+        Test that send_mail raising SMTPException logs the correct message based on SQUELCH_PII_IN_LOGS setting.
+        """
+        mock_send_mail.side_effect = SMTPException("SMTP error")
+
+        def test_and_assert_case(squelch_pii, states):
+            mock_log.reset_mock()
+            with self.settings(SQUELCH_PII_IN_LOGS=squelch_pii), mock.patch.dict(
+                'django.conf.settings.FEATURES', self.enable_creator_group_patch
+            ):
+                for state in states:
+                    self._change_state(state)
+                expected_identifier = self.user.id if squelch_pii else self.user.email
+                mock_log.warning.assert_any_call(
+                    "Failure sending 'pending state' e-mail for %s to %s",
+                    expected_identifier,
+                    self.studio_request_email
+                )
+
+        test_and_assert_case(True, [CourseCreator.PENDING])
+        # True case left the object at PENDING; False case needs UNREQUESTED -> PENDING to retrigger.
+        test_and_assert_case(False, [CourseCreator.UNREQUESTED, CourseCreator.PENDING])

--- a/common/djangoapps/student/emails.py
+++ b/common/djangoapps/student/emails.py
@@ -27,8 +27,10 @@ def send_proctoring_requirements_email(context):
             user_context={'full_name': user.profile.name}
         )
         ace.send(msg)
-        log.info('Proctoring requirements email sent to user: %r', user.username)
+        user_identifier_for_log = user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.username
+        log.info('Proctoring requirements email sent to user %s', user_identifier_for_log)
         return True
     except Exception:  # pylint: disable=broad-except
-        log.exception('Could not send email for proctoring requirements to user %s', user.username)
+        user_identifier_for_log = user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.username
+        log.exception('Could not send email for proctoring requirements to user %s', user_identifier_for_log)
         return False

--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -673,10 +673,13 @@ class CourseEnrollment(models.Model):
 
         except Exception:  # pylint: disable=broad-except
             if event_name and self.course_id:
+                user_identifier_for_log = (
+                    self.user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else self.user.username
+                )
                 log.exception(
                     'Unable to emit event %s for user %s and course %s',
                     event_name,
-                    self.user.username,
+                    user_identifier_for_log,
                     self.course_id,
                 )
 
@@ -740,39 +743,55 @@ class CourseEnrollment(models.Model):
                 course_key=course.id,
                 display_name=course.display_name,
             )
-        except CourseOverview.DoesNotExist:
+        except CourseOverview.DoesNotExist as err:
             # This is here to preserve legacy behavior which allowed enrollment in courses
             # announced before the start of content creation.
             course_data = CourseData(
                 course_key=course_key,
             )
             if check_access:
-                log.warning("User %s failed to enroll in non-existent course %s", user.username, str(course_key))
-                raise NonExistentCourseError  # lint-amnesty, pylint: disable=raise-missing-from
+                user_identifier_for_log = (
+                    user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.username
+                )
+                log.warning(
+                    "User %s failed to enroll in non-existent course %s",
+                    user_identifier_for_log,
+                    str(course_key),
+                )
+                raise NonExistentCourseError from err
 
         if check_access:
             if cls.is_enrollment_closed(user, course) and not can_upgrade:
+                user_identifier_for_log = (
+                    user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.username
+                )
                 log.warning(
                     "User %s failed to enroll in course %s because enrollment is closed (can_upgrade=%s).",
-                    user.username,
+                    user_identifier_for_log,
                     str(course_key),
                     can_upgrade,
                 )
                 raise EnrollmentClosedError
 
             if cls.objects.is_course_full(course):
+                user_identifier_for_log = (
+                    user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.username
+                )
                 log.warning(
                     "Course %s has reached its maximum enrollment of %d learners. User %s failed to enroll.",
                     str(course_key),
                     course.max_student_enrollments_allowed,
-                    user.username,
+                    user_identifier_for_log,
                 )
                 raise CourseFullError
         if cls.is_enrolled(user, course_key):
+            user_identifier_for_log = (
+                user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.username
+            )
             log.warning(
                 "User %s attempted to enroll in %s, but they were already enrolled",
-                user.username,
-                str(course_key)
+                user_identifier_for_log,
+                str(course_key),
             )
             if check_access:
                 raise AlreadyEnrolledError
@@ -837,8 +856,8 @@ class CourseEnrollment(models.Model):
             user = User.objects.get(email=email)
             return cls.enroll(user, course_id, mode)
         except User.DoesNotExist:
-            err_msg = "Tried to enroll email {} into course {}, but user not found"
-            log.error(err_msg.format(email, course_id))
+            email_for_log = "[REDACTED]" if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else email
+            log.error("Tried to enroll email %s into course %s, but user not found", email_for_log, course_id)
             if ignore_errors:
                 return None
             raise

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -887,7 +887,12 @@ class Registration(models.Model):
         self.activation_timestamp = datetime.utcnow()
         self.save()
         USER_ACCOUNT_ACTIVATED.send_robust(self.__class__, user=self.user)
-        log.info('User %s (%s) account is successfully activated.', self.user.username, self.user.email)
+        user_identifier_for_log = (
+            self.user.id
+            if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+            else f'{self.user.username}, {self.user.email}'
+        )
+        log.info('User %s account is successfully activated.', user_identifier_for_log)
 
 
 class PendingNameChange(DeletableByUserValue, models.Model):
@@ -1313,10 +1318,11 @@ def log_successful_login(sender, request, user, **kwargs):  # lint-amnesty, pyli
             'event_type': "login",
         }
     )
-    if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-        AUDIT_LOG.info(f"Login success - user.id: {user.id}")
-    else:
-        AUDIT_LOG.info(f"Login success - {user.username} ({user.email})")
+    user_identifier_for_log = (
+        user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+        else f"{user.username} ({user.email})"
+    )
+    AUDIT_LOG.info(f"Login success - {user_identifier_for_log}")
 
 
 @receiver(user_logged_out)
@@ -1330,10 +1336,11 @@ def log_successful_logout(sender, request, user, **kwargs):  # lint-amnesty, pyl
                 'event_type': "logout",
             }
         )
-        if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-            AUDIT_LOG.info(f'Logout - user.id: {request.user.id}')  # pylint: disable=logging-format-interpolation
-        else:
-            AUDIT_LOG.info(f'Logout - {request.user}')  # pylint: disable=logging-format-interpolation
+        user_identifier_for_log = (
+            request.user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+            else request.user
+        )
+        AUDIT_LOG.info(f'Logout - {user_identifier_for_log}')  # pylint: disable=logging-format-interpolation
         if request.user.id:
             segment.track(request.user.id, 'edx.bi.user.account.logout')
 

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 import ddt
+import pytest
 from config_models.models import cache
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -28,6 +29,7 @@ from common.djangoapps.student.models import (
     AnonymousUserId,
     CourseEnrollment,
     LinkedInAddToProfileConfiguration,
+    NonExistentCourseError,
     UserAttribute,
     anonymous_id_for_user,
     unique_id_for_user,
@@ -802,6 +804,47 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
         # Unenroll on non-existent user shouldn't throw an error
         CourseEnrollment.unenroll_by_email("not_jack@fake.edx.org", course_id)
         self.assert_no_events_were_emitted()
+
+    @skip_unless_lms
+    @patch('common.djangoapps.student.models.course_enrollment.log')
+    def test_enroll_non_existent_course_squelch_logs(self, mock_log):
+        user = UserFactory.create(username="squelchy", email="squelchy@example.com")
+        course_id = CourseLocator("edX", "NoExist", "2013")
+
+        def test_and_assert_case(squelch_pii, expected_user_identifier):
+            mock_log.reset_mock()
+            with self.settings(SQUELCH_PII_IN_LOGS=squelch_pii):
+                with pytest.raises(NonExistentCourseError):
+                    CourseEnrollment.enroll(user, course_id, check_access=True)
+                mock_log.warning.assert_any_call(
+                    "User %s failed to enroll in non-existent course %s",
+                    expected_user_identifier,
+                    str(course_id)
+                )
+
+        test_and_assert_case(True, user.id)
+        test_and_assert_case(False, user.username)
+
+    @skip_unless_lms
+    @patch('common.djangoapps.student.models.course_enrollment.log')
+    def test_enroll_by_email_non_existent_user_squelch_logs(self, mock_log):
+        course_id = CourseLocator("edX", "Test101", "2013")
+        CourseOverviewFactory.create(id=course_id)
+        email = "non_existent_user@example.com"
+
+        def test_and_assert_case(squelch_pii, expected_email_for_log):
+            mock_log.reset_mock()
+            with self.settings(SQUELCH_PII_IN_LOGS=squelch_pii):
+                with pytest.raises(User.DoesNotExist):
+                    CourseEnrollment.enroll_by_email(email, course_id, ignore_errors=False)
+                mock_log.error.assert_any_call(
+                    "Tried to enroll email %s into course %s, but user not found",
+                    expected_email_for_log,
+                    course_id
+                )
+
+        test_and_assert_case(True, "[REDACTED]")
+        test_and_assert_case(False, email)
 
     @skip_unless_lms
     def test_enrollment_multiple_classes(self):

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -475,7 +475,8 @@ def change_enrollment(request, check_access=True):
         except UnenrollmentNotAllowed as exc:
             return HttpResponseBadRequest(str(exc))
 
-        log.info("User %s unenrolled from %s; sending REFUND_ORDER", user.username, course_id)
+        user_identifier_for_log = user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.username
+        log.info("User %s unenrolled from %s; sending REFUND_ORDER", user_identifier_for_log, course_id)
         REFUND_ORDER.send(sender=None, course_enrollment=enrollment)
         return HttpResponse()
     else:
@@ -540,14 +541,19 @@ def disable_account_ajax(request):
         user_account, _success = UserStanding.objects.get_or_create(
             user=user, defaults={'changed_by': request.user},
         )
+        request_user_identifier_for_log, user_identifier_for_log = (
+            (request.user.id, user.id)
+            if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+            else (request.user, username)
+        )
         if account_action == 'disable':
             user_account.account_status = UserStanding.ACCOUNT_DISABLED
             context['message'] = _("Successfully disabled {}'s account").format(username)
-            log.info("%s disabled %s's account", request.user, username)
+            log.info("%s disabled %s's account", request_user_identifier_for_log, user_identifier_for_log)
         elif account_action == 'reenable':
             user_account.account_status = UserStanding.ACCOUNT_ENABLED
             context['message'] = _("Successfully reenabled {}'s account").format(username)
-            log.info("%s reenabled %s's account", request.user, username)
+            log.info("%s reenabled %s's account", request_user_identifier_for_log, user_identifier_for_log)
         else:
             context['message'] = _("Unexpected account status")
             return JsonResponse(context, status=400)
@@ -843,11 +849,12 @@ def do_email_change_request(user, new_email, activation_key=None, secondary_emai
 
     try:
         ace.send(msg)
-        log.info("Email activation link sent to user [%s].", new_email)
-    except Exception:
+        user_identifier_for_log = user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else new_email
+        log.info("Email activation link sent to user [%s].", user_identifier_for_log)
+    except Exception as err:
         from_address = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
         log.error('Unable to send email activation link to user from "%s"', from_address, exc_info=True)
-        raise ValueError(_('Unable to send email activation link. Please try again later.'))  # lint-amnesty, pylint: disable=raise-missing-from
+        raise ValueError(_('Unable to send email activation link. Please try again later.')) from err
 
     if not secondary_email_change_request:
         # When the email address change is complete, a "edx.user.settings.changed" event will be emitted.

--- a/lms/djangoapps/bulk_user_retirement/views.py
+++ b/lms/djangoapps/bulk_user_retirement/views.py
@@ -3,6 +3,7 @@ An API for retiring user accounts.
 """
 import logging
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from rest_framework import permissions, status
@@ -50,16 +51,28 @@ class BulkUsersRetirementView(APIView):
 
         successful_user_retirements, failed_user_retirements = [], []
 
-        for username in usernames_to_retire:
+        for index, username in enumerate(usernames_to_retire):
             try:
                 user_to_retire = User.objects.get(username=username)
                 with transaction.atomic():
                     create_retirement_request_and_deactivate_account(user_to_retire)
-                log.info(f'The user "{username}" has been added to the retirement pipeline \
-                         by "{request.user}"')
+                user_identifier_for_log, request_user_identifier_for_log = (
+                    (user_to_retire.id, request.user.id)
+                    if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+                    else (username, request.user)
+                )
+                log.info(
+                    'User %s added to retirement pipeline by user %s at index %s',
+                    user_identifier_for_log,
+                    request_user_identifier_for_log,
+                    index,
+                )
 
             except User.DoesNotExist:
-                log.exception(f'The user "{username}" does not exist.')
+                user_identifier_for_log = (
+                    f'index {index}' if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else username
+                )
+                log.exception('Bulk retirement user %s does not exist.', user_identifier_for_log)
                 failed_user_retirements.append(username)
 
             except Exception as exc:  # pylint: disable=broad-except

--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -59,7 +59,8 @@ def send_ace_message(goal, session_id):
     """
     user = goal.user
     if not user.has_usable_password():
-        log.info(f'Goal Reminder User is disabled {user.username} course {goal.course_key}')
+        user_identifier_for_log = user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.username
+        log.info('Goal Reminder User is disabled user %s course %s', user_identifier_for_log, goal.course_key)
         return False
     try:
         course = CourseOverview.get_from_id(goal.course_key)

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -27,6 +27,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict, namedtuple
 
+from django.conf import settings
 from django.db import DatabaseError, IntegrityError, transaction
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
@@ -405,9 +406,13 @@ class UserStateCache:
                 self.user.username,
                 pending_updates
             )
-        except DatabaseError:
-            log.exception("Saving user state failed for %s", self.user.username)
-            raise KeyValueMultiSaveError([])  # lint-amnesty, pylint: disable=raise-missing-from
+        except DatabaseError as err:
+            user_identifier_for_log = (
+                self.user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+                else self.user.username
+            )
+            log.exception("Saving user state failed for %s", user_identifier_for_log)
+            raise KeyValueMultiSaveError([]) from err
         finally:
             self._cache.update(pending_updates)
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1488,7 +1488,10 @@ def generate_user_cert(request, course_id):
         return HttpResponseBadRequest(str(e))
 
     if not is_course_passed(student, course):
-        log.info("User %s has not passed the course: %s", student.username, course_id)
+        user_identifier_for_log = (
+            student.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else student.username
+        )
+        log.info("User %s has not passed the course: %s", user_identifier_for_log, course_id)
         return HttpResponseBadRequest(_("Your certificate will be available when you pass the course."))
 
     certificate_status = certs_api.certificate_downloadable_status(student, course.id)

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -718,9 +718,8 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
 
         # test the log for email that's send to new created user.
         info_log.assert_called_with(
-            "user already exists with username '%s' and email '%s'",
-            'test_student_1',
-            'test_student@example.com'
+            'user already exists with %s',
+            "username 'test_student_1' and email 'test_student@example.com'"
         )
 
     def test_file_upload_type_not_csv(self):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -501,13 +501,18 @@ class RegisterAndEnrollStudents(APIView):
                             warnings.append({
                                 'username': username, 'email': email, 'response': warning_message
                             })
-                            log.warning('email %s already exist', email)
-                        else:
-                            log.info(
-                                "user already exists with username '%s' and email '%s'",
-                                username,
-                                email
+                            user_identifier_for_log = (
+                                user.id
+                                if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+                                else email
                             )
+                            log.warning('email for user (%s) already exists', user_identifier_for_log)
+                        else:
+                            user_identifier_for_log = (
+                                f'user ID {user.id}' if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+                                else f"username '{username}' and email '{email}'"
+                            )
+                            log.info('user already exists with %s', user_identifier_for_log)
 
                         # enroll a user if it is not already enrolled.
                         if not is_user_enrolled_in_course(user, course_id):

--- a/lms/djangoapps/verify_student/management/commands/manual_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/manual_verifications.py
@@ -7,7 +7,8 @@ import logging
 import os
 from pprint import pformat
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.conf import settings
+from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand, CommandError
 
 from lms.djangoapps.verify_student.models import ManualVerification
@@ -53,7 +54,10 @@ class Command(BaseCommand):
         if single_email:
             successfully_verified = self._add_user_to_manual_verification(single_email)
             if successfully_verified is False:
-                log.error(f'Manual verification of {single_email} failed')
+                user_identifier_for_log = (
+                    '[REDACTED]' if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else single_email
+                )
+                log.error('Manual verification of %s failed', user_identifier_for_log)
             return
 
         email_ids_file = options['email_ids_file']
@@ -70,7 +74,10 @@ class Command(BaseCommand):
                 len(failed_emails),
                 total_emails
             ))
-            log.error(f'Failed emails:{pformat(failed_emails)}')
+            failed_emails_for_log = (
+                '[REDACTED]' if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else pformat(failed_emails)
+            )
+            log.error('Failed emails for manual verification:%s', failed_emails_for_log)
         else:
             log.info(f'Successfully generated manual verification for {total_emails} emails.')
 
@@ -122,7 +129,8 @@ class Command(BaseCommand):
                     status='approved',
                 ))
             else:
-                log.info(f'Skipping email {user.email}, existing verification found.')
+                user_identifier_for_log = user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.email
+                log.info('Skipping user %s, existing verification found.', user_identifier_for_log)
         ManualVerification.objects.bulk_create(verifications_to_create)
         failed_emails = set(email_ids) - set(users.values_list('email', flat=True))
         return list(failed_emails)
@@ -147,5 +155,6 @@ class Command(BaseCommand):
             )
             return True
         except User.DoesNotExist:
-            log.error(f'Tried to verify email {email_id}, but user not found')
+            email_for_log = '[REDACTED]' if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else email_id
+            log.error('Tried to verify email %s, but user not found', email_for_log)
             return False

--- a/lms/djangoapps/verify_student/management/commands/tests/test_manual_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_manual_verify_student.py
@@ -95,7 +95,7 @@ class TestVerifyStudentCommand(TestCase):
              ),
             (LOGGER_NAME,
              'ERROR',
-             "Failed emails:['unknown@unknown.com']"
+             "Failed emails for manual verification:['unknown@unknown.com']"
              )
         )
         with LogCapture(LOGGER_NAME, level=logging.INFO) as logger:

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -198,7 +198,8 @@ def _enforce_password_policy_compliance(request, user):  # lint-amnesty, pylint:
         if LoginFailures.is_feature_enabled():
             LoginFailures.increment_lockout_counter(user)
 
-        AUDIT_LOG.info("Password reset initiated for email %s.", user.email)
+        user_identifier_for_log = user.id if getattr(settings, 'SQUELCH_PII_IN_LOGS', False) else user.email
+        AUDIT_LOG.info("Password reset initiated for email %s.", user_identifier_for_log)
         tracker.emit(
             PASSWORD_RESET_INITIATED,
             {


### PR DESCRIPTION
Update application logging to prevent exposure of customer identity information in logs when SQUELCH_PII_IN_LOGS is enabled. Log records that currently include usernames, email addresses, or other user-identifying strings should instead use non-PII identifiers (for example, numeric user IDs) where appropriate.

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
