### PR TITLE
fix: prevent storing GCP language codes in edx-val

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/tests/test_transcript_storage_handlers.py
@@ -52,6 +52,7 @@ class UploadTranscriptLanguageNormalizationTest(TestCase):
         ("zh", "zh-cn"),
         ("es", "es-419"),
         ("pt", "pt-br"),
+        ("pt-BR", "pt-br"),
         ("de", "de-de"),
         ("it", "it-it"),
         ("ko", "ko-kr"),
@@ -88,13 +89,13 @@ class UploadTranscriptLanguageNormalizationTest(TestCase):
     @patch("cms.djangoapps.contentstore.transcript_storage_handlers.use_mock_video_uploads", return_value=False)
     @patch("cms.djangoapps.contentstore.transcript_storage_handlers.create_or_update_video_transcript")
     def test_is_replace_detection_uses_normalized_code(self, mock_create_or_update, mock_use_mock):  # pylint: disable=unused-argument
-        # An existing transcript is stored under the canonical code ("zh-cn"), while the
-        # upload request supplies the bare code ("zh") for the same language.
+        # An existing transcript is stored under the legacy code ("zh"), while the
+        # upload request supplies the canonical code ("zh-cn") for the same language.
         with patch(
             "cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages",
-            return_value=["zh-cn"],
+            return_value=["zh"],
         ):
-            request = _build_request(new_language_code="zh")
+            request = _build_request(new_language_code="zh-cn")
             response = transcript_storage_handlers.upload_transcript(request)
 
         # Without normalization this would be treated as a brand new language (201, not 200).
@@ -113,11 +114,11 @@ class ValidateTranscriptUploadDataNormalizationTest(TestCase):
         self.files = {"file": ContentFile(b"0\n", name="transcript.srt")}
 
     @patch("cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages",
-           return_value=["es-419"])
+           return_value=["es"])
     def test_bare_duplicate_code_is_detected_via_normalization(self, mock_get_available_languages):  # pylint: disable=unused-argument
-        # A transcript in "es-419" already exists; uploading "es" (its bare equivalent)
+        # A transcript in legacy "es" already exists; uploading canonical "es-419"
         # for the same language should be flagged as a duplicate.
-        data = {"edx_video_id": "video-1", "language_code": "en", "new_language_code": "es"}
+        data = {"edx_video_id": "video-1", "language_code": "en", "new_language_code": "es-419"}
 
         error = transcript_storage_handlers.validate_transcript_upload_data(data, self.files)
 

--- a/cms/djangoapps/contentstore/tests/test_transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/tests/test_transcript_storage_handlers.py
@@ -1,0 +1,134 @@
+"""
+Tests for language code normalization in the Studio manual transcript upload
+handler (cms.djangoapps.contentstore.transcript_storage_handlers).
+
+Bare 2-letter language codes (e.g. "es", "zh") selected in the transcript
+upload UI must be normalized to their canonical edX dialect code (e.g.
+"es-419", "zh-cn") before being handed to edxval, so that a transcript
+uploaded under either spelling always lands on the same
+`edxval_videotranscript` row.
+"""
+
+from unittest.mock import Mock, patch
+
+import ddt
+from django.core.files.base import ContentFile
+from django.test import TestCase
+
+from cms.djangoapps.contentstore import transcript_storage_handlers
+
+
+VALID_SRT_CONTENT = (
+    b"0\n"
+    b"00:00:10,500 --> 00:00:13,000\n"
+    b"Hello world\n\n"
+)
+
+
+def _build_request(
+        edx_video_id="video-1", language_code="en", new_language_code="es", file_content=VALID_SRT_CONTENT,
+):
+    """
+    Return a minimal Mock standing in for the WSGI request `upload_transcript` expects.
+    """
+    request = Mock()
+    request.POST = {
+        "edx_video_id": edx_video_id,
+        "language_code": language_code,
+        "new_language_code": new_language_code,
+    }
+    request.FILES = {"file": ContentFile(file_content, name="transcript.srt")}
+    return request
+
+
+@ddt.ddt
+class UploadTranscriptLanguageNormalizationTest(TestCase):
+    """
+    Verify that `upload_transcript` normalizes the incoming (new) language code
+    to its canonical edX dialect code before calling into edxval.
+    """
+
+    @ddt.data(
+        ("zh", "zh-cn"),
+        ("es", "es-419"),
+        ("pt", "pt-br"),
+        ("de", "de-de"),
+        ("it", "it-it"),
+        ("ko", "ko-kr"),
+        ("tr", "tr-tr"),
+        # Already-canonical codes must pass through unchanged.
+        ("es-419", "es-419"),
+        ("pt-br", "pt-br"),
+        # "fr", "ru" and "fa" are themselves distinct canonical edX codes (not aliases of a
+        # dialect, e.g. "fa" is generic Persian while "fa-ir" is a separate, distinct
+        # language), so they must NOT be remapped.
+        ("fr", "fr"),
+        ("ru", "ru"),
+        ("fa", "fa"),
+        # A code with no known mapping must pass through unchanged.
+        ("da", "da"),
+    )
+    @ddt.unpack
+    @patch("cms.djangoapps.contentstore.transcript_storage_handlers.use_mock_video_uploads", return_value=False)
+    @patch("cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages",
+           return_value=[])
+    @patch("cms.djangoapps.contentstore.transcript_storage_handlers.create_or_update_video_transcript")
+    def test_new_language_code_is_normalized_before_edxval_call(
+            self, bare_code, expected_code, mock_create_or_update, mock_get_available_languages, mock_use_mock,
+    ):  # pylint: disable=unused-argument, too-many-positional-arguments
+        request = _build_request(new_language_code=bare_code)
+
+        response = transcript_storage_handlers.upload_transcript(request)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(mock_create_or_update.call_count, 1)
+        _args, kwargs = mock_create_or_update.call_args
+        self.assertEqual(kwargs["metadata"]["language_code"], expected_code)
+
+    @patch("cms.djangoapps.contentstore.transcript_storage_handlers.use_mock_video_uploads", return_value=False)
+    @patch("cms.djangoapps.contentstore.transcript_storage_handlers.create_or_update_video_transcript")
+    def test_is_replace_detection_uses_normalized_code(self, mock_create_or_update, mock_use_mock):  # pylint: disable=unused-argument
+        # An existing transcript is stored under the canonical code ("zh-cn"), while the
+        # upload request supplies the bare code ("zh") for the same language.
+        with patch(
+            "cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages",
+            return_value=["zh-cn"],
+        ):
+            request = _build_request(new_language_code="zh")
+            response = transcript_storage_handlers.upload_transcript(request)
+
+        # Without normalization this would be treated as a brand new language (201, not 200).
+        self.assertEqual(response.status_code, 200)
+
+
+@ddt.ddt
+class ValidateTranscriptUploadDataNormalizationTest(TestCase):
+    """
+    Verify that `validate_transcript_upload_data` compares/normalizes the new language
+    code so that a bare code isn't wrongly treated as distinct from its canonical form.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.files = {"file": ContentFile(b"0\n", name="transcript.srt")}
+
+    @patch("cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages",
+           return_value=["es-419"])
+    def test_bare_duplicate_code_is_detected_via_normalization(self, mock_get_available_languages):  # pylint: disable=unused-argument
+        # A transcript in "es-419" already exists; uploading "es" (its bare equivalent)
+        # for the same language should be flagged as a duplicate.
+        data = {"edx_video_id": "video-1", "language_code": "en", "new_language_code": "es"}
+
+        error = transcript_storage_handlers.validate_transcript_upload_data(data, self.files)
+
+        self.assertIsNotNone(error)
+        self.assertIn("es-419", error)
+
+    @patch("cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages",
+           return_value=[])
+    def test_no_error_when_language_not_already_present(self, mock_get_available_languages):  # pylint: disable=unused-argument
+        data = {"edx_video_id": "video-1", "language_code": "en", "new_language_code": "es"}
+
+        error = transcript_storage_handlers.validate_transcript_upload_data(data, self.files)
+
+        self.assertIsNone(error)

--- a/cms/djangoapps/contentstore/transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/transcript_storage_handlers.py
@@ -30,6 +30,32 @@ from .video_storage_handlers import TranscriptProvider
 
 LOGGER = logging.getLogger(__name__)
 
+# Maps a bare language code, as offered in the manual transcript upload UI, to the
+# canonical edX dialect code that `ai-translations` uses for the same language. This
+# keeps a manually-uploaded transcript and an AI-generated one for the "same" language
+# on the same edxval_videotranscript row instead of creating duplicate language entries.
+# Source of truth: ai_translations/apps/utils/platform_to_gcp_language_mapper.py
+# (_IDENTICAL_CODES / _GCP_CODE_MAPPING_TUPLES). Codes already canonical (e.g. "fr", "ru")
+# are intentionally absent here and pass through unchanged.
+BARE_TO_CANONICAL_LANGUAGE_CODE = {
+    'de': 'de-de',
+    'es': 'es-419',
+    'it': 'it-it',
+    'ko': 'ko-kr',
+    'pt': 'pt-br',
+    'tr': 'tr-tr',
+    'zh': 'zh-cn',
+}
+
+
+def normalize_language_code(language_code):
+    """
+    Normalize a bare language code (e.g. "es") to its canonical edX dialect code
+    (e.g. "es-419"). Codes with no known mapping, including already-canonical ones,
+    are returned unchanged.
+    """
+    return BARE_TO_CANONICAL_LANGUAGE_CODE.get(language_code, language_code)
+
 
 class TranscriptionProviderErrorType:
     """
@@ -178,7 +204,7 @@ def upload_transcript(request):
     """
     edx_video_id = request.POST['edx_video_id']
     language_code = request.POST['language_code']
-    new_language_code = request.POST['new_language_code']
+    new_language_code = normalize_language_code(request.POST['new_language_code'])
     transcript_file = request.FILES['file']
     try:
         # Determine whether this upload replaces an existing transcript
@@ -229,15 +255,17 @@ def validate_transcript_upload_data(data, files):
     missing = [attr for attr in must_have_attrs if attr not in data]
     if missing:
         error = _('The following parameters are required: {missing}.').format(missing=', '.join(missing))
-    elif (
-        data['language_code'] != data['new_language_code'] and
-        data['new_language_code'] in get_available_transcript_languages(video_id=data['edx_video_id'])
-    ):
-        error = _('A transcript with the "{language_code}" language code already exists.'.format(  # lint-amnesty, pylint: disable=translation-of-non-string
-            language_code=data['new_language_code']
-        ))
-    elif 'file' not in files:
-        error = _('A transcript file is required.')
+    else:
+        new_language_code = normalize_language_code(data['new_language_code'])
+        if (
+            data['language_code'] != new_language_code and
+            new_language_code in get_available_transcript_languages(video_id=data['edx_video_id'])
+        ):
+            error = _('A transcript with the "{language_code}" language code already exists.'.format(  # lint-amnesty, pylint: disable=translation-of-non-string
+                language_code=new_language_code
+            ))
+        elif 'file' not in files:
+            error = _('A transcript file is required.')
 
     return error
 

--- a/cms/djangoapps/contentstore/transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/transcript_storage_handlers.py
@@ -43,18 +43,24 @@ BARE_TO_CANONICAL_LANGUAGE_CODE = {
     'it': 'it-it',
     'ko': 'ko-kr',
     'pt': 'pt-br',
+    'pt-br': 'pt-br',
     'tr': 'tr-tr',
     'zh': 'zh-cn',
+    'zh-cn': 'zh-cn',
 }
 
 
 def normalize_language_code(language_code):
     """
-    Normalize a bare language code (e.g. "es") to its canonical edX dialect code
-    (e.g. "es-419"). Codes with no known mapping, including already-canonical ones,
-    are returned unchanged.
+    Normalize a bare language code (e.g. "es", "pt-BR") to its canonical edX dialect
+    code (e.g. "es-419", "pt-br"). Codes with no known mapping, including already-
+    canonical ones, are returned unchanged (after case normalization).
     """
-    return BARE_TO_CANONICAL_LANGUAGE_CODE.get(language_code, language_code)
+    if not language_code:
+        return language_code
+
+    code = language_code.lower().replace('_', '-')
+    return BARE_TO_CANONICAL_LANGUAGE_CODE.get(code, code)
 
 
 class TranscriptionProviderErrorType:
@@ -203,13 +209,18 @@ def upload_transcript(request):
         Transcript file in SRT format
     """
     edx_video_id = request.POST['edx_video_id']
-    language_code = request.POST['language_code']
+    language_code = normalize_language_code(request.POST['language_code'])
     new_language_code = normalize_language_code(request.POST['new_language_code'])
     transcript_file = request.FILES['file']
     try:
+        available_languages = get_available_transcript_languages(video_id=edx_video_id)
+        normalized_available_languages = {
+            normalize_language_code(language_code)
+            for language_code in available_languages
+        }
         # Determine whether this upload replaces an existing transcript
         # (return 200) or creates a new one (return 201).
-        is_replace = new_language_code in get_available_transcript_languages(video_id=edx_video_id)
+        is_replace = new_language_code in normalized_available_languages
         # Convert SRT transcript into an SJSON format
         # and upload it to S3.
         sjson_subs = Transcript.convert(
@@ -256,10 +267,16 @@ def validate_transcript_upload_data(data, files):
     if missing:
         error = _('The following parameters are required: {missing}.').format(missing=', '.join(missing))
     else:
+        language_code = normalize_language_code(data['language_code'])
         new_language_code = normalize_language_code(data['new_language_code'])
+        available_languages = get_available_transcript_languages(video_id=data['edx_video_id'])
+        normalized_available_languages = {
+            normalize_language_code(language_code)
+            for language_code in available_languages
+        }
         if (
-            data['language_code'] != new_language_code and
-            new_language_code in get_available_transcript_languages(video_id=data['edx_video_id'])
+            language_code != new_language_code and
+            new_language_code in normalized_available_languages
         ):
             error = _('A transcript with the "{language_code}" language code already exists.'.format(  # lint-amnesty, pylint: disable=translation-of-non-string
                 language_code=new_language_code

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -332,7 +332,7 @@ class TranscriptUploadTest(CourseTestCase):
             video_id='123',
             language_code='en',
             metadata={
-                'language_code': 'es',
+                'language_code': 'es-419',
                 'file_format': 'sjson',
                 'provider': 'Custom'
             },
@@ -411,7 +411,7 @@ class TranscriptUploadTest(CourseTestCase):
 
     @patch(
         'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
-        Mock(return_value=['en', 'es'])
+        Mock(return_value=['en', 'es-419'])
     )
     def test_transcript_upload_handler_existing_transcript(self):
         """
@@ -428,7 +428,7 @@ class TranscriptUploadTest(CourseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             json.loads(response.content.decode('utf-8'))['error'],
-            'A transcript with the "es" language code already exists.'
+            'A transcript with the "es-419" language code already exists.'
         )
 
     @patch(
@@ -642,7 +642,7 @@ class TranscriptUploadApiTest(CourseTestCase):
             video_id='123',
             language_code='en',
             metadata={
-                'language_code': 'es',
+                'language_code': 'es-419',
                 'file_format': 'sjson',
                 'provider': 'Custom'
             },
@@ -696,7 +696,7 @@ class TranscriptUploadApiTest(CourseTestCase):
 
     @patch(
         'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
-        Mock(return_value=['en', 'es'])
+        Mock(return_value=['en', 'es-419'])
     )
     def test_transcript_upload_handler_existing_transcript(self):
         """
@@ -713,7 +713,7 @@ class TranscriptUploadApiTest(CourseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             json.loads(response.content.decode('utf-8'))['error'],
-            'A transcript with the "es" language code already exists.'
+            'A transcript with the "es-419" language code already exists.'
         )
 
     @patch(


### PR DESCRIPTION
## Description
Normalizes target language codes in Studio's transcript storage handlers (`edx-platform`) so that manual transcript uploads convert bare/GCP language codes (e.g., `es`, `zh`, `de`) into canonical edX language codes (e.g., `es-419`, `zh-cn`, `de-de`) before registering records in `edx-val`.

## Related Tickets
- **Jira:** [LP-1118](https://2u-internal.atlassian.net/browse/LP-1118)
- **Frontend PR:** [frontend-app-authoring#118](https://github.com/edx/frontend-app-authoring/pull/118)

## Changes Made
- Added `BARE_TO_CANONICAL_LANGUAGE_CODE` mapping dictionary and `normalize_language_code` helper function in `cms/djangoapps/contentstore/transcript_storage_handlers.py`.
- Updated `upload_transcript` to normalize `new_language_code` before passing metadata to `create_or_update_video_transcript` (writing to `edx-val`).
- Updated `validate_transcript_upload_data` to normalize incoming codes, ensuring duplicate detection correctly compares canonical forms against existing transcript records.
- Added unit tests in `cms/djangoapps/contentstore/tests/test_transcript_storage_handlers.py` to cover language code normalization and duplicate validation edge cases.
